### PR TITLE
ci: extract SDK_COMMIT_PIN commit-pinned companion SDK build

### DIFF
--- a/.github/actions/setup-sdk-companion/action.yml
+++ b/.github/actions/setup-sdk-companion/action.yml
@@ -4,8 +4,9 @@ description: >-
   zcash/zcash-android-wallet-sdk, installs its Rust/NDK toolchain, and points Gradle's
   composite build at it via ORG_GRADLE_PROJECT_SDK_INCLUDED_BUILD_PATH — so a co-developed
   app PR can build/lint/test against unreleased SDK changes without waiting on a Maven
-  publish. No-ops (does nothing) whenever the pin is blank, which is the default, normal
-  case for every branch that isn't actively co-developing against an SDK PR.
+  publish. Supported on main, maint/* branches, and branches targeting either. No-ops (does
+  nothing) whenever the pin is blank, which is the default, normal case for every branch
+  that isn't actively co-developing against an SDK PR.
 outputs:
   active:
     description: "'true' if the companion SDK build was activated this run, else empty."
@@ -20,8 +21,8 @@ runs:
         PIN="$(grep -m1 '^SDK_COMMIT_PIN=' gradle.properties | cut -d= -f2 | tr -d '[:space:]')"
         [ -z "${PIN}" ] || [[ "${PIN}" =~ ^[0-9a-f]{40}$ ]] || { echo '::error::SDK_COMMIT_PIN must be a full 40-char commit sha'; exit 1; }
         TARGET="${{ github.base_ref || github.ref_name }}"
-        if [ -n "${PIN}" ] && [ "${TARGET}" != "main" ]; then
-          echo "::error::SDK_COMMIT_PIN is set to '${PIN}' but this workflow's target branch is '${TARGET}', not main. SDK_COMMIT_PIN is only supported on main and branches targeting main — clear it before merging into maint/release/review branches, which must always build against a real published SDK version." >&2
+        if [ -n "${PIN}" ] && [ "${TARGET}" != "main" ] && [[ "${TARGET}" != maint/* ]]; then
+          echo "::error::SDK_COMMIT_PIN is set to '${PIN}' but this workflow's target branch is '${TARGET}'. SDK_COMMIT_PIN is only supported on main, maint/* branches, and branches targeting them — clear it before merging into release/review branches, which must always build against a real published SDK version." >&2
           exit 1
         fi
         echo "commit=${PIN}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-sdk-companion/action.yml
+++ b/.github/actions/setup-sdk-companion/action.yml
@@ -1,0 +1,88 @@
+name: 'Companion SDK Build (commit-pinned)'
+description: >-
+  If SDK_COMMIT_PIN is set in gradle.properties, checks out that exact commit of
+  zcash/zcash-android-wallet-sdk, installs its Rust/NDK toolchain, and points Gradle's
+  composite build at it via ORG_GRADLE_PROJECT_SDK_INCLUDED_BUILD_PATH — so a co-developed
+  app PR can build/lint/test against unreleased SDK changes without waiting on a Maven
+  publish. No-ops (does nothing) whenever the pin is blank, which is the default, normal
+  case for every branch that isn't actively co-developing against an SDK PR.
+outputs:
+  active:
+    description: "'true' if the companion SDK build was activated this run, else empty."
+    value: ${{ steps.pin.outputs.commit != '' && 'true' || '' }}
+runs:
+  using: "composite"
+  steps:
+    - name: Read SDK_COMMIT_PIN and enforce the branch gate
+      id: pin
+      shell: bash
+      run: |
+        PIN="$(grep -m1 '^SDK_COMMIT_PIN=' gradle.properties | cut -d= -f2 | tr -d '[:space:]')"
+        [ -z "${PIN}" ] || [[ "${PIN}" =~ ^[0-9a-f]{40}$ ]] || { echo '::error::SDK_COMMIT_PIN must be a full 40-char commit sha'; exit 1; }
+        TARGET="${{ github.base_ref || github.ref_name }}"
+        if [ -n "${PIN}" ] && [ "${TARGET}" != "main" ]; then
+          echo "::error::SDK_COMMIT_PIN is set to '${PIN}' but this workflow's target branch is '${TARGET}', not main. SDK_COMMIT_PIN is only supported on main and branches targeting main — clear it before merging into maint/release/review branches, which must always build against a real published SDK version." >&2
+          exit 1
+        fi
+        echo "commit=${PIN}" >> "$GITHUB_OUTPUT"
+    - name: Checkout companion SDK commit
+      if: steps.pin.outputs.commit != ''
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      with:
+        repository: zcash/zcash-android-wallet-sdk
+        ref: ${{ steps.pin.outputs.commit }}
+        path: .sdk-companion
+        fetch-depth: 1
+        persist-credentials: false
+    - name: Set up Android NDK for the companion SDK build
+      if: steps.pin.outputs.commit != ''
+      shell: bash
+      run: |
+        ANDROID_ROOT=/usr/local/lib/android
+        ANDROID_SDK_ROOT=${ANDROID_ROOT}/sdk
+        SDKMANAGER=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager
+        echo "y" | "${SDKMANAGER}" "ndk;27.0.12077973"
+    - name: Set up Rust toolchain for the companion SDK build
+      if: steps.pin.outputs.commit != ''
+      shell: bash
+      working-directory: .sdk-companion
+      run: |
+        # rust-toolchain.toml in the SDK checkout is the single source of truth for the
+        # channel and target list — read it rather than hardcoding a version here, so this
+        # step never silently drifts from what the SDK itself actually builds with.
+        CHANNEL="$(sed -n 's/^channel *= *"\([^"]*\)".*/\1/p' rust-toolchain.toml)"
+        rustup toolchain install "${CHANNEL}"
+        rustup default "${CHANNEL}"
+        rustup target add --toolchain "${CHANNEL}" \
+          armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android
+    - name: Rust cache for the companion SDK build
+      if: steps.pin.outputs.commit != ''
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+      with:
+        path: |
+          .sdk-companion/backend-lib/target
+          ~/.cargo/bin
+          ~/.cargo/registry/index
+          ~/.cargo/registry/cache
+          ~/.cargo/registry/src
+        key: ${{ runner.os }}-sdk-companion-rust-${{ steps.pin.outputs.commit }}
+        restore-keys: |
+          ${{ runner.os }}-sdk-companion-rust-
+    - name: Export SDK composite build override
+      if: steps.pin.outputs.commit != ''
+      shell: bash
+      run: |
+        echo "ORG_GRADLE_PROJECT_SDK_INCLUDED_BUILD_PATH=${{ github.workspace }}/.sdk-companion" >> "$GITHUB_ENV"
+        # The SDK's build-conventions module locks its own (build-tooling-only, not
+        # shipped-library) dependency graph via Gradle's dependencyLocking. Consumed as a
+        # composite build, that graph resolves inside this app's unified build session
+        # instead of standalone, which can shift a version just enough to violate the
+        # lock even though nothing about the actual voting/migration library code changed.
+        # ZCASH_IS_DEPENDENCY_LOCKING_ENABLED is build-conventions/build.gradle.kts's own,
+        # purpose-built escape hatch for exactly this (deliberately read only from a
+        # system property/CLI arg/env var, never from gradle.properties, so an included
+        # build's own gradle.properties can't silently flip it) — safe to disable here
+        # since this env var reaches only the companion build's tooling classpath
+        # resolution, not the app's own dependency locking (if any).
+        echo "ORG_GRADLE_PROJECT_ZCASH_IS_DEPENDENCY_LOCKING_ENABLED=false" >> "$GITHUB_ENV"
+        echo "::notice::Building against zcash-android-wallet-sdk@${{ steps.pin.outputs.commit }} (SDK_COMMIT_PIN), not the published Maven artifact."

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -97,6 +97,13 @@ jobs:
         with:
           ref: ${{ steps.tag.outputs.tag }}
 
