### PR TITLE
Keystone Android E2E: pairing flow, testTags, and CI wiring (Phase K1)

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -113,7 +113,7 @@ jobs:
         if: steps.keystone-cache.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake clang xvfb
+          sudo apt-get install -y cmake clang xvfb libsdl2-dev
           cargo install bindgen-cli cbindgen
 
       - name: Build (or reuse cached) simulator binary

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -66,6 +66,70 @@ jobs:
           path: app/build/outputs/apk/zcashmainnetInternal/debug/*.apk
           retention-days: 1
 
+  # Separate from `build` on purpose: this is a native CMake+Rust cross of
+  # KeystoneHQ/keystone3-firmware (the Cypherpunk simulator), unrelated to
+  # the Gradle/APK build above. The Android debug APK already contains
+  # everything the Keystone flow needs (E2eKeystoneQrFrameSource.kt is
+  # ordinary DEBUG-gated source already covered by the `build` job's cache
+  # key), so it is reused as-is via `needs: build` in e2e-keystone below --
+  # only the simulator binary needs its own build.
+  #
+  # scripts/keystone/build-simulator.sh already has its own idempotent
+  # cache (keyed on the pinned firmware release/automation SHAs + patch
+  # hash, see keystone_build_cache_key() in env.sh) -- actions/cache below
+  # just persists that same directory across runs so a cache hit skips the
+  # native build entirely instead of only skipping within a single job.
+  build-keystone-simulator:
+    runs-on: ubuntu-latest
+    # Generous headroom for a cold cache: this is a real CMake+Rust build,
+    # not just an APK assemble. Should only actually run this long when the
+    # pinned firmware SHAs or patch change (rare and deliberate -- see
+    # env.sh's comment on KEYSTONE_FIRMWARE_AUTOMATION_SHA).
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout smoke tests
+        uses: actions/checkout@v4
+        with:
+          repository: zodl-inc/zodl-qa
+          path: zodl-qa
+          token: ${{ secrets.ZODL_QA }}
+
+      - name: Restore cached simulator binary
+        id: keystone-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/zodl-keystone-simulator
+          key: ${{ runner.os }}-keystone-sim-${{ hashFiles('zodl-qa/scripts/keystone/env.sh', 'zodl-qa/scripts/keystone/patches/**') }}
+
+      # Only needed to actually build (cache miss). cmake and clang are
+      # already on the ubuntu-latest image; Rust itself is too, but not
+      # necessarily the exact nightly keystone3-firmware pins via its own
+      # rust-toolchain file -- rustup auto-installs that on first cargo
+      # invocation inside the cloned checkout, so no explicit toolchain
+      # step is needed here. bindgen-cli/cbindgen are not preinstalled.
+      - name: Install build tools (cache miss only)
+        if: steps.keystone-cache.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake clang xvfb
+          cargo install bindgen-cli cbindgen
+
+      - name: Build (or reuse cached) simulator binary
+        run: |
+          chmod +x zodl-qa/scripts/keystone/build-simulator.sh
+          zodl-qa/scripts/keystone/build-simulator.sh \
+            "${{ runner.temp }}/keystone3-firmware" \
+            "${{ runner.temp }}/keystone-simulator/simulator"
+
+      - name: Upload simulator binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: keystone-simulator-binary
+          path: ${{ runner.temp }}/keystone-simulator/simulator
+          retention-days: 1
+
   e2e-android:
     needs: build
     runs-on: ubuntu-latest
@@ -199,3 +263,85 @@ jobs:
           path: |
             ~/.maestro/tests/
             ${{ runner.temp }}/zodl-enroll-fail/
+
+  # Phase K1 of KEYSTONE_E2E_CI_PLAN.md ("Android pairing canary"): drives
+  # a real Keystone Cypherpunk simulator through pairing with the app via
+  # scripts/run-keystone-android.sh, which orchestrates the non-Maestro
+  # half (simulator provisioning/navigation, real QR frame capture) and
+  # then hands off to maestro/keystone/onboarding/connect-keystone-wallet.yaml
+  # for the app-side half. Manual dispatch only for now, deliberately not
+  # on every pull_request -- see KEYSTONE_E2E_CI_PLAN.md's Phase K5, which
+  # calls for proving out runtime/flake rate on a schedule before making
+  # this PR-required alongside e2e-android.
+  e2e-keystone:
+    needs: [build, build-keystone-simulator]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    name: Keystone
+    steps:
+      - name: Checkout smoke tests
+        uses: actions/checkout@v4
+        with:
+          repository: zodl-inc/zodl-qa
+          path: zodl-qa
+          token: ${{ secrets.ZODL_QA }}
+
+      - name: Download APK
+        uses: actions/download-artifact@v4
+        with:
+          name: zodl-android-debug-apk
+          path: apk
+
+      - name: Download simulator binary
+        uses: actions/download-artifact@v4
+        with:
+          name: keystone-simulator-binary
+          path: keystone-simulator
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Install Maestro
+        run: |
+          curl -Ls "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+
+      # xvfb: the simulator is an SDL app and needs a display to open a
+      # window on even though nothing here screen-captures it -- readiness
+      # and control are entirely over its TCP command channel (see
+      # simulator.sh). netcat: that command channel is spoken over `nc`.
+      - name: Install runtime deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb netcat-openbsd
+
+      - name: Run smoke tests
+        uses: reactivecircus/android-emulator-runner@v2
+        env:
+          ZODL_KEYSTONE_TEST_ENTROPY_HEX: ${{ secrets.ZODL_KEYSTONE_TEST_ENTROPY_HEX }}
+          ZODL_KEYSTONE_TEST_PIN: ${{ secrets.ZODL_KEYSTONE_TEST_PIN }}
+          KEYSTONE_SIMULATOR_BINARY: ${{ github.workspace }}/keystone-simulator/simulator
+        with:
+          api-level: 35
+          arch: x86_64
+          profile: pixel_6
+          script: |
+            adb install apk/*.apk
+            chmod +x keystone-simulator/simulator
+            chmod +x zodl-qa/scripts/run-keystone-android.sh
+            cd zodl-qa
+            xvfb-run -a ./scripts/run-keystone-android.sh
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-keystone-results
+          path: |
+            ~/.maestro/tests/
+            /tmp/zodl-keystone-sim.*/

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -113,7 +113,7 @@ jobs:
         if: steps.keystone-cache.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake clang xvfb libsdl2-dev
