### PR TITLE
MOB-1678: Migrate CHP voting to the v1.3.0 chain (poly-aware PIR, auth v2, round-bound shares)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed:
+
+- Shielded coinholder polling works again after the voting infrastructure's v1.3.0 upgrade: the app now reads the PIR polynomial length from the
+  voting configuration, verifies the new round-attestation signature format, and submits vote shares with the round binding the voting server
+  requires. Rounds signed with the old attestation format are no longer shown.
+
 ## [3.9.2 (2370)] - 2026-08-10
 
 ### Fixed:

--- a/feature-voting/build.gradle.kts
+++ b/feature-voting/build.gradle.kts
@@ -86,4 +86,9 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockk)
     testImplementation("io.ktor:ktor-client-mock")
+    // Plain-JVM org.json: the Android `org.json` classes on this module's unit-test
+    // classpath are stubs (`unitTests.isReturnDefaultValues = true`), so the reference
+    // JVM implementation is needed to exercise `VotingApiProvider`'s `org.json`-built
+    // wire bodies (MOB-1678's SharePostBodyWireContractTest).
+    testImplementation("org.json:json:20260719")
 }

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/model/voting/RoundAuthenticator.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/model/voting/RoundAuthenticator.kt
@@ -1,6 +1,8 @@
 package co.electriccoin.zcash.ui.common.model.voting
 
 import com.google.crypto.tink.subtle.Ed25519Verify
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 
 enum class RoundAuthStatus {
     AUTHENTICATED,
@@ -41,24 +43,47 @@ private fun votingRoundAuthMessage(status: RoundAuthStatus, roundIdHex: String):
         }
     }
 