+      - name: Refuse to deploy with a live SDK_COMMIT_PIN
+        run: |
+          if grep -qE '^SDK_COMMIT_PIN=.+' gradle.properties; then
+            echo '::error::SDK_COMMIT_PIN is set — releases must build against a published SDK.'
+            exit 1
+          fi
+
       - name: Parse tag and extract changelog section
         id: meta
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0  # To fetch all commits
+      - name: Refuse to deploy with a live SDK_COMMIT_PIN
+        timeout-minutes: 1
+        shell: bash
+        run: |
+          if grep -qE '^SDK_COMMIT_PIN=.+' gradle.properties; then
+            echo '::error::SDK_COMMIT_PIN is set — releases must build against a published SDK.'
+            exit 1
+          fi
       - name: Set up Java
         uses: ./.github/actions/setup-java
         timeout-minutes: 1

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -20,12 +20,19 @@ jobs:
   # APK in each phase job, paying ~7 min twice.
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # 60 rather than the usual 20: when SDK_COMMIT_PIN is set (see setup-sdk-companion),
+    # this compiles the companion SDK's Rust dependency graph with a cold cargo/target
+    # cache on the first run — observed at 20-25 min alone in pull-request.yml's build job.
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
       - name: Checkout app
         uses: actions/checkout@v4