+          sudo apt-get install -y cmake clang xvfb libsdl2-dev libxcb1-dev
           cargo install bindgen-cli cbindgen
 
       - name: Build (or reuse cached) simulator binary

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -333,8 +333,7 @@ jobs:
             adb install apk/*.apk
             chmod +x keystone-simulator/simulator
             chmod +x zodl-qa/scripts/run-keystone-android.sh
-            cd zodl-qa
-            xvfb-run -a ./scripts/run-keystone-android.sh
+            xvfb-run -a zodl-qa/scripts/run-keystone-android.sh
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -313,10 +313,19 @@ jobs:
       # window on even though nothing here screen-captures it -- readiness
       # and control are entirely over its TCP command channel (see
       # simulator.sh). netcat: that command channel is spoken over `nc`.
+      # libsdl2-2.0-0: the simulator binary is built (and gets SDL2's
+      # runtime lib for free) in the separate build-keystone-simulator
+      # job -- this job only downloads the compiled binary, on a
+      # different fresh VM that never installed SDL2 at all, so it fails
+      # instantly with "error while loading shared libraries:
+      # libSDL2-2.0.so.0" without the runtime package here too. libxcb1
+      # added preemptively for the same reason (build needed libxcb1-dev
+      # to link against) -- not yet confirmed needed at runtime, but
+      # cheap to install and this exact class of gap already bit us once.
       - name: Install runtime deps
         run: |
           sudo apt-get update
-          sudo apt-get install -y xvfb netcat-openbsd
+          sudo apt-get install -y xvfb netcat-openbsd libsdl2-2.0-0 libxcb1
 
       - name: Run smoke tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -269,10 +269,8 @@ jobs:
   # scripts/run-keystone-android.sh, which orchestrates the non-Maestro
   # half (simulator provisioning/navigation, real QR frame capture) and
   # then hands off to maestro/keystone/onboarding/connect-keystone-wallet.yaml
-  # for the app-side half. Manual dispatch only for now, deliberately not
-  # on every pull_request -- see KEYSTONE_E2E_CI_PLAN.md's Phase K5, which
-  # calls for proving out runtime/flake rate on a schedule before making
-  # this PR-required alongside e2e-android.
+  # for the app-side half. Runs on every pull_request alongside e2e-android
+  # (shares this workflow's top-level `on:` trigger -- no per-job gate).
   e2e-keystone:
     needs: [build, build-keystone-simulator]
     runs-on: ubuntu-latest
@@ -323,8 +321,9 @@ jobs:
       - name: Run smoke tests
         uses: reactivecircus/android-emulator-runner@v2
         env:
-          ZODL_KEYSTONE_TEST_ENTROPY_HEX: ${{ secrets.ZODL_KEYSTONE_TEST_ENTROPY_HEX }}
-          ZODL_KEYSTONE_TEST_PIN: ${{ secrets.ZODL_KEYSTONE_TEST_PIN }}
+          ZODL_KEYSTONE_TEST_ENTROPY_HEX_ANDROID: ${{ secrets.ZODL_KEYSTONE_TEST_ENTROPY_HEX_ANDROID }}
+          ZODL_KEYSTONE_TEST_PIN_ANDROID: ${{ secrets.ZODL_KEYSTONE_TEST_PIN_ANDROID }}
+          ZODL_KEYSTONE_TEST_BIRTHDAY_ANDROID: ${{ secrets.ZODL_KEYSTONE_TEST_BIRTHDAY_ANDROID }}
           KEYSTONE_SIMULATOR_BINARY: ${{ github.workspace }}/keystone-simulator/simulator
         with:
           api-level: 35

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/common/BirthdayPickerState.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/common/BirthdayPickerState.kt
@@ -18,4 +18,5 @@ data class BirthdayPickerState(
     val secondaryButton: ButtonState?,
     val dialogButton: IconButtonState?,
     val onBack: () -> Unit,
+    val secondaryButtonTestTag: String? = null,
 )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/common/BirthdayPickerView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/common/BirthdayPickerView.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -92,7 +93,10 @@ private fun Content(
         state.secondaryButton?.let { secondary ->
             ZashiButton(
                 state = secondary,
-                modifier = Modifier.fillMaxWidth(),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .then(state.secondaryButtonTestTag?.let { Modifier.testTag(it) } ?: Modifier),
                 defaultPrimaryColors = ZashiButtonDefaults.secondaryColors(),
             )
             Spacer(Modifier.height(12.dp))

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/common/KeepOpenState.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/common/KeepOpenState.kt
@@ -17,4 +17,5 @@ data class KeepOpenState(
     val description: StringResource,
     val bullet1: StringResource = stringRes(R.string.keep_open_bullet_1),
     val bullet2: StringResource = stringRes(R.string.keep_open_bullet_2),
+    val buttonTestTag: String? = null,
 )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/common/KeepOpenView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/common/KeepOpenView.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -123,7 +124,10 @@ private fun Content(
 
         ZashiButton(
             state = state.button,
-            modifier = Modifier.fillMaxWidth(),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .then(state.buttonTestTag?.let { Modifier.testTag(it) } ?: Modifier),
         )
     }
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/connect/KeystoneConnectTag.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/connect/KeystoneConnectTag.kt
@@ -1,0 +1,5 @@
+package co.electriccoin.zcash.ui.screen.connectkeystone.connect
+
+object KeystoneConnectTag {
+    const val READY_TO_SCAN = "KEYSTONE_CONNECT_READY_TO_SCAN"
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/connect/KeystoneConnectView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/connect/KeystoneConnectView.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.buildAnnotatedString
@@ -79,7 +80,7 @@ fun ConnectKeystoneView(state: KeystoneConnectState) {
 private fun BottomSection(state: KeystoneConnectState) {
     Column {
         ZashiButton(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().testTag(KeystoneConnectTag.READY_TO_SCAN),
             text = stringResource(R.string.keystone_addHWWallet_readyToScan),
             onClick = state.onContinueClick
         )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/connected/KeystoneConnectedTag.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/connected/KeystoneConnectedTag.kt
@@ -1,0 +1,5 @@
+package co.electriccoin.zcash.ui.screen.connectkeystone.connected
+
+object KeystoneConnectedTag {
+    const val CLOSE_BTN = "KEYSTONE_CONNECTED_CLOSE"
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/connected/KeystoneConnectedView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/connected/KeystoneConnectedView.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -73,7 +74,7 @@ fun KeystoneConnectedView(state: KeystoneConnectedState) {
                 )
                 Spacer(Modifier.weight(1f))
                 ZashiButton(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier.fillMaxWidth().testTag(KeystoneConnectedTag.CLOSE_BTN),
                     text = stringResource(R.string.keystone_addHWWallet_close),
                     onClick = state.onClose,
                 )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/date/KeystoneDateTag.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/date/KeystoneDateTag.kt
@@ -1,0 +1,5 @@
+package co.electriccoin.zcash.ui.screen.connectkeystone.date
+
+object KeystoneDateTag {
+    const val ENTER_MANUALLY_BTN = "KEYSTONE_DATE_ENTER_MANUALLY"
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/date/KeystoneDateVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/date/KeystoneDateVM.kt
@@ -67,6 +67,7 @@ class KeystoneDateVM(
                 ),
             onBack = ::onBack,
             onYearMonthChange = ::onYearMonthChange,
+            secondaryButtonTestTag = KeystoneDateTag.ENTER_MANUALLY_BTN,
         )
 
     private fun onEstimateClick(yearMonth: YearMonth) =

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/height/KeystoneHeightTag.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/height/KeystoneHeightTag.kt
@@ -1,0 +1,6 @@
+package co.electriccoin.zcash.ui.screen.connectkeystone.height
+
+object KeystoneHeightTag {
+    const val CONNECT_BTN = "KEYSTONE_HEIGHT_CONNECT"
+    const val BLOCK_HEIGHT_FIELD = "KEYSTONE_HEIGHT_BLOCK_HEIGHT_FIELD"
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/height/KeystoneHeightVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/height/KeystoneHeightVM.kt
@@ -66,6 +66,8 @@ class KeystoneHeightVM(
                     ),
                 secondaryButton = null,
                 blockHeight = NumberTextFieldState(innerState = text, onValueChange = ::onValueChanged),
+                primaryButtonTestTag = KeystoneHeightTag.CONNECT_BTN,
+                blockHeightFieldTestTag = KeystoneHeightTag.BLOCK_HEIGHT_FIELD,
             )
         }.withLce(createAccountLce, errorStateMapper::mapToState)
             .stateIn(this)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/neworactive/KeystoneNewOrActiveTag.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/neworactive/KeystoneNewOrActiveTag.kt
@@ -1,0 +1,6 @@
+package co.electriccoin.zcash.ui.screen.connectkeystone.neworactive
+
+object KeystoneNewOrActiveTag {
+    const val NEW_DEVICE = "KEYSTONE_NEW_OR_ACTIVE_NEW_DEVICE"
+    const val ACTIVE_DEVICE = "KEYSTONE_NEW_OR_ACTIVE_ACTIVE_DEVICE"
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/neworactive/KeystoneNewOrActiveView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/connectkeystone/neworactive/KeystoneNewOrActiveView.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -66,13 +67,13 @@ fun KeystoneNewOrActiveView(state: KeystoneNewOrActiveState) {
             Spacer(Modifier.height(24.dp))
             ZashiButton(
                 state = state.activeDevice,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().testTag(KeystoneNewOrActiveTag.ACTIVE_DEVICE),
                 defaultPrimaryColors = ZashiButtonDefaults.secondaryColors(),
             )
             Spacer(Modifier.height(12.dp))
             ZashiButton(
                 state = state.newDevice,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().testTag(KeystoneNewOrActiveTag.NEW_DEVICE),
             )
         }
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keepopen/KeepOpenTag.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keepopen/KeepOpenTag.kt
@@ -1,0 +1,5 @@
+package co.electriccoin.zcash.ui.screen.keepopen
+
+object KeepOpenTag {
+    const val OK_BTN = "KEEP_OPEN_OK"
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keepopen/KeepOpenVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/keepopen/KeepOpenVM.kt
@@ -84,6 +84,7 @@ class KeepOpenVM(
                             text = stringRes(co.electriccoin.zcash.ui.design.R.string.general_ok),
                             onClick = ::onButtonClick,
                         ),
+                    buttonTestTag = KeepOpenTag.OK_BTN,
                 )
             }
         }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/scankeystone/e2e/E2eKeystoneQrFrameSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/scankeystone/e2e/E2eKeystoneQrFrameSource.kt
@@ -1,0 +1,63 @@
+package co.electriccoin.zcash.ui.screen.scankeystone.e2e
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalContext
+import co.electriccoin.zcash.spackle.Twig
+import co.electriccoin.zcash.ui.BuildConfig
+import kotlinx.coroutines.delay
+import java.io.File
+
+/**
+ * Test-only replacement for the camera in [co.electriccoin.zcash.ui.screen.scankeystone.view.ScanKeystoneView],
+ * used by the Keystone simulator E2E harness (see KEYSTONE_E2E_CI_PLAN.md in the workspace root) to feed real
+ * captured Keystone QR frames into the app without a physical/simulated camera.
+ *
+ * Disabled unless BOTH hold:
+ * - this is a debug build ([BuildConfig.DEBUG]), and
+ * - the inbox file returned by [inboxFile] exists in the app's private files dir at the moment the scan screen
+ *   composes. A CI harness creates it via `adb exec-out run-as <package> sh -c 'cat > files/...'` before driving
+ *   the app to this screen; a normal user's device will never have it.
+ *
+ * When enabled, this polls the inbox file and calls [onScan] once per new line, mirroring the shape of a real
+ * camera delivering one frame per analysis cycle -- the receiving side (the same onScan lambda
+ * [co.electriccoin.zcash.ui.screen.scankeystone.viewmodel.ScanKeystoneSignInRequestViewModel.onScanned] would
+ * get from a camera) never knows the difference, so the real UR-decoding/navigation logic runs unmodified.
+ */
+object E2eKeystoneQrFrameSource {
+    private const val INBOX_FILE_NAME = "e2e_keystone_scan_inbox.txt"
+    private const val POLL_INTERVAL_MS = 250L
+
+    fun inboxFile(context: Context): File = File(context.filesDir, INBOX_FILE_NAME)
+
+    fun isEnabled(context: Context): Boolean = BuildConfig.DEBUG && inboxFile(context).exists()
+
+    @Composable
+    fun Compose(onScan: (String) -> Unit) {
+        val context = LocalContext.current
+        LaunchedEffect(Unit) {
+            Twig.debug { "E2E Keystone scan: fake camera active, polling ${inboxFile(context)}" }
+            var linesDelivered = 0
+            while (true) {
+                val lines =
+                    runCatching {
+                        inboxFile(context).takeIf { it.exists() }?.readLines().orEmpty()
+                    }.getOrDefault(emptyList())
+
+                if (lines.size > linesDelivered) {
+                    for (index in linesDelivered until lines.size) {
+                        val frame = lines[index].trim()
+                        if (frame.isNotEmpty()) {
+                            Twig.debug { "E2E Keystone scan: delivering frame $index" }
+                            onScan(frame)
+                        }
+                    }
+                    linesDelivered = lines.size
+                }
+
+                delay(POLL_INTERVAL_MS)
+            }
+        }
+    }
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/scankeystone/view/ScanKeystoneView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/scankeystone/view/ScanKeystoneView.kt
@@ -89,6 +89,7 @@ import co.electriccoin.zcash.ui.screen.scan.ScanScreenState
 import co.electriccoin.zcash.ui.screen.scan.ScanTag
 import co.electriccoin.zcash.ui.screen.scan.ScanValidationState
 import co.electriccoin.zcash.ui.screen.scan.util.QrCodeAnalyzerImpl
+import co.electriccoin.zcash.ui.screen.scankeystone.e2e.E2eKeystoneQrFrameSource
 import co.electriccoin.zcash.ui.screen.scankeystone.model.ScanKeystoneState
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionState
@@ -405,13 +406,17 @@ private fun ScanMainContent(
                 onScanStateChange(ScanScreenState.Scanning)
 
                 if (!LocalInspectionMode.current) {
-                    ScanCameraView(
-                        framePosition = framePosition,
-                        isTorchOn = isTorchOn,
-                        onScan = onScan,
-                        permissionState = permissionState,
-                        setScanState = setScanState,
-                    )
+                    if (E2eKeystoneQrFrameSource.isEnabled(LocalContext.current)) {
+                        E2eKeystoneQrFrameSource.Compose(onScan = onScan)
+                    } else {
+                        ScanCameraView(
+                            framePosition = framePosition,
+                            isTorchOn = isTorchOn,
+                            onScan = onScan,
+                            permissionState = permissionState,
+                            setScanState = setScanState,
+                        )
+                    }
                 }
 
                 Canvas(modifier = Modifier.fillMaxSize()) {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/selectkeystoneaccount/view/SelectKeystoneAccountTag.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/selectkeystoneaccount/view/SelectKeystoneAccountTag.kt
@@ -1,0 +1,5 @@
+package co.electriccoin.zcash.ui.screen.selectkeystoneaccount.view
+
+object SelectKeystoneAccountTag {
+    const val NEXT_BTN = "SELECT_KEYSTONE_ACCOUNT_NEXT"
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/selectkeystoneaccount/view/SelectKeystoneAccountView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/selectkeystoneaccount/view/SelectKeystoneAccountView.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -101,7 +102,7 @@ private fun BottomSection(
         modifier
     ) {
         ZashiButton(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().testTag(SelectKeystoneAccountTag.NEXT_BTN),
             state = state.positiveButtonState
         )
     }


### PR DESCRIPTION
## Summary

Phase K1 of the Keystone E2E CI plan (`KEYSTONE_E2E_CI_PLAN.md` at the workspace root): a working, CI-verified Android pairing flow between this app and a real Keystone Cypherpunk simulator, plus the testTag ids and CI jobs needed to drive it headlessly.

- **`E2eKeystoneQrFrameSource`** — the debug-only camera-swap seam. Polls an app-private inbox file (`files/e2e_keystone_scan_inbox.txt`) and calls the same `onScan` lambda a camera frame would, so nothing downstream — UR decoding, account parsing, navigation — differs from a real scan. Gated on `BuildConfig.DEBUG` *and* the inbox file's existence; a real device or normal manual/dev use of the scan screen is unaffected by default.
- **testTag ids** across the whole Connect Keystone flow: ready-to-scan, account confirmation, new/active device choice, the Active Device manual-height sub-flow (birthday date picker → enter-manually → block height field → Connect), the "Keep Zodl open" dialog, and the Connected confirmation screen. `BirthdayPickerState`/`View` and `KeepOpenState`/`View` (both shared with restore/resync) gained nullable testTag fields following the existing `BlockHeightState` pattern — other flows are unaffected.
- **CI**: two new jobs in `e2e-smoke.yml`, `build-keystone-simulator` (builds the pinned Cypherpunk simulator, cached, uploaded as an artifact — mirrors how the APK build already works) and `Keystone` (downloads both artifacts, runs the actual pairing flow via `zodl-qa/scripts/run-keystone-android.sh`). Runs on every `pull_request` alongside `e2e-android`.

## Validation

**Locally**, against the real funded test wallet (not a throwaway), end to end on a rebuilt debug APK:
- Provision → PIN unlock → simulator navigation to its "Connect Zodl" QR
- Real captured animated-QR frames staged into the app's private inbox, decoded by the app's unmodified `URDecoder` + account-import flow
- Paired as **Active Device** with a manually-entered birthday height (not New Device, which starts scanning from the current tip and would never find this wallet's existing balance)
- Handled the "Keep Zodl open" and "Connected!" screens (both optional — neither appears on the New Device path)
- Waited on a **real wallet-sync-completion signal** (`HomeTags.SYNC_COMPLETE`, from `main`'s `#2433`) rather than stopping once "Keystone"/"Receive" are visible, which passes even mid-sync — confirmed against a screen showing an actual synced balance and transaction history

**In CI**, `build-keystone-simulator` and `Keystone` both pass on this branch. Getting there surfaced (and fixed) five real CI-environment gaps the local build never hit: rustup not auto-installing the pinned toolchain, missing SDL2 dev headers, a missing explicit `-lxcb` link flag, a script invoked from the wrong working directory, and missing SDL2/xcb *runtime* libs on the job that actually runs the compiled simulator (separate job, separate fresh VM, from the one that built it).

Also fixed along the way: `run-keystone-android.sh` wasn't exporting `KEYSTONE_RUNTIME_DIR`, so each `simulator.sh`/`provision-simulator.sh` subprocess re-sourced `env.sh` and got its own fresh temp directory — the post-provision relaunch silently read empty state from a different directory than the one just provisioned into (surfaced as the simulator landing on `SCREEN_SETUP` instead of the PIN-unlocked home screen). Fixed in `zodl-qa`.

## Test plan

- [x] `ktlintFormat` — clean
- [x] `ui-lib` compiles (`:ui-lib:compileZcashmainnetInternalDebugKotlin`)
- [x] Manual end-to-end pairing validated live on emulator, twice (New Device and Active Device paths), against both a throwaway and the real funded wallet
- [x] `build-keystone-simulator` and `Keystone` CI jobs pass on this branch
- [ ] Not yet covered: PCZT signing in either direction (Phase K2), iOS parity (Phase K4)