+/**
+ * The wallet accepts only [AUTH_VERSION_V2] dynamic-config round attestations.
+ *
+ * Policy decision (MOB-1678, `zcash_voting` 3.0 bump): v1 entries — signatures over the raw
+ * 32-byte `ea_pk` only — are rejected outright, matching the crate's own verifier. Accepting
+ * v1 would let the wallet act on a round whose attestation does not pin the round id or the
+ * PIR layout it is about to be queried with. Deliberate and overturnable, not an oversight.
+ */
 object RoundAuthenticator {
-    const val AUTH_VERSION_V1 = 1
+    const val AUTH_VERSION_V2 = 2
 
+    /**
+     * Authenticate one chain-sourced round against the dynamic config registry.
+     *
+     * For `auth_version: 2`, the admin signature covers the fixed-width payload built by
+     * [signingPayloadV2]: domain tag, round id, `ea_pk`, and the config's full PIR layout.
+     * [pirLayout] MUST be the top-level `pir_layout` of the same dynamic config [rounds]
+     * came from — the signature binds them, so a config mixing layouts and rounds from
+     * different generations fails here by construction. After verifying the signature
+     * against a key from the bundled static config, the wallet still checks that the chain
+     * response carries exactly the same `ea_pk`; this chain-binding step catches a stale or
+     * hostile vote server response and is not subsumed by v2.
+     */
     fun authenticate(
         chainEaPK: ByteArray,
         roundIdHex: String,
         rounds: Map<String, VotingServiceConfig.RoundEntry>,
-        trustedKeys: List<StaticVotingConfig.TrustedKey>
+        trustedKeys: List<StaticVotingConfig.TrustedKey>,
+        pirLayout: VotingPirLayout
     ): RoundAuthStatus {
         val entry = rounds[roundIdHex] ?: return RoundAuthStatus.MISSING_ROUND
-        if (entry.authVersion != AUTH_VERSION_V1) {
+        if (entry.authVersion != AUTH_VERSION_V2) {
             return RoundAuthStatus.UNKNOWN_AUTH_VERSION
         }
 
         val entryEaPk =
             runCatching { entry.eaPkBytes() }.getOrNull()
                 ?: return RoundAuthStatus.INVALID_SIGNATURES
-        if (entryEaPk.size != EA_PK_BYTES || !verifyEntrySignatures(entry, trustedKeys)) {
+        if (entryEaPk.size != EA_PK_BYTES ||
+            !verifyEntrySignatures(entry, roundIdHex, pirLayout, trustedKeys)
+        ) {
             return RoundAuthStatus.INVALID_SIGNATURES
         }
         if (!chainEaPK.contentEquals(entryEaPk)) {
@@ -67,18 +92,25 @@ object RoundAuthenticator {
         return RoundAuthStatus.AUTHENTICATED
     }
 
+    /**
+     * Returns true when at least one entry signature validates over the v2 payload.
+     *
+     * The dynamic config names a trusted admin key by `key_id`; it does not inline public
+     * keys. This resolves `key_id` into the static config, requires matching algorithms, and
+     * verifies the ed25519 signature over [signingPayloadV2] for [roundIdHex] and [pirLayout].
+     */
     fun verifyEntrySignatures(
         entry: VotingServiceConfig.RoundEntry,
+        roundIdHex: String,
+        pirLayout: VotingPirLayout,
         trustedKeys: List<StaticVotingConfig.TrustedKey>
     ): Boolean {
-        if (entry.authVersion != AUTH_VERSION_V1 || entry.signatures.isEmpty()) {
+        if (entry.authVersion != AUTH_VERSION_V2 || entry.signatures.isEmpty()) {
             return false
         }
 
         val eaPk = runCatching { entry.eaPkBytes() }.getOrNull() ?: return false
-        if (eaPk.size != EA_PK_BYTES) {
-            return false
-        }
+        val payload = signingPayloadV2(roundIdHex, eaPk, pirLayout) ?: return false
 
         val trustedByKeyId = trustedKeys.associateBy(StaticVotingConfig.TrustedKey::keyId)
         return entry.signatures.any { signature ->
@@ -92,12 +124,48 @@ object RoundAuthenticator {
             publicKey.size == ED25519_PUBLIC_KEY_BYTES &&
                 signatureBytes.size == ED25519_SIGNATURE_BYTES &&
                 runCatching {
-                    Ed25519Verify(publicKey).verify(signatureBytes, eaPk)
+                    Ed25519Verify(publicKey).verify(signatureBytes, payload)
                 }.isSuccess
         }
     }
 
+    /**
+     * Canonical round-auth v2 bytes, mirroring `zcash_voting::round_auth::RoundAuthPayloadV2`:
+     *
+     * `"zcash-shielded-vote:round-auth:v2" (33B) || round_id (32B) || ea_pk (32B) ||
+     * pir_depth || tier0_layers || tier1_layers || poly_len` (each u32 little-endian).
+     *
+     * Returns null — the entry can never authenticate — when [roundIdHex] does not
+     * strict-hex-decode to exactly 32 bytes (crate parity: an undecodable id is skipped
+     * defensively), when [eaPk] is not 32 bytes, or when [pirLayout] predates
+     * `pir_layout.poly_len` (a pre-3.0 config cannot have produced a v2 attestation).
+     */
+    fun signingPayloadV2(
+        roundIdHex: String,
+        eaPk: ByteArray,
+        pirLayout: VotingPirLayout
+    ): ByteArray? {
+        val roundId = runCatching { roundIdHex.lowercaseHexToBytes() }.getOrNull() ?: return null
+        if (roundId.size != ROUND_ID_BYTES || eaPk.size != EA_PK_BYTES || pirLayout.polyLen == 0) {
+            return null
+        }
+
+        val payloadSize = DOMAIN_TAG_V2.size + roundId.size + eaPk.size + PIR_LAYOUT_FIELD_COUNT * Int.SIZE_BYTES
+        val buffer = ByteBuffer.allocate(payloadSize).order(ByteOrder.LITTLE_ENDIAN)
+        buffer.put(DOMAIN_TAG_V2)
+        buffer.put(roundId)
+        buffer.put(eaPk)
+        buffer.putInt(pirLayout.pirDepth)
+        buffer.putInt(pirLayout.tier0Layers)
+        buffer.putInt(pirLayout.tier1Layers)
+        buffer.putInt(pirLayout.polyLen)
+        return buffer.array()
+    }
+
+    private val DOMAIN_TAG_V2 = "zcash-shielded-vote:round-auth:v2".toByteArray(Charsets.US_ASCII)
+    private const val ROUND_ID_BYTES = 32
     private const val EA_PK_BYTES = 32
     private const val ED25519_PUBLIC_KEY_BYTES = 32
     private const val ED25519_SIGNATURE_BYTES = 64
+    private const val PIR_LAYOUT_FIELD_COUNT = 4
 }

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/model/voting/VotingRequests.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/model/voting/VotingRequests.kt
@@ -136,6 +136,8 @@ data class SharePayload(
     val voteDecision: Int,
     val encShare: EncryptedShare,
     val treePosition: Long,
+    /** Voting round ID as 32 bytes encoded in lowercase hex, as populated by the crate. */
+    val voteRoundId: String,
     val allEncShares: List<EncryptedShare> = emptyList(),
     val shareComms: List<ByteArray> = emptyList(),
     val primaryBlind: ByteArray = ByteArray(0),
@@ -150,6 +152,7 @@ data class SharePayload(
             voteDecision == other.voteDecision &&
             encShare == other.encShare &&
             treePosition == other.treePosition &&
+            voteRoundId == other.voteRoundId &&
             allEncShares.contentListEquals(other.allEncShares, EncryptedShare::equals) &&
             shareComms.contentListEquals(other.shareComms) &&
             primaryBlind.contentEquals(other.primaryBlind) &&
@@ -162,6 +165,7 @@ data class SharePayload(
         result = 31 * result + voteDecision
         result = 31 * result + encShare.hashCode()
         result = 31 * result + treePosition.hashCode()
+        result = 31 * result + voteRoundId.hashCode()
         result = 31 * result + allEncShares.contentListHashCode(EncryptedShare::hashCode)
         result = 31 * result + shareComms.contentListHashCode()
         result = 31 * result + primaryBlind.contentHashCode()

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/model/voting/VotingServiceConfig.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/model/voting/VotingServiceConfig.kt
@@ -127,7 +127,29 @@ data class VotingPirLayout(
     val tier0Layers: Int = 0,
     @SerialName("tier1_layers")
     val tier1Layers: Int = 0,
+    /**
+     * Absent in configs published before the v1.3.0 vote chain (zcash_voting 3.0.0-rc.3)
+     * introduced the poly_len handshake field; decodes to 0, which keeps this layout at the
+     * UNKNOWN sentinel below rather than silently assuming 2048.
+     */
+    @SerialName("poly_len")
+    val polyLen: Int = 0,
 )
+
+/**
+ * MOB-1678 (zcash_voting 3.0 bump): `pir_layout.poly_len` is load-bearing — the crate
+ * validates it locally (must be 2048 or 4096) and the PIR connect handshake re-checks it
+ * against the server. A dynamic config without the field predates the 3.0 service, so every
+ * delegation entry point fails closed *before any FFI call* rather than fabricating a value.
+ * The thrown [VotingConfigException] reuses the existing voting config-error copy — no new
+ * strings are introduced for this guard.
+ */
+fun VotingPirLayout.requireKnownPolyLen(): VotingPirLayout {
+    if (polyLen == 0) {
+        throw VotingConfigException("Voting config is missing pir_layout.poly_len required for delegation")
+    }
+    return this
+}
 
 open class VotingConfigException(
     message: String
@@ -150,7 +172,12 @@ fun VotingServiceConfig.retainingRoundsWithValidSignatures(
 ): VotingServiceConfig =
     copy(
         rounds =
-            rounds.filter { (_, entry) ->
-                RoundAuthenticator.verifyEntrySignatures(entry = entry, trustedKeys = trustedKeys)
+            rounds.filter { (roundIdHex, entry) ->
+                RoundAuthenticator.verifyEntrySignatures(
+                    entry = entry,
+                    roundIdHex = roundIdHex,
+                    pirLayout = pirLayout,
+                    trustedKeys = trustedKeys
+                )
             }
     )

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/model/voting/VotingSubmissionParsers.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/model/voting/VotingSubmissionParsers.kt
@@ -61,6 +61,7 @@ fun String.toSharePayloads(): List<SharePayload> {
                     voteDecision = payload.getInt("vote_decision"),
                     encShare = payload.getJSONObject("enc_share").toEncryptedShare(),
                     treePosition = payload.getLong("tree_position"),
+                    voteRoundId = payload.getString("vote_round_id"),
                     allEncShares = payload.optJSONArray("all_enc_shares").toEncryptedShares(),
                     shareComms = payload.optJSONArray("share_comms").toByteArrays(),
                     primaryBlind =

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -103,10 +103,7 @@ interface VotingApiProvider {
 
     suspend fun fetchTallyResults(roundIdHex: String): TallyResults
 
-    suspend fun delegateShares(
-        shares: List<SharePayload>,
-        roundIdHex: String
-    ): List<DelegatedShareInfo>
+    suspend fun delegateShares(shares: List<SharePayload>): List<DelegatedShareInfo>
 
     suspend fun fetchShareStatus(
         helperBaseUrl: String,
@@ -116,7 +113,6 @@ interface VotingApiProvider {
 
     suspend fun resubmitShare(
         payload: SharePayload,
-        roundIdHex: String,
         candidateUrls: List<String>,
         excludeUrls: List<String>
     ): List<String>
@@ -233,10 +229,7 @@ class KtorVotingApiProvider(
         }
     }
 
-    override suspend fun delegateShares(
-        shares: List<SharePayload>,
-        roundIdHex: String
-    ): List<DelegatedShareInfo> =
+    override suspend fun delegateShares(shares: List<SharePayload>): List<DelegatedShareInfo> =
         executeWithKtorTimeoutSupport delegateShares@{ supportsKtorTimeouts ->
             if (shares.isEmpty()) {
                 return@delegateShares emptyList()
@@ -256,7 +249,7 @@ class KtorVotingApiProvider(
 
             buildList {
                 for (share in shares) {
-                    val body = share.toApiBody(roundIdHex)
+                    val body = share.toApiBody()
                     val healthyServers = serverHealthTracker.healthyServers(serverUrls)
                     val quorum = max(1, (healthyServers.size + 1) / 2)
                     val targets = healthyServers.shuffled().take(quorum)
@@ -320,7 +313,6 @@ class KtorVotingApiProvider(
 
     override suspend fun resubmitShare(
         payload: SharePayload,
-        roundIdHex: String,
         candidateUrls: List<String>,
         excludeUrls: List<String>
     ): List<String> =
@@ -334,7 +326,7 @@ class KtorVotingApiProvider(
 
             val healthyServers = serverHealthTracker.healthyServers(allServers)
             val candidateServers = healthyServers.filterNot { serverUrl -> serverUrl in excludedServers }
-            val body = payload.withSubmitAt(0).toApiBody(roundIdHex)
+            val body = payload.withSubmitAt(0).toApiBody()
 
             if (candidateServers.isEmpty()) {
                 for (serverUrl in healthyServers.shuffled()) {
@@ -731,12 +723,11 @@ private fun List<String>.normalizeServerUrls(): List<String> =
  * byte field base64, matching `VoteShareWire`'s `serde_base64_bytes` fields exactly.
  * `all_enc_shares` was dropped from this wire struct (2.0-rc.4) and must never be sent.
  *
- * [roundIdHex] stays app-supplied: the SDK's `buildSharePayloadsNative`/`JniSharePayload`
- * does not yet expose the crate's own `SharePayload::to_wire_json()` (no `vote_round_id`
- * field on the JNI model), so the app cannot forward the crate-produced JSON verbatim here
- * without a corresponding SDK change — tracked separately, out of this pass's SDK scope.
+ * `vote_round_id` is the crate-provided [SharePayload.voteRoundId] verbatim — the SDK's
+ * `buildSharePayloadsNative`/`JniSharePayload` now carries it, so nothing is injected
+ * app-side.
  */
-internal fun SharePayload.toApiBody(roundIdHex: String) =
+internal fun SharePayload.toApiBody() =
     JSONObject()
         .put("shares_hash", sharesHash.toBase64String())
         .put("proposal_id", proposalId)
@@ -749,7 +740,7 @@ internal fun SharePayload.toApiBody(roundIdHex: String) =
                 .put("share_index", encShare.shareIndex)
         ).put("share_index", encShare.shareIndex)
         .put("tree_position", treePosition)
-        .put("vote_round_id", roundIdHex)
+        .put("vote_round_id", voteRoundId)
         .put("share_comms", org.json.JSONArray(shareComms.map(ByteArray::toBase64String)))
         .put("primary_blind", primaryBlind.toBase64String())
         .put("submit_at", submitAt)

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -471,7 +471,8 @@ class KtorVotingApiProvider(
                 chainEaPK = session.eaPK,
                 roundIdHex = roundIdHex,
                 rounds = resolvedConfig.rawServiceConfig.rounds,
-                trustedKeys = resolvedConfig.staticConfig.trustedKeys
+                trustedKeys = resolvedConfig.staticConfig.trustedKeys,
+                pirLayout = resolvedConfig.rawServiceConfig.pirLayout
             )
         if (status != RoundAuthStatus.AUTHENTICATED) {
             throw VotingRoundAuthenticationException(status = status, roundIdHex = roundIdHex)
@@ -723,7 +724,19 @@ private fun List<String>.normalizeServerUrls(): List<String> =
         .map { serverUrl -> serverUrl.trimEnd('/') }
         .distinct()
 
-private fun SharePayload.toApiBody(roundIdHex: String) =
+/**
+ * Builds the share-delegation POST body as `zcash_voting::wire::VoteShareWire::to_json()`
+ * defines it (MOB-1678, zcash_voting 3.0): `shares_hash`, `enc_share`, `share_index`,
+ * `tree_position`, `vote_round_id`, `share_comms`, `primary_blind`, `submit_at` — every
+ * byte field base64, matching `VoteShareWire`'s `serde_base64_bytes` fields exactly.
+ * `all_enc_shares` was dropped from this wire struct (2.0-rc.4) and must never be sent.
+ *
+ * [roundIdHex] stays app-supplied: the SDK's `buildSharePayloadsNative`/`JniSharePayload`
+ * does not yet expose the crate's own `SharePayload::to_wire_json()` (no `vote_round_id`
+ * field on the JNI model), so the app cannot forward the crate-produced JSON verbatim here
+ * without a corresponding SDK change — tracked separately, out of this pass's SDK scope.
+ */
+internal fun SharePayload.toApiBody(roundIdHex: String) =
     JSONObject()
         .put("shares_hash", sharesHash.toBase64String())
         .put("proposal_id", proposalId)
@@ -737,17 +750,7 @@ private fun SharePayload.toApiBody(roundIdHex: String) =
         ).put("share_index", encShare.shareIndex)
         .put("tree_position", treePosition)
         .put("vote_round_id", roundIdHex)
-        .put(
-            "all_enc_shares",
-            org.json.JSONArray(
-                allEncShares.map { share ->
-                    JSONObject()
-                        .put("c1", share.c1.toBase64String())
-                        .put("c2", share.c2.toBase64String())
-                        .put("share_index", share.shareIndex)
-                }
-            )
-        ).put("share_comms", org.json.JSONArray(shareComms.map(ByteArray::toBase64String)))
+        .put("share_comms", org.json.JSONArray(shareComms.map(ByteArray::toBase64String)))
         .put("primary_blind", primaryBlind.toBase64String())
         .put("submit_at", submitAt)
         .toString()

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingCryptoClient.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingCryptoClient.kt
@@ -36,6 +36,7 @@ import co.electriccoin.zcash.ui.common.model.voting.VotingShareDelegationRecord
 import co.electriccoin.zcash.ui.common.model.voting.VotingTxHashLookup
 import co.electriccoin.zcash.ui.common.model.voting.VotingVoteCommitment
 import co.electriccoin.zcash.ui.common.model.voting.VotingVoteRecord
+import co.electriccoin.zcash.ui.common.model.voting.requireKnownPolyLen
 import co.electriccoin.zcash.ui.common.model.voting.toVoteCommitmentBundle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
@@ -842,6 +843,7 @@ class VotingCryptoClientImpl : VotingCryptoClient {
                     pirLayout.pirDepth,
                     pirLayout.tier0Layers,
                     pirLayout.tier1Layers,
+                    pirLayout.requireKnownPolyLen().polyLen,
                     notesJson.toVotingNoteInfos()
                 ).toAppModel()
         }
@@ -869,6 +871,7 @@ class VotingCryptoClientImpl : VotingCryptoClient {
                     pirLayout.pirDepth,
                     pirLayout.tier0Layers,
                     pirLayout.tier1Layers,
+                    pirLayout.requireKnownPolyLen().polyLen,
                     notesJson.toVotingNoteInfos(),
                     fvkBytes,
                     hotkeySeed,

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingCryptoClient.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingCryptoClient.kt
@@ -1556,6 +1556,7 @@ private fun List<VotingSharePayload>.toSharePayloadsJson(): String =
                 .put("vote_decision", payload.voteDecision)
                 .put("enc_share", payload.encShare.toJson())
                 .put("tree_position", payload.treePosition)
+                .put("vote_round_id", payload.voteRoundId)
                 .put("all_enc_shares", payload.allEncShares.toEncryptedSharesJsonArray())
                 .put("share_comms", payload.shareComms.toHexJsonArray())
                 .put("primary_blind", payload.primaryBlind.toHexString())

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepository.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepository.kt
@@ -6,6 +6,7 @@ import cash.z.ecc.android.sdk.model.ZcashNetwork
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.model.KeystoneAccount
 import co.electriccoin.zcash.ui.common.model.voting.isDelegationSetupOverwrite
+import co.electriccoin.zcash.ui.common.model.voting.requireKnownPolyLen
 import co.electriccoin.zcash.ui.common.model.voting.votingBundleRawWeights
 import co.electriccoin.zcash.ui.common.provider.KeystoneSDKProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
@@ -268,7 +269,7 @@ class VotingKeystoneRepositoryImpl(
                             roundId = roundId,
                             bundleIndex = bundleIndex,
                             pirEndpoints = sessionContext.serviceConfig.pirEndpoints.map { endpoint -> endpoint.url },
-                            pirLayout = sessionContext.serviceConfig.pirLayout,
+                            pirLayout = sessionContext.serviceConfig.pirLayout.requireKnownPolyLen(),
                             expectedSnapshotHeight = session.snapshotHeight,
                             networkId = networkId,
                             notesJson = allNotesJson

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/usecase/PrepareVotingRoundUseCase.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/usecase/PrepareVotingRoundUseCase.kt
@@ -12,6 +12,7 @@ import co.electriccoin.zcash.ui.common.model.voting.VotingBundleSetupResult
 import co.electriccoin.zcash.ui.common.model.voting.VotingPirLayout
 import co.electriccoin.zcash.ui.common.model.voting.VotingRoundPreparationResult
 import co.electriccoin.zcash.ui.common.model.voting.isDelegationSetupOverwrite
+import co.electriccoin.zcash.ui.common.model.voting.requireKnownPolyLen
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import co.electriccoin.zcash.ui.common.provider.VotingCryptoClient
 import co.electriccoin.zcash.ui.common.provider.VotingHotkeySeedProvider
@@ -309,7 +310,7 @@ class PrepareVotingRoundUseCase(
                                     roundName = session.title,
                                     pirEndpoints =
                                         sessionContext.serviceConfig.pirEndpoints.map { endpoint -> endpoint.url },
-                                    pirLayout = sessionContext.serviceConfig.pirLayout,
+                                    pirLayout = sessionContext.serviceConfig.pirLayout.requireKnownPolyLen(),
                                     expectedSnapshotHeight = session.snapshotHeight
                                 )
                         }.onFailure { throwable ->

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCase.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCase.kt
@@ -1145,7 +1145,7 @@ class SubmitVotesUseCase(
             return
         }
 
-        val delegationResults = delegateSharesWithRetry(pendingPayloads, roundId)
+        val delegationResults = delegateSharesWithRetry(pendingPayloads)
         delegationResults.forEach { info ->
             val payload =
                 pendingPayloads.firstOrNull { candidate ->
@@ -1200,14 +1200,11 @@ class SubmitVotesUseCase(
         }
     }
 
-    private suspend fun delegateSharesWithRetry(
-        payloads: List<SharePayload>,
-        roundId: String
-    ): List<DelegatedShareInfo> {
+    private suspend fun delegateSharesWithRetry(payloads: List<SharePayload>): List<DelegatedShareInfo> {
         var lastRetryableError: Exception? = null
         repeat(SHARE_DELEGATION_ATTEMPTS) { attempt ->
             try {
-                return votingApiProvider.delegateShares(payloads, roundId)
+                return votingApiProvider.delegateShares(payloads)
             } catch (exception: CancellationException) {
                 throw exception
             } catch (exception: Exception) {

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCase.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCase.kt
@@ -21,6 +21,7 @@ import co.electriccoin.zcash.ui.common.model.voting.VotingSubmissionResult
 import co.electriccoin.zcash.ui.common.model.voting.VotingTxHashLookup
 import co.electriccoin.zcash.ui.common.model.voting.isDelegationSetupOverwrite
 import co.electriccoin.zcash.ui.common.model.voting.isLastMoment
+import co.electriccoin.zcash.ui.common.model.voting.requireKnownPolyLen
 import co.electriccoin.zcash.ui.common.model.voting.toDelegationRegistration
 import co.electriccoin.zcash.ui.common.model.voting.toSharePayloads
 import co.electriccoin.zcash.ui.common.model.voting.toVoteCommitmentBundle
@@ -209,7 +210,7 @@ class SubmitVotesUseCase(
                     hotkeySeed = hotkeySeed,
                     isKeystone = isKeystone,
                     pirServerUrl = pirServerUrl,
-                    pirLayout = serviceConfig.pirLayout,
+                    pirLayout = serviceConfig.pirLayout.requireKnownPolyLen(),
                     singleShare = singleShare,
                     sortedChoices = sortedChoices,
                     totalChoices = totalChoices

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/usecase/TrackVotingSharesUseCase.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/usecase/TrackVotingSharesUseCase.kt
@@ -173,7 +173,6 @@ class TrackVotingSharesUseCase(
                             runCatching {
                                 votingApiProvider.resubmitShare(
                                     payload = payload,
-                                    roundIdHex = roundId,
                                     candidateUrls = roundVoteServerUrls,
                                     excludeUrls = delegation.sentToUrls
                                 )

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/votingerror/VotingErrorMapper.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/votingerror/VotingErrorMapper.kt
@@ -66,6 +66,10 @@ object VotingErrorMapper {
                 stringRes(UiR.string.coinVote_store_userError_pirSnapshotMismatch)
             }
 
+            lower.contains("pir poly_len mismatch") -> {
+                stringRes(UiR.string.coinVote_store_userError_pirSnapshotMismatch)
+            }
+
             lower.contains("pir proof verification failed") -> {
                 stringRes(UiR.string.coinVote_store_userError_pirInvalidProofData)
             }
@@ -73,6 +77,10 @@ object VotingErrorMapper {
             lower.contains("pir server connect failed") ||
                 lower.contains("pir parallel fetch failed") -> {
                 stringRes(UiR.string.coinVote_store_userError_pirUnavailable)
+            }
+
+            lower.contains("unsupported pir layout") -> {
+                stringRes(UiR.string.coinVote_store_userError_pirEndpointsMissing)
             }
 
             lower.contains("no pir endpoints are configured") -> {
@@ -83,7 +91,15 @@ object VotingErrorMapper {
                 stringRes(UiR.string.coinVote_store_userError_commitmentTreeNotGrown)
             }
 
+            lower.contains("is absent from the synced vote tree") -> {
+                stringRes(UiR.string.coinVote_store_userError_commitmentTreeNotGrown)
+            }
+
             lower.contains("invalid commitment tree anchor height") -> {
+                stringRes(UiR.string.coinVote_store_userError_invalidAnchorHeight)
+            }
+
+            lower.contains("does not match its synced vote-tree leaf") -> {
                 stringRes(UiR.string.coinVote_store_userError_invalidAnchorHeight)
             }
 

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/model/voting/VotingServiceConfigTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/model/voting/VotingServiceConfigTest.kt
@@ -1,10 +1,12 @@
 package co.electriccoin.zcash.ui.common.model.voting
 
+import com.google.crypto.tink.subtle.Ed25519Sign
 import java.security.MessageDigest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class StaticVotingConfigTest {
@@ -171,6 +173,7 @@ class VotingServiceConfigTest {
                   "config_version": 1,
                   "vote_servers": [{"url": "https://vote.example.com", "label": "vote"}],
                   "pir_endpoints": [{"url": "https://pir.example.com", "label": "pir"}],
+                  "pir_layout": {"pir_depth": 19, "tier0_layers": 12, "tier1_layers": 7, "poly_len": 4096},
                   "supported_versions": {
                     "pir": ["v0"],
                     "vote_protocol": "v0",
@@ -179,10 +182,10 @@ class VotingServiceConfigTest {
                   },
                   "rounds": {
                     "$ROUND_ID": {
-                      "auth_version": 1,
+                      "auth_version": 2,
                       "ea_pk": "$EA_PK_BASE64",
                       "signatures": [
-                        {"key_id": "valar-test", "alg": "ed25519", "sig": "$ADMIN_SIGNATURE_BASE64"}
+                        {"key_id": "valar-test", "alg": "ed25519", "sig": "${validSignatureBase64()}"}
                       ]
                     }
                   }
@@ -194,17 +197,44 @@ class VotingServiceConfigTest {
 
         assertEquals(setOf(ROUND_ID), config.rounds.keys)
         assertEquals(EA_PK_BASE64, config.rounds.getValue(ROUND_ID).eaPk)
+        assertEquals(PIR_LAYOUT_FIXTURE, config.pirLayout)
+    }
+
+    @Test
+    fun decodeDefaultsPolyLenToZeroWhenAbsent() {
+        val config =
+            VotingServiceConfig.decode(
+                """
+                {
+                  "config_version": 1,
+                  "vote_servers": [{"url": "https://vote.example.com", "label": "vote"}],
+                  "pir_endpoints": [{"url": "https://pir.example.com", "label": "pir"}],
+                  "pir_layout": {"pir_depth": 19, "tier0_layers": 12, "tier1_layers": 7},
+                  "supported_versions": {
+                    "pir": ["v0"],
+                    "vote_protocol": "v0",
+                    "tally": "v0",
+                    "vote_server": "v1"
+                  },
+                  "rounds": {}
+                }
+                """.trimIndent()
+            )
+
+        assertEquals(0, config.pirLayout.polyLen)
     }
 
     @Test
     fun serviceConfigDropsOnlyRoundsWithoutValidSignatures() {
-        val invalidRoundId = "b".repeat(64)
+        val otherRoundId = "0".repeat(63) + "2"
+        val v1RoundId = "b".repeat(64)
         val config =
             makeServiceConfig(
                 rounds =
                     mapOf(
                         ROUND_ID to makeEntry(),
-                        invalidRoundId to makeEntry(signature = ADMIN_SIGNATURE_BASE64.flipFirstBase64Byte())
+                        otherRoundId to makeEntry(),
+                        v1RoundId to makeLegacyV1Entry()
                     )
             )
 
@@ -224,15 +254,82 @@ class VotingServiceConfigTest {
 }
 
 class RoundAuthenticatorTest {
+    /**
+     * Golden vector from zcash_voting 3.0.0-rc.2
+     * (`dynamic_resolution_accepts_vote_sdk_ui_signed_round_entry`, config/mod.rs): a
+     * vote-sdk admin-UI / Keplr-derived key signing the poly_len-bound v2 preimage (tag ||
+     * round_id || ea_pk || 19/12/7/4096). Passing pins byte-for-byte compatibility with the
+     * crate's verifier.
+     */
     @Test
-    fun authenticateAcceptsFixtureFromDynamicConfig() {
+    fun authenticateAcceptsCrateGoldenVector() {
+        val goldenRoundId = "06aae723e42cf615d174f338e8f30a72d2bf3275eb9d9e835cc894f197904b20"
+        val goldenKeyId = "keplr:sv1mqts0klc9768rns9h2ykeaka5tve6ts39c2zu3"
+        val goldenEaPkBase64 = "GpYa1sCGIMe2bp1O9UgrThrwkCdxu6oHDmhoBTw6EZ8="
+        val goldenPubkeyBase64 = "NDygCpG+Y4T4uu8M1Sb/YG+74lUVj9XgYypUoMQMXT8="
+        val goldenSigBase64 =
+            "RHbpnj2a1VA+wadIQT3JM/r6ADH11VeA8UgT5dhwhixMcS5Bw5ispndM/ZYH/d2vxNBxTRtZwnLyXZjxcVD+Dg=="
+        val entry =
+            VotingServiceConfig.RoundEntry(
+                authVersion = RoundAuthenticator.AUTH_VERSION_V2,
+                eaPk = goldenEaPkBase64,
+                signatures =
+                    listOf(
+                        VotingServiceConfig.Signature(keyId = goldenKeyId, alg = "ed25519", sig = goldenSigBase64)
+                    )
+            )
+        val trustedKey =
+            StaticVotingConfig.TrustedKey(keyId = goldenKeyId, alg = "ed25519", pubkey = goldenPubkeyBase64)
+
+        val status =
+            RoundAuthenticator.authenticate(
+                chainEaPK = goldenEaPkBase64.base64Bytes(),
+                roundIdHex = goldenRoundId,
+                rounds = mapOf(goldenRoundId to entry),
+                trustedKeys = listOf(trustedKey),
+                pirLayout = PIR_LAYOUT_FIXTURE
+            )
+
+        assertEquals(RoundAuthStatus.AUTHENTICATED, status)
+    }
+
+    /**
+     * Golden byte layout from zcash_voting 3.0.0-rc.2
+     * (`encoding_matches_round_auth_v2_wire_format`, round_auth.rs): round_id [1u8; 32],
+     * ea_pk [2u8; 32], layout 19/12/7/4096, every u32 little-endian.
+     */
+    @Test
+    fun signingPayloadV2MatchesCrateWireFormat() {
+        val payload =
+            RoundAuthenticator.signingPayloadV2(
+                roundIdHex = "01".repeat(32),
+                eaPk = ByteArray(32) { 0x02 },
+                pirLayout = PIR_LAYOUT_FIXTURE
+            )
+
+        val expected =
+            "zcash-shielded-vote:round-auth:v2".toByteArray(Charsets.US_ASCII) +
+                ByteArray(32) { 0x01 } +
+                ByteArray(32) { 0x02 } +
+                byteArrayOf(19, 0, 0, 0) +
+                byteArrayOf(12, 0, 0, 0) +
+                byteArrayOf(7, 0, 0, 0) +
+                byteArrayOf(0x00, 0x10, 0x00, 0x00)
+
+        assertEquals(113, payload?.size)
+        assertTrue(payload.contentEquals(expected))
+    }
+
+    @Test
+    fun authenticateAcceptsV2EntrySignedOverV2Payload() {
         assertEquals(
             RoundAuthStatus.AUTHENTICATED,
             RoundAuthenticator.authenticate(
                 chainEaPK = EA_PK_BASE64.base64Bytes(),
                 roundIdHex = ROUND_ID,
                 rounds = mapOf(ROUND_ID to makeEntry()),
-                trustedKeys = listOf(makeTrustedKey())
+                trustedKeys = listOf(makeTrustedKey()),
+                pirLayout = PIR_LAYOUT_FIXTURE
             )
         )
     }
@@ -245,33 +342,41 @@ class RoundAuthenticatorTest {
                 chainEaPK = EA_PK_BASE64.base64Bytes(),
                 roundIdHex = ROUND_ID,
                 rounds = emptyMap(),
-                trustedKeys = listOf(makeTrustedKey())
+                trustedKeys = listOf(makeTrustedKey()),
+                pirLayout = PIR_LAYOUT_FIXTURE
             )
         )
     }
 
+    /**
+     * v1 policy pin (MOB-1678, deliberate + overturnable — see [RoundAuthenticator]'s doc
+     * comment): a *valid* v1-style signature over the raw `ea_pk` must no longer
+     * authenticate, matching the crate's own dynamic-resolution behavior.
+     */
     @Test
-    fun authenticateReportsInvalidSignature() {
-        assertEquals(
-            RoundAuthStatus.INVALID_SIGNATURES,
-            RoundAuthenticator.authenticate(
-                chainEaPK = EA_PK_BASE64.base64Bytes(),
-                roundIdHex = ROUND_ID,
-                rounds = mapOf(ROUND_ID to makeEntry(signature = ADMIN_SIGNATURE_BASE64.flipFirstBase64Byte())),
-                trustedKeys = listOf(makeTrustedKey())
-            )
-        )
-    }
-
-    @Test
-    fun authenticateReportsUnknownAuthVersion() {
+    fun authenticateRejectsLegacyV1Entry() {
         assertEquals(
             RoundAuthStatus.UNKNOWN_AUTH_VERSION,
             RoundAuthenticator.authenticate(
                 chainEaPK = EA_PK_BASE64.base64Bytes(),
                 roundIdHex = ROUND_ID,
-                rounds = mapOf(ROUND_ID to makeEntry(authVersion = 2)),
-                trustedKeys = listOf(makeTrustedKey())
+                rounds = mapOf(ROUND_ID to makeLegacyV1Entry()),
+                trustedKeys = listOf(makeTrustedKey()),
+                pirLayout = PIR_LAYOUT_FIXTURE
+            )
+        )
+    }
+
+    @Test
+    fun authenticateReportsInvalidSignatures() {
+        assertEquals(
+            RoundAuthStatus.INVALID_SIGNATURES,
+            RoundAuthenticator.authenticate(
+                chainEaPK = EA_PK_BASE64.base64Bytes(),
+                roundIdHex = ROUND_ID,
+                rounds = mapOf(ROUND_ID to makeEntry(signature = validSignatureBase64().flipFirstBase64Byte())),
+                trustedKeys = listOf(makeTrustedKey()),
+                pirLayout = PIR_LAYOUT_FIXTURE
             )
         )
     }
@@ -289,7 +394,8 @@ class RoundAuthenticatorTest {
                 chainEaPK = EA_PK_BASE64.base64Bytes(),
                 roundIdHex = ROUND_ID,
                 rounds = mapOf(ROUND_ID to makeEntry(eaPK = shortEaPk)),
-                trustedKeys = listOf(makeTrustedKey())
+                trustedKeys = listOf(makeTrustedKey()),
+                pirLayout = PIR_LAYOUT_FIXTURE
             )
         )
     }
@@ -304,9 +410,99 @@ class RoundAuthenticatorTest {
                 chainEaPK = chainEaPK,
                 roundIdHex = ROUND_ID,
                 rounds = mapOf(ROUND_ID to makeEntry()),
-                trustedKeys = listOf(makeTrustedKey())
+                trustedKeys = listOf(makeTrustedKey()),
+                pirLayout = PIR_LAYOUT_FIXTURE
             )
         )
+    }
+
+    /**
+     * The v2 signature binds the round id: replaying an entry signed for one round under a
+     * different key in the `rounds` map must not authenticate.
+     */
+    @Test
+    fun authenticateRejectsEntryReplayedUnderDifferentRoundId() {
+        val otherRoundId = "0".repeat(63) + "2"
+        val entry = makeEntry()
+
+        assertEquals(
+            RoundAuthStatus.INVALID_SIGNATURES,
+            RoundAuthenticator.authenticate(
+                chainEaPK = EA_PK_BASE64.base64Bytes(),
+                roundIdHex = otherRoundId,
+                rounds = mapOf(otherRoundId to entry),
+                trustedKeys = listOf(makeTrustedKey()),
+                pirLayout = PIR_LAYOUT_FIXTURE
+            )
+        )
+    }
+
+    /**
+     * The v2 signature binds the full PIR layout: a config host swapping poly_len (or any
+     * tier) after signing invalidates the attestation.
+     */
+    @Test
+    fun authenticateRejectsWhenPolyLenChangedAfterSigning() {
+        val entry = makeEntry()
+        val swappedLayout = PIR_LAYOUT_FIXTURE.copy(polyLen = 2048)
+
+        assertEquals(
+            RoundAuthStatus.INVALID_SIGNATURES,
+            RoundAuthenticator.authenticate(
+                chainEaPK = EA_PK_BASE64.base64Bytes(),
+                roundIdHex = ROUND_ID,
+                rounds = mapOf(ROUND_ID to entry),
+                trustedKeys = listOf(makeTrustedKey()),
+                pirLayout = swappedLayout
+            )
+        )
+    }
+
+    /**
+     * A config that predates `pir_layout.poly_len` cannot carry v2 attestations: the
+     * payload is unconstructible, so nothing authenticates (fail closed).
+     */
+    @Test
+    fun authenticateRejectsWhenConfigLacksPolyLen() {
+        val entry = makeEntry()
+        val preBumpLayout = PIR_LAYOUT_FIXTURE.copy(polyLen = 0)
+
+        assertEquals(
+            RoundAuthStatus.INVALID_SIGNATURES,
+            RoundAuthenticator.authenticate(
+                chainEaPK = EA_PK_BASE64.base64Bytes(),
+                roundIdHex = ROUND_ID,
+                rounds = mapOf(ROUND_ID to entry),
+                trustedKeys = listOf(makeTrustedKey()),
+                pirLayout = preBumpLayout
+            )
+        )
+    }
+
+    /**
+     * Crate parity: a round id that does not strict-hex-decode to exactly 32 bytes can never
+     * authenticate.
+     */
+    @Test
+    fun authenticateRejectsRoundIdsThatDoNotDecodeTo32Bytes() {
+        val thirtyOneByteId = "ab".repeat(31)
+        val nonHexId = "zz".repeat(32)
+
+        listOf(thirtyOneByteId, nonHexId).forEach { badId ->
+            val entry = makeEntry(roundIdHex = badId)
+
+            assertEquals(
+                RoundAuthStatus.INVALID_SIGNATURES,
+                RoundAuthenticator.authenticate(
+                    chainEaPK = EA_PK_BASE64.base64Bytes(),
+                    roundIdHex = badId,
+                    rounds = mapOf(badId to entry),
+                    trustedKeys = listOf(makeTrustedKey()),
+                    pirLayout = PIR_LAYOUT_FIXTURE
+                ),
+                "round id $badId must never authenticate"
+            )
+        }
     }
 
     @Test
@@ -314,6 +510,8 @@ class RoundAuthenticatorTest {
         assertFalse(
             RoundAuthenticator.verifyEntrySignatures(
                 entry = makeEntry(signatures = emptyList()),
+                roundIdHex = ROUND_ID,
+                pirLayout = PIR_LAYOUT_FIXTURE,
                 trustedKeys = listOf(makeTrustedKey())
             )
         )
@@ -324,6 +522,8 @@ class RoundAuthenticatorTest {
         assertFalse(
             RoundAuthenticator.verifyEntrySignatures(
                 entry = makeEntry(keyId = "unknown-key"),
+                roundIdHex = ROUND_ID,
+                pirLayout = PIR_LAYOUT_FIXTURE,
                 trustedKeys = listOf(makeTrustedKey())
             )
         )
@@ -338,34 +538,82 @@ class RoundAuthenticatorTest {
                         VotingServiceConfig.Signature(
                             keyId = "valar-test",
                             alg = "ed25519",
-                            sig = ALTERNATE_VALID_SIGNATURE_BASE64
+                            sig = ALTERNATE_INVALID_SIGNATURE_BASE64
                         ),
                         VotingServiceConfig.Signature(
                             keyId = "valar-test",
                             alg = "ed25519",
-                            sig = ADMIN_SIGNATURE_BASE64
+                            sig = validSignatureBase64()
                         )
                     )
             )
 
-        assertTrue(RoundAuthenticator.verifyEntrySignatures(entry, listOf(makeTrustedKey())))
+        assertTrue(
+            RoundAuthenticator.verifyEntrySignatures(
+                entry = entry,
+                roundIdHex = ROUND_ID,
+                pirLayout = PIR_LAYOUT_FIXTURE,
+                trustedKeys = listOf(makeTrustedKey())
+            )
+        )
+    }
+
+    @Test
+    fun signingPayloadV2ReturnsNullForUndecodableRoundId() {
+        assertNull(
+            RoundAuthenticator.signingPayloadV2(
+                roundIdHex = "zz".repeat(32),
+                eaPk = EA_PK_BASE64.base64Bytes(),
+                pirLayout = PIR_LAYOUT_FIXTURE
+            )
+        )
+    }
+
+    @Test
+    fun signingPayloadV2ReturnsNullForMissingPolyLen() {
+        assertNull(
+            RoundAuthenticator.signingPayloadV2(
+                roundIdHex = ROUND_ID,
+                eaPk = EA_PK_BASE64.base64Bytes(),
+                pirLayout = PIR_LAYOUT_FIXTURE.copy(polyLen = 0)
+            )
+        )
     }
 }
 
+/** Layout mirroring the crate's `test_pir_layout()` (config/mod.rs tests): 19/12/7/4096. */
+private val PIR_LAYOUT_FIXTURE = VotingPirLayout(pirDepth = 19, tier0Layers = 12, tier1Layers = 7, polyLen = 4096)
+
 private const val ROUND_ID = "58d9319ac86933b81769a7c0972444fa39212ad3790646398de6ce6534de2225"
 private const val EA_PK_BASE64 = "N72oXeIF96QwWBtChaCwde3tjTt75ZfAs455V4usYwM="
-private const val ADMIN_PUBKEY_BASE64 = "rKDbmhkoW9ja7dMiCV+1uTao7wXWV6xN/57erkrOuiQ="
-private const val ADMIN_SIGNATURE_BASE64 =
-    "rnll+KsHIFt73GpyNoWrX57dlcX8hTi8GU5X/xpwg3vcE+jCARUXpD7LsK+OLw6R5q1kU/zccwNgzsmclt4WAg=="
-private const val ALTERNATE_VALID_SIGNATURE_BASE64 =
+private const val ALTERNATE_INVALID_SIGNATURE_BASE64 =
     "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ=="
 
+/**
+ * Fresh per-test-run admin key; entries are signed the way the crate's own tests sign
+ * theirs: ed25519 over the constructed v2 payload (round_auth.rs test recipe).
+ */
+private val adminKeyPair: Ed25519Sign.KeyPair by lazy { Ed25519Sign.KeyPair.newKeyPair() }
+private val adminSigner: Ed25519Sign by lazy { Ed25519Sign(adminKeyPair.privateKey) }
+
+private fun validSignatureBase64(): String {
+    val payload =
+        RoundAuthenticator.signingPayloadV2(
+            roundIdHex = ROUND_ID,
+            eaPk = EA_PK_BASE64.base64Bytes(),
+            pirLayout = PIR_LAYOUT_FIXTURE
+        ) ?: error("PIR_LAYOUT_FIXTURE must produce a signable v2 payload")
+    return adminSigner.sign(payload).base64String()
+}
+
 private fun makeServiceConfig(
-    rounds: Map<String, VotingServiceConfig.RoundEntry>
+    rounds: Map<String, VotingServiceConfig.RoundEntry>,
+    pirLayout: VotingPirLayout = PIR_LAYOUT_FIXTURE
 ): VotingServiceConfig =
     VotingServiceConfig(
         voteServers = listOf(VotingServiceConfig.ServiceEndpoint(url = "https://vote.example.com", label = "vote")),
         pirEndpoints = listOf(VotingServiceConfig.ServiceEndpoint(url = "https://pir.example.com", label = "pir")),
+        pirLayout = pirLayout,
         supportedVersions =
             VotingServiceConfig.SupportedVersions(
                 pir = listOf("v0"),
@@ -376,43 +624,86 @@ private fun makeServiceConfig(
         rounds = rounds
     )
 
+/**
+ * Builds a registry entry signed exactly the way the crate's tests sign theirs: ed25519 over
+ * [RoundAuthenticator.signingPayloadV2] for [roundIdHex], [eaPK], and [PIR_LAYOUT_FIXTURE].
+ * For undecodable round ids the canonical payload cannot exist; a stand-in message is signed
+ * instead so the entry still carries a well-formed 64-byte signature for the verifier to
+ * refuse.
+ */
 private fun makeEntry(
-    authVersion: Int = 1,
+    roundIdHex: String = ROUND_ID,
     eaPK: String = EA_PK_BASE64,
     keyId: String = "valar-test",
     signatureAlg: String = "ed25519",
-    signature: String = ADMIN_SIGNATURE_BASE64,
-    signatures: List<VotingServiceConfig.Signature> =
-        listOf(
-            VotingServiceConfig.Signature(
-                keyId = keyId,
-                alg = signatureAlg,
-                sig = signature
+    signature: String? = null,
+    signatures: List<VotingServiceConfig.Signature>? = null
+): VotingServiceConfig.RoundEntry {
+    val resolvedSignature =
+        signature
+            ?: run {
+                val payload =
+                    RoundAuthenticator.signingPayloadV2(
+                        roundIdHex = roundIdHex,
+                        eaPk = eaPK.base64Bytes(),
+                        pirLayout = PIR_LAYOUT_FIXTURE
+                    ) ?: "undecodable-round-id-stand-in".toByteArray(Charsets.UTF_8)
+                adminSigner.sign(payload).base64String()
+            }
+    return VotingServiceConfig.RoundEntry(
+        authVersion = RoundAuthenticator.AUTH_VERSION_V2,
+        eaPk = eaPK,
+        signatures =
+            signatures ?: listOf(
+                VotingServiceConfig.Signature(
+                    keyId = keyId,
+                    alg = signatureAlg,
+                    sig = resolvedSignature
+                )
             )
-        )
+    )
+}
+
+/** A legacy v1 entry: a valid signature over the raw 32-byte `ea_pk`, nothing else. */
+private fun makeLegacyV1Entry(
+    eaPK: String = EA_PK_BASE64,
+    keyId: String = "valar-test"
 ): VotingServiceConfig.RoundEntry =
     VotingServiceConfig.RoundEntry(
-        authVersion = authVersion,
+        authVersion = 1,
         eaPk = eaPK,
-        signatures = signatures
+        signatures =
+            listOf(
+                VotingServiceConfig.Signature(
+                    keyId = keyId,
+                    alg = "ed25519",
+                    sig = adminSigner.sign(eaPK.base64Bytes()).base64String()
+                )
+            )
     )
 
 private fun makeTrustedKey(): StaticVotingConfig.TrustedKey =
     StaticVotingConfig.TrustedKey(
         keyId = "valar-test",
         alg = "ed25519",
-        pubkey = ADMIN_PUBKEY_BASE64
+        pubkey = adminKeyPair.publicKey.base64String()
     )
+
+private val ADMIN_PUBKEY_BASE64: String
+    get() = adminKeyPair.publicKey.base64String()
 
 private fun String.base64Bytes(): ByteArray =
     java.util.Base64
         .getDecoder()
         .decode(this)
 
+private fun ByteArray.base64String(): String =
+    java.util.Base64
+        .getEncoder()
+        .encodeToString(this)
+
 private fun String.flipFirstBase64Byte(): String {
     val bytes = base64Bytes()
     bytes[0] = (bytes[0].toInt() xor 0xff).toByte()
-    return java.util.Base64
-        .getEncoder()
-        .encodeToString(bytes)
+    return bytes.base64String()
 }

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/SharePostBodyWireContractTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/SharePostBodyWireContractTest.kt
@@ -13,7 +13,8 @@ import kotlin.test.assertFalse
  * Pins [SharePayload.toApiBody]'s output against `zcash_voting::wire::VoteShareWire`
  * (MOB-1678, zcash_voting 3.0): the crate's wire struct dropped `all_enc_shares` in
  * 2.0-rc.4, so the POST body must never carry it, and every remaining field must match
- * the wire struct's names and base64 byte encoding exactly.
+ * the wire struct's names and base64 byte encoding exactly. `vote_round_id` is the
+ * crate-provided [SharePayload.voteRoundId] verbatim — nothing is injected app-side.
  *
  * Parses with kotlinx.serialization rather than `org.json` — the latter is an
  * Android-framework stub that throws under this module's plain-JVM `unitTests
@@ -23,7 +24,7 @@ import kotlin.test.assertFalse
 class SharePostBodyWireContractTest {
     @Test
     fun toApiBodyOmitsAllEncSharesAndMatchesTheWireFieldSet() {
-        val body = Json.parseToJsonElement(makeSharePayload().toApiBody(ROUND_ID_HEX)).jsonObject
+        val body = Json.parseToJsonElement(makeSharePayload().toApiBody()).jsonObject
 
         assertFalse(body.containsKey("all_enc_shares"))
         assertEquals(
@@ -44,19 +45,31 @@ class SharePostBodyWireContractTest {
     }
 
     @Test
-    fun toApiBodyCarriesTheRoundIdAsLowercaseHexVerbatim() {
-        val body = Json.parseToJsonElement(makeSharePayload().toApiBody(ROUND_ID_HEX)).jsonObject
+    fun toApiBodyCarriesTheCrateProvidedRoundIdVerbatim() {
+        val body = Json.parseToJsonElement(makeSharePayload(voteRoundId = ROUND_ID_HEX).toApiBody()).jsonObject
 
         assertEquals(ROUND_ID_HEX, body.getValue("vote_round_id").jsonPrimitive.content)
     }
 
-    private fun makeSharePayload(): SharePayload =
+    @Test
+    fun toApiBodyDoesNotInjectADifferentRoundIdThanThePayloadCarries() {
+        val otherRoundId = "02".repeat(32)
+        val payload = makeSharePayload(voteRoundId = otherRoundId)
+
+        val body = Json.parseToJsonElement(payload.toApiBody()).jsonObject
+
+        assertEquals(otherRoundId, body.getValue("vote_round_id").jsonPrimitive.content)
+        assertFalse(body.getValue("vote_round_id").jsonPrimitive.content == ROUND_ID_HEX)
+    }
+
+    private fun makeSharePayload(voteRoundId: String = ROUND_ID_HEX): SharePayload =
         SharePayload(
             sharesHash = ByteArray(32) { 1 },
             proposalId = 3,
             voteDecision = 1,
             encShare = EncryptedShare(c1 = ByteArray(32) { 2 }, c2 = ByteArray(32) { 3 }, shareIndex = 0),
             treePosition = 42L,
+            voteRoundId = voteRoundId,
             allEncShares =
                 listOf(
                     EncryptedShare(c1 = ByteArray(32) { 4 }, c2 = ByteArray(32) { 5 }, shareIndex = 0),

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/SharePostBodyWireContractTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/SharePostBodyWireContractTest.kt
@@ -1,0 +1,73 @@
+package co.electriccoin.zcash.ui.common.provider
+
+import co.electriccoin.zcash.ui.common.model.voting.EncryptedShare
+import co.electriccoin.zcash.ui.common.model.voting.SharePayload
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * Pins [SharePayload.toApiBody]'s output against `zcash_voting::wire::VoteShareWire`
+ * (MOB-1678, zcash_voting 3.0): the crate's wire struct dropped `all_enc_shares` in
+ * 2.0-rc.4, so the POST body must never carry it, and every remaining field must match
+ * the wire struct's names and base64 byte encoding exactly.
+ *
+ * Parses with kotlinx.serialization rather than `org.json` — the latter is an
+ * Android-framework stub that throws under this module's plain-JVM `unitTests
+ * .isReturnDefaultValues = true` setup, unlike the production code's `org.json` usage,
+ * which never round-trips its own output back through parsing.
+ */
+class SharePostBodyWireContractTest {
+    @Test
+    fun toApiBodyOmitsAllEncSharesAndMatchesTheWireFieldSet() {
+        val body = Json.parseToJsonElement(makeSharePayload().toApiBody(ROUND_ID_HEX)).jsonObject
+
+        assertFalse(body.containsKey("all_enc_shares"))
+        assertEquals(
+            setOf(
+                "shares_hash",
+                "proposal_id",
+                "vote_decision",
+                "enc_share",
+                "share_index",
+                "tree_position",
+                "vote_round_id",
+                "share_comms",
+                "primary_blind",
+                "submit_at"
+            ),
+            body.keys
+        )
+    }
+
+    @Test
+    fun toApiBodyCarriesTheRoundIdAsLowercaseHexVerbatim() {
+        val body = Json.parseToJsonElement(makeSharePayload().toApiBody(ROUND_ID_HEX)).jsonObject
+
+        assertEquals(ROUND_ID_HEX, body.getValue("vote_round_id").jsonPrimitive.content)
+    }
+
+    private fun makeSharePayload(): SharePayload =
+        SharePayload(
+            sharesHash = ByteArray(32) { 1 },
+            proposalId = 3,
+            voteDecision = 1,
+            encShare = EncryptedShare(c1 = ByteArray(32) { 2 }, c2 = ByteArray(32) { 3 }, shareIndex = 0),
+            treePosition = 42L,
+            allEncShares =
+                listOf(
+                    EncryptedShare(c1 = ByteArray(32) { 4 }, c2 = ByteArray(32) { 5 }, shareIndex = 0),
+                    EncryptedShare(c1 = ByteArray(32) { 6 }, c2 = ByteArray(32) { 7 }, shareIndex = 1)
+                ),
+            shareComms = listOf(ByteArray(32) { 8 }),
+            primaryBlind = ByteArray(32) { 9 },
+            submitAt = 99L
+        )
+
+    private companion object {
+        val ROUND_ID_HEX = "01".repeat(32)
+    }
+}

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepositoryTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepositoryTest.kt
@@ -23,6 +23,7 @@ import co.electriccoin.zcash.ui.common.model.voting.Proposal
 import co.electriccoin.zcash.ui.common.model.voting.SessionStatus
 import co.electriccoin.zcash.ui.common.model.voting.VoteOption
 import co.electriccoin.zcash.ui.common.model.voting.VotingGovernancePczt
+import co.electriccoin.zcash.ui.common.model.voting.VotingPirLayout
 import co.electriccoin.zcash.ui.common.model.voting.VotingServiceConfig
 import co.electriccoin.zcash.ui.common.model.voting.VotingSession
 import co.electriccoin.zcash.ui.common.provider.KeystoneSDKProvider
@@ -197,7 +198,8 @@ class VotingKeystoneRepositoryTest {
                 )
 
             val votingApiProvider = mockk<VotingApiProvider>(relaxed = true)
-            coEvery { votingApiProvider.fetchServiceConfig() } returns VotingServiceConfig.EMPTY
+            coEvery { votingApiProvider.fetchServiceConfig() } returns
+                VotingServiceConfig.EMPTY.copy(pirLayout = TEST_PIR_LAYOUT)
             coEvery { votingApiProvider.fetchAllRounds() } returns
                 RoundsListResult(
                     rounds = emptyList(),
@@ -728,6 +730,7 @@ class VotingKeystoneRepositoryTest {
         val EXPECTED_RK = byteArrayOf(0x30)
         val SIGNED_PCZT_BYTES = byteArrayOf(0x40)
         const val RESET_REBUILD_ROUND_ID_HEX = "aa000000000000000000000000000000000000000000000000000000000000bb"
+        val TEST_PIR_LAYOUT = VotingPirLayout(pirDepth = 1, tier0Layers = 1, tier1Layers = 1, polyLen = 4096)
     }
 }
 

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/RefreshActiveVotingSessionUseCaseTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/RefreshActiveVotingSessionUseCaseTest.kt
@@ -83,10 +83,8 @@ class RefreshActiveVotingSessionUseCaseTest {
         override suspend fun fetchTallyResults(roundIdHex: String): TallyResults =
             error("unused")
 
-        override suspend fun delegateShares(
-            shares: List<SharePayload>,
-            roundIdHex: String
-        ): List<DelegatedShareInfo> = error("unused")
+        override suspend fun delegateShares(shares: List<SharePayload>): List<DelegatedShareInfo> =
+            error("unused")
 
         override suspend fun fetchShareStatus(
             helperBaseUrl: String,
@@ -96,7 +94,6 @@ class RefreshActiveVotingSessionUseCaseTest {
 
         override suspend fun resubmitShare(
             payload: SharePayload,
-            roundIdHex: String,
             candidateUrls: List<String>,
             excludeUrls: List<String>
         ): List<String> = error("unused")

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/RefreshVotingRoundsUseCaseTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/RefreshVotingRoundsUseCaseTest.kt
@@ -82,10 +82,8 @@ class RefreshVotingRoundsUseCaseTest {
         override suspend fun fetchTallyResults(roundIdHex: String): TallyResults =
             error("unused")
 
-        override suspend fun delegateShares(
-            shares: List<SharePayload>,
-            roundIdHex: String
-        ): List<DelegatedShareInfo> = error("unused")
+        override suspend fun delegateShares(shares: List<SharePayload>): List<DelegatedShareInfo> =
+            error("unused")
 
         override suspend fun fetchShareStatus(
             helperBaseUrl: String,
@@ -95,7 +93,6 @@ class RefreshVotingRoundsUseCaseTest {
 
         override suspend fun resubmitShare(
             payload: SharePayload,
-            roundIdHex: String,
             candidateUrls: List<String>,
             excludeUrls: List<String>
         ): List<String> = error("unused")

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/screen/voting/votingerror/VotingErrorMapperTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/screen/voting/votingerror/VotingErrorMapperTest.kt
@@ -59,11 +59,18 @@ class VotingErrorMapperTest {
                 "vote round not found" to R.string.coinVote_store_userError_roundNotFound,
                 "No active voting round" to R.string.coinVote_store_userError_roundNotActive,
                 "PIR proof root mismatch" to R.string.coinVote_store_userError_pirSnapshotMismatch,
+                "PIR poly_len mismatch: expected 4096, server advertised 2048" to
+                    R.string.coinVote_store_userError_pirSnapshotMismatch,
                 "PIR proof verification failed" to R.string.coinVote_store_userError_pirInvalidProofData,
                 "PIR server connect failed" to R.string.coinVote_store_userError_pirUnavailable,
+                "unsupported PIR layout poly_len 1024" to R.string.coinVote_store_userError_pirEndpointsMissing,
                 "No PIR endpoints are configured" to R.string.coinVote_store_userError_pirEndpointsMissing,
                 "Commitment tree did not grow" to R.string.coinVote_store_userError_commitmentTreeNotGrown,
+                "vote-commitment position is absent from the synced vote tree" to
+                    R.string.coinVote_store_userError_commitmentTreeNotGrown,
                 "invalid commitment tree anchor height" to R.string.coinVote_store_userError_invalidAnchorHeight,
+                "confirmed VAN entry does not match its synced vote-tree leaf" to
+                    R.string.coinVote_store_userError_invalidAnchorHeight,
                 "invalid zero-knowledge proof" to R.string.coinVote_store_userError_invalidProof,
                 "delegation bundle build failed" to R.string.coinVote_store_userError_proofGenerationFailed,
                 "NoTreeState" to R.string.coinVote_store_userError_noTreeState,

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=1eb8874902fe55cb69e2c673fbe3305d4214d17c
+SDK_COMMIT_PIN=26dab43dbf6d8f2c8cbb5739686c71685f9e7981
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/gradle.properties
+++ b/gradle.properties
@@ -123,7 +123,7 @@ SDK_INCLUDED_BUILD_PATH=
 # you, defeating the point of a pin — and must be reachable from something more durable than
 # the SDK's own PR branch (which stops being fetchable once that branch is deleted): repoint
 # to the merged sha on origin/main once the companion SDK PR lands.
-SDK_COMMIT_PIN=e177a8811837baf0e9d276a79afd75009e53b4c9
+SDK_COMMIT_PIN=4ffe1ed8697ed0ad6e8a5287d5b0e7c262cf283e
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=860fb8237d0a9ecad2684164e486b47765d95515
+SDK_COMMIT_PIN=1eb8874902fe55cb69e2c673fbe3305d4214d17c
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/tools/detekt-baseline.xml
+++ b/tools/detekt-baseline.xml
@@ -71,7 +71,7 @@
     <ID>ThrowsCount:ChainDto.kt$private fun validateChainProposals(proposals: List&lt;Proposal&gt;)</ID>
     <ID>ThrowsCount:StaticVotingConfig.kt$PinnedConfigSource.Companion$fun parse(raw: String): PinnedConfigSource</ID>
     <ID>ThrowsCount:StaticVotingConfig.kt$StaticVotingConfig$fun validate()</ID>
-    <ID>ThrowsCount:SubmitVotesUseCase.kt$SubmitVotesUseCase$private suspend fun delegateSharesWithRetry( payloads: List&lt;SharePayload&gt;, roundId: String ): List&lt;DelegatedShareInfo&gt;</ID>
+    <ID>ThrowsCount:SubmitVotesUseCase.kt$SubmitVotesUseCase$private suspend fun delegateSharesWithRetry(payloads: List&lt;SharePayload&gt;): List&lt;DelegatedShareInfo&gt;</ID>
     <ID>ThrowsCount:VotingServerFailoverException.kt$internal suspend fun &lt;T&gt; withVoteServerFailover( path: String, serverUrls: List&lt;String&gt;, shouldTryNext: (Throwable) -&gt; Boolean = ::shouldTryNextVoteServer, operation: suspend (String) -&gt; T ): T</ID>
     <ID>ThrowsCount:VotingServiceConfig.kt$VotingServiceConfig$fun validate()</ID>
     <ID>TooGenericExceptionCaught:DebugStartMigrationE2EUseCase.kt$DebugStartMigrationE2EUseCase$e: RuntimeException</ID>

--- a/tools/detekt-baseline.xml
+++ b/tools/detekt-baseline.xml
@@ -55,8 +55,9 @@
     <ID>ReturnCount:PrepareVotingRoundUseCase.kt$PrepareVotingRoundUseCase$private fun VotingRecoverySnapshot.preparedBundleSetup(): VotingBundleSetupResult?</ID>
     <ID>ReturnCount:PrepareVotingRoundUseCase.kt$PrepareVotingRoundUseCase$private suspend fun getOrCreateHotkeySeed( accountUuid: String, roundId: String, recoverySnapshot: VotingRecoverySnapshot?, existingRoundStatePhase: RoundPhase? ): ByteArray</ID>
     <ID>ReturnCount:PrepareVotingRoundUseCase.kt$PrepareVotingRoundUseCase$private suspend fun isRoundRecoverable( recoverySnapshot: VotingRecoverySnapshot?, dbHandle: Long, roundId: String ): Boolean</ID>
-    <ID>ReturnCount:RoundAuthenticator.kt$RoundAuthenticator$fun authenticate( chainEaPK: ByteArray, roundIdHex: String, rounds: Map&lt;String, VotingServiceConfig.RoundEntry&gt;, trustedKeys: List&lt;StaticVotingConfig.TrustedKey&gt; ): RoundAuthStatus</ID>
-    <ID>ReturnCount:RoundAuthenticator.kt$RoundAuthenticator$fun verifyEntrySignatures( entry: VotingServiceConfig.RoundEntry, trustedKeys: List&lt;StaticVotingConfig.TrustedKey&gt; ): Boolean</ID>
+    <ID>ReturnCount:RoundAuthenticator.kt$RoundAuthenticator$fun authenticate( chainEaPK: ByteArray, roundIdHex: String, rounds: Map&lt;String, VotingServiceConfig.RoundEntry&gt;, trustedKeys: List&lt;StaticVotingConfig.TrustedKey&gt;, pirLayout: VotingPirLayout ): RoundAuthStatus</ID>
+    <ID>ReturnCount:RoundAuthenticator.kt$RoundAuthenticator$fun signingPayloadV2( roundIdHex: String, eaPk: ByteArray, pirLayout: VotingPirLayout ): ByteArray?</ID>
+    <ID>ReturnCount:RoundAuthenticator.kt$RoundAuthenticator$fun verifyEntrySignatures( entry: VotingServiceConfig.RoundEntry, roundIdHex: String, pirLayout: VotingPirLayout, trustedKeys: List&lt;StaticVotingConfig.TrustedKey&gt; ): Boolean</ID>
     <ID>ReturnCount:SignKeystoneVotingVM.kt$SignKeystoneVotingVM$private fun VotingRecoverySnapshot.toSkipBottomSheetState(): SkipKeystoneBundlesBottomSheetState?</ID>
     <ID>ReturnCount:VoteChainConfigVM.kt$VoteChainConfigVM$private fun onSaveEditor()</ID>
     <ID>ReturnCount:VoteOptionDisplay.kt$fun Proposal.tallyDisplayInfo( decision: Int, fallbackLabel: String, ): VoteOptionDisplayInfo</ID>


### PR DESCRIPTION
## Summary
- Migrates coinholder polling to the v1.3.0 vote chain (prod flipped 2026-08-14, no backward-serving). Android's 2.0-generation stack currently 502s on every tier-1 PIR query (hardcoded poly length 2048 vs the new 4096 dataset) and drops all rounds as `missingRound` (v1-only round authenticator vs v2-signed rounds).
- `VotingPirLayout` gains `polyLen` (wire key `pir_layout.poly_len` from the signed dynamic config; decode-tolerant for cached pre-3.0 configs), threaded through every delegation entry point into the SDK's new `pirPolyLen` parameters with a fail-closed `requireKnownPolyLen()` guard reusing existing config-error copy.
- `RoundAuthenticator` rewritten to auth v2 only: the Ed25519 signature now covers `"zcash-shielded-vote:round-auth:v2" ‖ round_id ‖ ea_pk ‖ pir_depth ‖ tier0_layers ‖ tier1_layers ‖ poly_len` (u32 LE), binding each round to the exact PIR geometry it is queried with. v1 entries are rejected outright (crate parity, no dual-accept); the separate chain `ea_pk` binding check is kept. Tests port the crate's golden vectors plus a full negative suite.
- Helper share submissions now forward the crate-authoritative `vote_round_id` (new in zcash_voting 3.0.0-rc.3, exposed by the companion SDK PR) instead of injecting it app-side, and drop the stale `all_enc_shares` field the wire struct removed in 2.0-rc.4. A wire-contract test pins that nothing is injected app-side.
- Maps the four new 3.0 error fingerprints ("PIR poly_len mismatch", "unsupported PIR layout", vote-tree VAN mismatch/absence) onto existing error copy — no new strings.
- Repoints `SDK_COMMIT_PIN` to the companion SDK branch head (to be repointed to the merged main sha once the SDK PR lands, per the property's contract).

Android analog of the iOS migration (zodl-inc/zodl-ios#1992); reference integration chainapsis/vizor-wallet#506+#507.

Companion SDK PR: zcash/zcash-android-wallet-sdk#2178

## Test plan
- [x] `feature-voting` unit tests 123/123 (incl. new `RoundAuthenticatorTest` golden vectors — independently cross-checked against the crate's own test vector — and `SharePostBodyWireContractTest`)
- [x] ktlint + detektAll clean
- [x] Full `:app:assembleZcashtestnetInternalDebug` against the companion SDK worktree
- [ ] Live stage e2e on-device: v2 rounds authenticate (poll list repopulates), tier-1 PIR queries 200 on the 4096 dataset, full delegation → vote → shares round accepted (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)