+
+      - name: Set up companion SDK build (if SDK_COMMIT_PIN is set)
+        timeout-minutes: 30
+        uses: ./.github/actions/setup-sdk-companion
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -161,6 +161,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0 # to fetch all commits
+      - name: Set up companion SDK build (if SDK_COMMIT_PIN is set)
+        timeout-minutes: 30
+        uses: ./.github/actions/setup-sdk-companion
       - name: Set up Java
         uses: ./.github/actions/setup-java
         timeout-minutes: 1
@@ -168,7 +171,11 @@ jobs:
         uses: ./.github/actions/setup-gradle
         timeout-minutes: 5
       - name: Android Lint
-        timeout-minutes: 15
+        # 45 rather than the usual 15: when SDK_COMMIT_PIN is set (see
+        # setup-sdk-companion), this compiles the full companion SDK's Rust dependency
+        # graph (Tor, orchard, etc.) for the first time with a cold cargo/target cache —
+        # observed at ~20-25 min alone before this step even reaches lint analysis.
+        timeout-minutes: 45
         env:
           # Disable minify, since it makes lint run faster
           ORG_GRADLE_PROJECT_IS_MINIFY_ENABLED: false
@@ -242,7 +249,11 @@ jobs:
     name: test_android_modules_emulator (${{ matrix.shard }})
     needs: [validate_gradle_wrapper]
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # 90 rather than the usual 45: the `app` shard needs the SDK compiled, and when
+    # SDK_COMMIT_PIN is set (see setup-sdk-companion) a cold cargo/target cache eats
+    # 20-25 min before the emulator/test steps even start — the emulator was previously
+    # observed dying mid-run ("device not found") once the job ran past 45 min total.
+    timeout-minutes: 90
     permissions:
       contents: read
     strategy:
@@ -269,12 +280,30 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0 # to fetch all commits
+      - name: Set up companion SDK build (if SDK_COMMIT_PIN is set)
+        timeout-minutes: 30
+        uses: ./.github/actions/setup-sdk-companion
       - name: Set up Java
         uses: ./.github/actions/setup-java
         timeout-minutes: 1
       - name: Set up Gradle
         uses: ./.github/actions/setup-gradle
         timeout-minutes: 5
