### PR TITLE
MOB-1382: Fix reject button no-op on Keystone shield signing screen

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/CancelProposalFlowUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/CancelProposalFlowUseCase.kt
@@ -5,6 +5,7 @@ import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.datasource.ExactInputSwapTransactionProposal
 import co.electriccoin.zcash.ui.common.datasource.ExactOutputSwapTransactionProposal
 import co.electriccoin.zcash.ui.common.datasource.MigrationSweepTransactionProposal
+import co.electriccoin.zcash.ui.common.datasource.ShieldTransactionProposal
 import co.electriccoin.zcash.ui.common.migration.MigrationNavigator
 import co.electriccoin.zcash.ui.common.model.KeystoneAccount
 import co.electriccoin.zcash.ui.common.model.ZashiAccount
@@ -51,6 +52,17 @@ class CancelProposalFlowUseCase(
                 // the `else` branch's `backTo(Send::class)` would silently no-op (no matching
                 // destination to pop to), leaving the user stuck on the Sign/reject sheet.
                 migrationNavigator.backToMigrationReview()
+            }
+
+            is ShieldTransactionProposal -> {
+                // Reached via ShieldFundsUseCase's Keystone branch, which (unlike the Zashi
+                // branch) never pops/replaces the screen the shield prompt was shown on before
+                // pushing the Sign screen. So that origin screen (ShieldFundsInfo dialog,
+                // Balances, or Home) is still directly beneath us on the back stack — falling
+                // through to the `else` branch's `backTo(Send::class)` would silently no-op
+                // (Send was never pushed for this flow), leaving the user stuck on the
+                // Sign/reject sheet. A plain back() pops the Sign screen and reveals it again.
+                navigationRouter.back()
             }
 
             else -> {

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/CancelProposalFlowUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/CancelProposalFlowUseCaseTest.kt
@@ -8,6 +8,7 @@ import co.electriccoin.zcash.ui.NavigationCommand
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.datasource.MigrationSweepTransactionProposal
+import co.electriccoin.zcash.ui.common.datasource.ShieldTransactionProposal
 import co.electriccoin.zcash.ui.common.migration.MigrationNavigator
 import co.electriccoin.zcash.ui.common.model.KeystoneAccount
 import co.electriccoin.zcash.ui.common.repository.KeystoneProposalRepository
@@ -57,6 +58,36 @@ class CancelProposalFlowUseCaseTest {
             assertEquals(1, migrationNavigator.backToReviewCalls)
         }
 
+    @Test
+    fun shieldProposalNavigatesBackInsteadOfSend() =
+        runTest {
+            val proposal = ShieldTransactionProposal(mockk<Proposal>())
+            val keystoneProposalRepository =
+                mockk<KeystoneProposalRepository>(relaxed = true) {
+                    coEvery { getTransactionProposal() } returns proposal
+                }
+            val router = FakeNavigationRouter()
+            val useCase =
+                CancelProposalFlowUseCase(
+                    zashiProposalRepository = mockk<ZashiProposalRepository>(relaxed = true),
+                    keystoneProposalRepository = keystoneProposalRepository,
+                    navigationRouter = router,
+                    observeClearSend = mockk<ObserveClearSendUseCase>(relaxed = true),
+                    accountDataSource =
+                        mockk<AccountDataSource> {
+                            coEvery { getSelectedAccount() } returns mockk<KeystoneAccount>(relaxed = true)
+                        },
+                    swapRepository = mockk<SwapRepository>(relaxed = true),
+                    migrationNavigator = FakeMigrationNavigator(),
+                )
+
+            useCase()
+
+            coVerify(exactly = 1) { keystoneProposalRepository.clear() }
+            assertEquals(0, router.backToCalls.size)
+            assertEquals(1, router.backCalls)
+        }
+
     private class FakeMigrationNavigator : MigrationNavigator {
         var backToReviewCalls = 0
 
@@ -71,6 +102,7 @@ class CancelProposalFlowUseCaseTest {
 
     private class FakeNavigationRouter : NavigationRouter {
         val backToCalls = mutableListOf<KClass<*>>()
+        var backCalls = 0
 
         override fun forward(vararg routes: Any) = Unit
 
@@ -78,7 +110,9 @@ class CancelProposalFlowUseCaseTest {
 
         override fun replaceAll(vararg routes: Any) = Unit
 
-        override fun back() = Unit
+        override fun back() {
+            backCalls++
+        }
 
         override fun backTo(route: KClass<*>) {
             backToCalls += route


### PR DESCRIPTION
## Summary
- `CancelProposalFlowUseCase` had no branch for `ShieldTransactionProposal`, so rejecting a Keystone shield-signing request fell into the generic `else` case (`navigationRouter.backTo(Send::class)`), which silently no-ops because `Send` is never on the back stack for the auto-shield flow — the user gets stuck on the signing screen after tapping "Reject signature".
- Added a `ShieldTransactionProposal` branch that calls `navigationRouter.back()`, popping the signing screen back to whichever origin screen (shield-prompt dialog, Balances, or Home) is actually beneath it — same pattern already established for the swap/migration branches in this use case (see `a0b729da4`, `61aa84a5c`).

## Test plan
- [x] Added `shieldProposalNavigatesBackInsteadOfSend` to `CancelProposalFlowUseCaseTest`, confirmed it fails against pre-fix code and passes after
- [x] `:ui-lib:testZcashmainnetInternalDebugUnitTest` — 342 tests, 0 failures

Fixes MOB-1382: https://linear.app/zodl/issue/MOB-1382/keystone-device-cannot-reject-zodl-shield-transaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)