+      - name: Pre-build companion SDK native libs (app shard only)
+        # When SDK_COMMIT_PIN is set, the app shard's instrumentation-test Gradle
+        # invocation would otherwise compile the companion SDK's Rust natives for the
+        # first time while the emulator is already up and running screenshot tests --
+        # observed causing rendering contention (ComposeTimeoutException, "Failed to
+        # find ColorBuffer") from CPU/memory pressure, not real UI regressions.
+        # Assembling (not running) the instrumentation APKs here forces that
+        # compilation to finish before Enable KVM/emulator boot, so the later
+        # `connectedAndroidTest` step only installs and runs against
+        # already-built artifacts. The libs shard doesn't depend on feature-voting
+        # (confirmed: it passes unaffected), so it skips this entirely.
+        if: matrix.shard == 'app'
+        timeout-minutes: 60
+        run: |
+          ./gradlew :app:assembleZcashmainnetStoreDebugAndroidTest :ui-screenshot-test:assembleAndroidTest
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
@@ -405,6 +434,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0 # to fetch all commits
+      - name: Set up companion SDK build (if SDK_COMMIT_PIN is set)
+        timeout-minutes: 30
+        uses: ./.github/actions/setup-sdk-companion
       - name: Set up Java
         uses: ./.github/actions/setup-java
         timeout-minutes: 1
@@ -434,7 +466,11 @@ jobs:
         run: |
           keytool -genkey -v -keystore $SIGNING_KEY_PATH -keypass android -storepass android -alias androiddebugkey -keyalg RSA -keysize 2048 -validity 100000 -dname "CN=, OU=, O=Test, L=, S=, C=" -noprompt
       - name: Build Store APK
-        timeout-minutes: 25
+        # 60 rather than the usual 25: when SDK_COMMIT_PIN is set (see
+        # setup-sdk-companion), this compiles the full companion SDK's Rust dependency
+        # graph for release, across both mainnet/testnet variants, with a cold
+        # cargo/target cache on the first run.
+        timeout-minutes: 60
         env:
           ORG_GRADLE_PROJECT_ZCASH_RELEASE_KEYSTORE_PATH: ${{ format('{0}/release.jks', env.home) }}
           ORG_GRADLE_PROJECT_ZCASH_RELEASE_KEYSTORE_PASSWORD: android
@@ -442,8 +478,25 @@ jobs:
           ORG_GRADLE_PROJECT_ZCASH_RELEASE_KEY_ALIAS_PASSWORD: android
           ORG_GRADLE_PROJECT_ZCASH_FLEXA_KEY: ${{ secrets.FLEXA_PUBLISHABLE_KEY }}
           ORG_GRADLE_PROJECT_ZCASH_CMC_KEY: ${{ secrets.CMC_PUBLISHABLE_KEY }}
+        shell: bash
         run: |
-          ./gradlew :app:assembleZcashmainnetStoreDebug :app:assembleZcashtestnetStoreDebug :app:bundleZcashmainnetStoreRelease :app:bundleZcashtestnetStoreRelease :app:packageZcashmainnetStoreReleaseUniversalApk
+          # This step's worker processes (bundletool's standalone-APK packaging,
+          # in particular) can OOM on the standard runner's RAM when SDK_COMMIT_PIN
+          # is set and the companion SDK's Rust compilation is sharing the box with
+          # this already-heavy multi-variant release build. A fresh Gradle daemon
+          # (and freshly-spawned workers) reliably clears it -- retry once, matching
+          # zodl-helpers/scripts/deploy.sh's established OOM-retry-once handling for
+          # this same build.
+          TASKS=":app:assembleZcashmainnetStoreDebug :app:assembleZcashtestnetStoreDebug :app:bundleZcashmainnetStoreRelease :app:bundleZcashtestnetStoreRelease :app:packageZcashmainnetStoreReleaseUniversalApk"
+          if ! ./gradlew ${TASKS} 2>&1 | tee build-store-apk.log; then
+            if grep -qi "OutOfMemoryError\|Java heap space" build-store-apk.log; then
+              echo "::warning::Build Store APK failed with OOM -- stopping the daemon and retrying once with a fresh heap."
+              ./gradlew --stop
+              ./gradlew ${TASKS}
+            else
+              exit 1
+            fi
+          fi
 
       - name: Collect Artifacts
         timeout-minutes: 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,14 @@ jobs:
           # manual workflow_dispatch recovery run, check out the requested tag.
           ref: ${{ inputs.tag || github.ref }}
 
+      - name: Refuse to deploy with a live SDK_COMMIT_PIN
+        shell: bash
+        run: |
+          if grep -qE '^SDK_COMMIT_PIN=.+' gradle.properties; then
+            echo '::error::SDK_COMMIT_PIN is set — releases must build against a published SDK.'
+            exit 1
+          fi
+
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:

--- a/gradle.properties
+++ b/gradle.properties
@@ -109,6 +109,21 @@ ZCASH_GOOGLE_PLAY_DEPLOY_STATUS=draft
 # When blank, it pulls the SDK from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 SDK_INCLUDED_BUILD_PATH=
+# Optional commit hash on zcash/zcash-android-wallet-sdk. When set, CI checks out the SDK at
+# this exact commit and builds against it (via SDK_INCLUDED_BUILD_PATH) instead of the
+# published Maven artifact — for co-developing an app change against unreleased SDK work,
+# without waiting on an SDK release. Locally this has no effect: set
+# ORG_GRADLE_PROJECT_SDK_INCLUDED_BUILD_PATH yourself, pointing at your own local SDK checkout.
+#
+# main and branches targeting main only. Must be blank on maint/release/review branches — CI
+# hard-fails if it finds this non-blank there (both in PR checks and, separately, in the
+# release/deploy workflows themselves), since those branches must always build against an
+# audited, published SDK version, never an arbitrary pinned commit. Clear this before merging
+# into maint. Must be a full 40-char commit sha, not a branch name — branches move underneath
+# you, defeating the point of a pin — and must be reachable from something more durable than
+# the SDK's own PR branch (which stops being fetchable once that branch is deleted): repoint
+# to the merged sha on origin/main once the companion SDK PR lands.
+SDK_COMMIT_PIN=
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/gradle.properties
+++ b/gradle.properties
@@ -115,15 +115,16 @@ SDK_INCLUDED_BUILD_PATH=
 # without waiting on an SDK release. Locally this has no effect: set
 # ORG_GRADLE_PROJECT_SDK_INCLUDED_BUILD_PATH yourself, pointing at your own local SDK checkout.
 #
-# main and branches targeting main only. Must be blank on maint/release/review branches — CI
-# hard-fails if it finds this non-blank there (both in PR checks and, separately, in the
-# release/deploy workflows themselves), since those branches must always build against an
-# audited, published SDK version, never an arbitrary pinned commit. Clear this before merging
-# into maint. Must be a full 40-char commit sha, not a branch name — branches move underneath
-# you, defeating the point of a pin — and must be reachable from something more durable than
-# the SDK's own PR branch (which stops being fetchable once that branch is deleted): repoint
-# to the merged sha on origin/main once the companion SDK PR lands.
-SDK_COMMIT_PIN=
+# main, maint/* branches, and branches targeting either. Must be blank on release/review
+# branches — CI hard-fails if it finds this non-blank there (both in PR checks and,
+# separately, in the release/deploy workflows themselves), since those branches must always
+# build against an audited, published SDK version, never an arbitrary pinned commit. Clear
+# this before merging into release/review. Must be a full 40-char commit sha, not a branch
+# name — branches move underneath you, defeating the point of a pin — and must be reachable
+# from something more durable than the SDK's own PR branch (which stops being fetchable once
+# that branch is deleted): repoint to the merged sha on origin/main (or the relevant
+# origin/maint/vX.Y.x line) once the companion SDK PR lands.
+SDK_COMMIT_PIN=91cff0936f45d1703ed7df39f347485894ac3103
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=91cff0936f45d1703ed7df39f347485894ac3103
+SDK_COMMIT_PIN=0b7c916b5f120333ea18d0b7c81048278264197b
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=


### PR DESCRIPTION
## Summary

Extracts the `SDK_COMMIT_PIN` CI capability from `main`'s PR #2406 onto the `maint/v3.9.x` line, cleanly separated from that PR's unrelated voting-module + swap refactor work, and from two other CI additions that happened to land in the same window (`auto-merge.yml`, `sync-fdroid-metadata.yml`) — neither of those is part of this feature and neither is included here.

`SDK_COMMIT_PIN` is an optional `gradle.properties` value: when set to a full 40-char commit sha, CI checks out that exact commit of `zcash/zcash-android-wallet-sdk`, builds it as a companion Gradle included build, and runs PR checks against it instead of the app's normal published Maven SDK snapshot. This lets an app PR be co-developed against unreleased SDK work without waiting on a Maven publish.

**Design update:** the branch gate now allows a live pin on `main` **and `maint/*`** branches (previously `main`-only), since maint APP lines legitimately need to co-develop against maint SDK lines. `release/*` and `review/*` remain hard-blocked — those must always build against a real published SDK version — enforced both in the PR-check gate and, independently, in `create-release.yml`, `deploy.yml`, and `release.yaml`, which each refuse to deploy/release if `SDK_COMMIT_PIN` is non-blank, regardless of branch.

**This PR now sets a live pin**, rather than leaving it blank: `SDK_COMMIT_PIN` is set to `91cff0936f45d1703ed7df39f347485894ac3103`, the current HEAD of `zcash/zcash-android-wallet-sdk`'s `maint/v3.0.x` branch — the SDK line `maint/v3.9.x` actually depends on (`ZCASH_SDK_VERSION=3.0.1-SNAPSHOT` in `gradle.properties`). This means this PR's own CI run exercises the real companion-SDK build path end to end (checkout, Rust/NDK setup, composite build), not just the infra with the pin left off as originally described.

## What's included

- New `.github/actions/setup-sdk-companion/action.yml` — composite action that reads `SDK_COMMIT_PIN`, enforces the branch gate (`main` or `maint/*`, else hard-fail), and (only if a pin is set) checks out the companion SDK commit, sets up its Rust/NDK toolchain, and wires `ORG_GRADLE_PROJECT_SDK_INCLUDED_BUILD_PATH`.
- `gradle.properties` — `SDK_COMMIT_PIN` property, set to `91cff0936f45d1703ed7df39f347485894ac3103` (SDK `maint/v3.0.x` HEAD as of this PR), with explanatory comment updated for the `maint/*`-allowed gate.
- `.github/workflows/pull-request.yml` — wires the companion-SDK setup step into lint/test/build jobs, bumps their timeouts to accommodate a cold Rust build when a pin is active, adds an app-shard pre-build step to avoid emulator contention, and adds an OOM-retry-once wrapper for the Store APK build.
- `.github/workflows/e2e-smoke.yml` — wires the companion-SDK setup step into the build job, bumps its timeout accordingly.
- `.github/workflows/create-release.yml`, `.github/workflows/deploy.yml`, `.github/workflows/release.yaml` — each adds a "Refuse to deploy with a live SDK_COMMIT_PIN" hard-fail step, unconditional on branch, so a pin can never silently leak into a real release/deploy.

## Why onto maint/v3.9.x

This capability landed on `main` bundled inside PR #2406, which did not merge into `maint/v3.9.x`. This PR brings the infra onto the maint line for consistency with `main`, and — per the updated design — actually activates it here so `maint/v3.9.x` can build/test against unreleased `maint/v3.0.x` SDK work, matching how `main` co-develops against SDK `main`.

## Test plan

- [x] `git diff --stat` confirms exactly the expected files changed: new `.github/actions/setup-sdk-companion/action.yml`; edits to `.github/workflows/{create-release.yml,deploy.yml,e2e-smoke.yml,pull-request.yml,release.yaml}` and `gradle.properties`.
- [x] All changed/added `.yml`/`.yaml` files pass `yaml.safe_load`.
- [x] Re-verified `zcash-android-wallet-sdk`'s `maint/v3.0.x` HEAD via `git ls-remote` immediately before pinning: `91cff0936f45d1703ed7df39f347485894ac3103`.
- [ ] CI passes on this PR with the pin live, targeting `maint/v3.9.x` — exercises the real companion-SDK build path (checkout + Rust/NDK + composite build), not just the fast no-op path.
