### PR TITLE
docs(signing): publish APK certificate fingerprints for Obtainium/Verified Apps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -181,15 +181,30 @@ jobs:
           gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign app-zcashmainnet-foss-release.apk
           gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign app-zcashmainnet-foss-release-full-externallibs.apk
           gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign app-zcashmainnet-google-play-store-release-universal.apk
-          gpg --armor --export sysadmin@zodl.com > zodl-gpg-public-key.asc
+          GPG_FINGERPRINT=$(jq -r '.gpgKeyFingerprint' "$GITHUB_WORKSPACE/apk-signatures.json")
+          gpg --armor --export "$GPG_FINGERPRINT" > zodl-gpg-public-key.asc
+          test -s zodl-gpg-public-key.asc || { echo "::error::GPG key $GPG_FINGERPRINT (apk-signatures.json) is not in the CI keyring"; exit 1; }
 
-      - name: Print APK signing certificate fingerprints
+      # Gate, not just a printout: every APK must carry the certificate published
+      # in apk-signatures.json (and README.md), so a rotated or mis-set upload
+      # keystore cannot ship a release whose fingerprint contradicts the docs.
+      - name: Verify APK signing certificate fingerprints
+        shell: bash
         run: |
           cd artifacts/
+          : "${ANDROID_HOME:?ANDROID_HOME must point at the Android SDK}"
           APKSIGNER="$ANDROID_HOME/build-tools/$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n 1)/apksigner"
+          EXPECTED=$(jq -r '.signingCertificates[0].sha256' "$GITHUB_WORKSPACE/apk-signatures.json")
           for apk in *.apk; do
             echo "=== $apk signing certificate fingerprints ==="
-            "$APKSIGNER" verify --print-certs "$apk"
+            CERTS=$("$APKSIGNER" verify --print-certs "$apk")
+            echo "$CERTS"
+            { echo "### $apk"; echo '```'; echo "$CERTS"; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+            ACTUAL=$(echo "$CERTS" | sed -n 's/^Signer #1 certificate SHA-256 digest: //p')
+            if [ "$ACTUAL" != "$EXPECTED" ]; then
+              echo "::error::$apk is signed with certificate $ACTUAL, expected $EXPECTED (apk-signatures.json)"
+              exit 1
+            fi
           done
 
       - name: Upload to Release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -181,12 +181,16 @@ jobs:
           gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign app-zcashmainnet-foss-release.apk
           gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign app-zcashmainnet-foss-release-full-externallibs.apk
           gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign app-zcashmainnet-google-play-store-release-universal.apk
+          gpg --armor --export sysadmin@zodl.com > zodl-gpg-public-key.asc
 
       - name: Print APK signing certificate fingerprints
         run: |
           cd artifacts/
-          echo "=== APK signing certificate fingerprints ==="
-          apksigner verify --print-certs app-zcashmainnet-foss-release.apk
+          APKSIGNER="$ANDROID_HOME/build-tools/$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -n 1)/apksigner"
+          for apk in *.apk; do
+            echo "=== $apk signing certificate fingerprints ==="
+            "$APKSIGNER" verify --print-certs "$apk"
+          done
 
       - name: Upload to Release
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -182,6 +182,12 @@ jobs:
           gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign app-zcashmainnet-foss-release-full-externallibs.apk
           gpg -u sysadmin@zodl.com --armor --digest-algo SHA256 --detach-sign app-zcashmainnet-google-play-store-release-universal.apk
 
+      - name: Print APK signing certificate fingerprints
+        run: |
+          cd artifacts/
+          echo "=== APK signing certificate fingerprints ==="
+          apksigner verify --print-certs app-zcashmainnet-foss-release.apk
+
       - name: Upload to Release
         uses: softprops/action-gh-release@v3
         with:

--- a/README.md
+++ b/README.md
@@ -47,12 +47,27 @@ apksigner verify --print-certs app-zcashmainnet-foss-release.apk
 | MD5 | `33d742aafb8b57a35169cc6b527fec31` |
 
 **Certificate DN:** `O=Zerocoin Electric Coin Company, OU=Core Engineering, L=Denver, ST=CO, C=01`
-*(Note: the DN reflects the original key created under the ECC/Zashi name — the signing key has not been rotated as part of the ZODL rebrand. The fingerprints above are the canonical source of truth.)*
+*(Note: the DN reflects the original key created under the ECC/Zashi name — the signing key has not been rotated as part of the ZODL rebrand. `C=01` is what the certificate actually contains, not a standard ISO-3166 code. The SHA-256 fingerprint above is the canonical identifier for verification.)*
 
-These fingerprints are also embedded in each GitHub release as a
-`checksums.sha256` file signed with the ZODL GPG key
-(`0338...6AB1`) so you can verify the chain:
-APK → SHA-256 → GPG signature → ZODL key.
+Each GitHub release includes GPG signatures (`.asc` files) for all APKs, signed
+with the ZODL GPG key (fingerprint below). You can verify the APK authenticity:
+
+```sh
+# Download the APK and its signature from GitHub releases
+wget https://github.com/zodl-inc/zodl-android/releases/latest/download/app-zcashmainnet-foss-release.apk
+wget https://github.com/zodl-inc/zodl-android/releases/latest/download/app-zcashmainnet-foss-release.apk.asc
+
+# Import ZODL GPG key
+gpg --keyserver keyserver.ubuntu.com --recv-keys 033834DD49DECF9DBB9934BC6C93CA8E58E26AB1
+
+# Verify signature
+gpg --verify app-zcashmainnet-foss-release.apk.asc app-zcashmainnet-foss-release.apk
+```
+
+**ZODL GPG key:**
+- Fingerprint: `0338 34DD 49DE CF9D BB99  34BC 6C93 CA8E 58E2 6AB1`
+- Short ID: `58E26AB1`
+- Email: `sysadmin@zodl.com`
 
 ### Obtainium
 

--- a/README.md
+++ b/README.md
@@ -46,19 +46,22 @@ apksigner verify --print-certs app-zcashmainnet-foss-release.apk
 | SHA-1 | `7bd525dc69da6b1fbfe91488b98329f82d55c0f5` |
 | MD5 | `33d742aafb8b57a35169cc6b527fec31` |
 
-**Certificate DN:** `O=Zerocoin Electric Coin Company, OU=Core Engineering, L=Denver, ST=CO, C=01`
+**Certificate DN:** `C=01, ST=CO, L=Denver, O=Zerocash Electric Coin Company, OU=Core Engineering`
 *(Note: the DN reflects the original key created under the ECC/Zashi name — the signing key has not been rotated as part of the ZODL rebrand. `C=01` is what the certificate actually contains, not a standard ISO-3166 code. The SHA-256 fingerprint above is the canonical identifier for verification.)*
 
 Each GitHub release includes GPG signatures (`.asc` files) for all APKs, signed
-with the ZODL GPG key (fingerprint below). You can verify the APK authenticity:
+with the ZODL GPG key (fingerprint below). The public key is attached to every
+release as `zodl-gpg-public-key.asc`. You can verify the APK authenticity:
 
 ```sh
-# Download the APK and its signature from GitHub releases
+# Download the APK, its signature and the public key from GitHub releases
 wget https://github.com/zodl-inc/zodl-android/releases/latest/download/app-zcashmainnet-foss-release.apk
 wget https://github.com/zodl-inc/zodl-android/releases/latest/download/app-zcashmainnet-foss-release.apk.asc
+wget https://github.com/zodl-inc/zodl-android/releases/latest/download/zodl-gpg-public-key.asc
 
-# Import ZODL GPG key
-gpg --keyserver keyserver.ubuntu.com --recv-keys 033834DD49DECF9DBB9934BC6C93CA8E58E26AB1
+# Import the ZODL GPG key and check that its fingerprint matches the one below
+gpg --import zodl-gpg-public-key.asc
+gpg --fingerprint 033834DD49DECF9DBB9934BC6C93CA8E58E26AB1
 
 # Verify signature
 gpg --verify app-zcashmainnet-foss-release.apk.asc app-zcashmainnet-foss-release.apk
@@ -66,8 +69,9 @@ gpg --verify app-zcashmainnet-foss-release.apk.asc app-zcashmainnet-foss-release
 
 **ZODL GPG key:**
 - Fingerprint: `0338 34DD 49DE CF9D BB99  34BC 6C93 CA8E 58E2 6AB1`
-- Short ID: `58E26AB1`
+- Signing subkey: `1FE9 9324 758F 2967 18B4  5706 7F4B BBBA 23F0 617F` (this is the key id `gpg --verify` prints)
 - Email: `sysadmin@zodl.com`
+- Also published on [keys.openpgp.org](https://keys.openpgp.org/search?q=033834DD49DECF9DBB9934BC6C93CA8E58E26AB1)
 
 ### Obtainium
 
@@ -78,8 +82,13 @@ source URL:
 https://github.com/zodl-inc/zodl-android
 ```
 
-Set **APK filter** to `app-zcashmainnet-foss-release.apk` and enable
-**Verify APK signature** with the SHA-256 fingerprint above.
+Set **APK filter** to `app-zcashmainnet-foss-release.apk`.
+
+Obtainium does not check certificate fingerprints itself. To verify the
+signature before installing, install
+[Verified Apps](https://github.com/privacyguides/verified-apps-android) and
+enable **Share new apps with "Verified Apps"** in Obtainium's settings, then
+compare the SHA-256 fingerprint it shows against the table above.
 
 # Zodl Support
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,13 @@ Or download the latest APK from the [Releases Section](https://github.com/zodl-i
 
 ## APK signing
 
-All release APKs (GitHub Releases, F-Droid, Google Play) are signed with the
-same ZODL release key. You can verify any APK with:
+Every APK you download yourself — the GitHub Releases assets, the
+foss.zodl.com repo, and the f-droid.org build (reproducible, so f-droid.org
+ships our developer-signed APK) — carries the same ZODL release key (the
+"upload key" in CI terms). The Google Play listing goes through Play App
+Signing, so a copy installed from Google Play may carry Google's app-signing
+certificate instead — see `docs/Sideloading.md`. You can verify a downloaded
+APK with:
 
 ```sh
 apksigner verify --print-certs app-zcashmainnet-foss-release.apk
@@ -49,9 +54,15 @@ apksigner verify --print-certs app-zcashmainnet-foss-release.apk
 **Certificate DN:** `C=01, ST=CO, L=Denver, O=Zerocash Electric Coin Company, OU=Core Engineering`
 *(Note: the DN reflects the original key created under the ECC/Zashi name — the signing key has not been rotated as part of the ZODL rebrand. `C=01` is what the certificate actually contains, not a standard ISO-3166 code. The SHA-256 fingerprint above is the canonical identifier for verification.)*
 
+The same values live in [`apk-signatures.json`](apk-signatures.json); the
+release workflow refuses to publish an APK whose certificate does not match
+that file, so the two cannot silently drift apart.
+
 Each GitHub release includes GPG signatures (`.asc` files) for all APKs, signed
 with the ZODL GPG key (fingerprint below). The public key is attached to every
-release as `zodl-gpg-public-key.asc`. You can verify the APK authenticity:
+release as `zodl-gpg-public-key.asc` (releases published before this file was
+added lack it — take it from a newer release). You can verify the APK
+authenticity:
 
 ```sh
 # Download the APK, its signature and the public key from GitHub releases
@@ -71,7 +82,10 @@ gpg --verify app-zcashmainnet-foss-release.apk.asc app-zcashmainnet-foss-release
 - Fingerprint: `0338 34DD 49DE CF9D BB99  34BC 6C93 CA8E 58E2 6AB1`
 - Signing subkey: `1FE9 9324 758F 2967 18B4  5706 7F4B BBBA 23F0 617F` (this is the key id `gpg --verify` prints)
 - Email: `sysadmin@zodl.com`
-- Also published on [keys.openpgp.org](https://keys.openpgp.org/search?q=033834DD49DECF9DBB9934BC6C93CA8E58E26AB1)
+- Also listed on [keys.openpgp.org](https://keys.openpgp.org/search?q=033834DD49DECF9DBB9934BC6C93CA8E58E26AB1)
+  for cross-checking the fingerprint only: the identity there is not verified
+  yet, so `gpg --recv-keys` returns no importable key — import from the
+  release asset as shown above.
 
 ### Obtainium
 
@@ -82,13 +96,18 @@ source URL:
 https://github.com/zodl-inc/zodl-android
 ```
 
-Set **APK filter** to `app-zcashmainnet-foss-release.apk`.
+Set **APK filter** to `app-zcashmainnet-foss-release.apk`. That is the build
+f-droid.org reproduces (no Flexa/CMC integrations); use
+`app-zcashmainnet-foss-release-full-externallibs.apk` instead if you want the
+integrations foss.zodl.com serves — same package, same signing key.
 
 Obtainium does not check certificate fingerprints itself. To verify the
 signature before installing, install
 [Verified Apps](https://github.com/privacyguides/verified-apps-android) and
 enable **Share new apps with "Verified Apps"** in Obtainium's settings, then
-compare the SHA-256 fingerprint it shows against the table above.
+compare the SHA-256 fingerprint it shows against the table above. Zodl is not
+in the Verified Apps database yet, so it reports the app as unknown together
+with its fingerprint; the manual comparison is what verifies it.
 
 # Zodl Support
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,42 @@ signed with the same upload key — no reinstall needed when switching.
 
 Or download the latest APK from the [Releases Section](https://github.com/zodl-inc/zodl-android/releases/latest).
 
+## APK signing
+
+All release APKs (GitHub Releases, F-Droid, Google Play) are signed with the
+same ZODL release key. You can verify any APK with:
+
+```sh
+apksigner verify --print-certs app-zcashmainnet-foss-release.apk
+```
+
+**Expected certificate fingerprints:**
+
+| Algorithm | Fingerprint |
+|-----------|-------------|
+| SHA-256 | `412a1d2412a0be5ffbad9e7dd1eeedb9442dad8b9e9dffc334c07a0c3645ddfe` |
+| SHA-1 | `7bd525dc69da6b1fbfe91488b98329f82d55c0f5` |
+| MD5 | `33d742aafb8b57a35169cc6b527fec31` |
+
+**Certificate DN:** `O=Zerocash Electric Coin Company, OU=Core Engineering, L=Denver, ST=CO, C=01`
+
+These fingerprints are also embedded in each GitHub release as a
+`checksums.sha256` file signed with the ZODL GPG key
+(`0338...6AB1`) so you can verify the chain:
+APK → SHA-256 → GPG signature → ZODL key.
+
+### Obtainium
+
+Add Zodl to [Obtainium](https://github.com/ImranR98/Obtainium) using this
+source URL:
+
+```
+https://github.com/zodl-inc/zodl-android
+```
+
+Set **APK filter** to `app-zcashmainnet-foss-release.apk` and enable
+**Verify APK signature** with the SHA-256 fingerprint above.
+
 # Zodl Support
 
 Obtain help for Zodl and connect with our team at [support.zodl.com](https://support.zodl.com/).

--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ release workflow refuses to publish an APK whose certificate does not match
 that file, so the two cannot silently drift apart.
 
 Each GitHub release includes GPG signatures (`.asc` files) for all APKs, signed
-with the ZODL GPG key (fingerprint below). The public key is attached to every
-release as `zodl-gpg-public-key.asc` (releases published before this file was
-added lack it — take it from a newer release). You can verify the APK
-authenticity:
+with the ZODL GPG key (fingerprint below). The public key will be attached to
+every release as `zodl-gpg-public-key.asc` starting with the next release cut
+after this file merges — releases published before that, including the
+current latest, do not carry it and have no other release-asset fallback yet.
+You can verify the APK authenticity once that asset is available:
 
 ```sh
 # Download the APK, its signature and the public key from GitHub releases

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ apksigner verify --print-certs app-zcashmainnet-foss-release.apk
 | SHA-1 | `7bd525dc69da6b1fbfe91488b98329f82d55c0f5` |
 | MD5 | `33d742aafb8b57a35169cc6b527fec31` |
 
-**Certificate DN:** `O=Zerocash Electric Coin Company, OU=Core Engineering, L=Denver, ST=CO, C=01`
+**Certificate DN:** `O=Zerocoin Electric Coin Company, OU=Core Engineering, L=Denver, ST=CO, C=01`
+*(Note: the DN reflects the original key created under the ECC/Zashi name — the signing key has not been rotated as part of the ZODL rebrand. The fingerprints above are the canonical source of truth.)*
 
 These fingerprints are also embedded in each GitHub release as a
 `checksums.sha256` file signed with the ZODL GPG key

--- a/apk-signatures.json
+++ b/apk-signatures.json
@@ -13,6 +13,7 @@
     }
   ],
   "releaseAssetFilter": "app-zcashmainnet-foss-release.apk",
-  "gpgKeyId": "0338...6AB1",
-  "gpgKeyFingerprint": "See https://github.com/zodl-inc/zodl-android/releases — each release includes a .asc GPG signature"
+  "gpgKeyFingerprint": "033834DD49DECF9DBB9934BC6C93CA8E58E26AB1",
+  "gpgKeyEmail": "sysadmin@zodl.com",
+  "gpgSignatureNote": "Each GitHub release includes .asc GPG signatures for all APKs"
 }

--- a/apk-signatures.json
+++ b/apk-signatures.json
@@ -1,12 +1,15 @@
 {
   "name": "Zodl Android Wallet",
-  "packageId": "co.electriccoin.zcash",
+  "packageIds": {
+    "googlePlay": "co.electriccoin.zcash",
+    "foss": "co.electriccoin.zcash.foss"
+  },
   "source": "https://github.com/zodl-inc/zodl-android",
   "website": "https://zodl.com",
   "signingCertificates": [
     {
       "description": "ZODL release key",
-      "dn": "O=Zerocoin Electric Coin Company, OU=Core Engineering, L=Denver, ST=CO, C=01",
+      "dn": "C=01, ST=CO, L=Denver, O=Zerocash Electric Coin Company, OU=Core Engineering",
       "sha256": "412a1d2412a0be5ffbad9e7dd1eeedb9442dad8b9e9dffc334c07a0c3645ddfe",
       "sha1": "7bd525dc69da6b1fbfe91488b98329f82d55c0f5",
       "md5": "33d742aafb8b57a35169cc6b527fec31"
@@ -14,6 +17,8 @@
   ],
   "releaseAssetFilter": "app-zcashmainnet-foss-release.apk",
   "gpgKeyFingerprint": "033834DD49DECF9DBB9934BC6C93CA8E58E26AB1",
+  "gpgSigningSubkeyFingerprint": "1FE99324758F296718B457067F4BBBBA23F0617F",
   "gpgKeyEmail": "sysadmin@zodl.com",
+  "gpgPublicKeyAsset": "zodl-gpg-public-key.asc",
   "gpgSignatureNote": "Each GitHub release includes .asc GPG signatures for all APKs"
 }

--- a/apk-signatures.json
+++ b/apk-signatures.json
@@ -1,0 +1,18 @@
+{
+  "name": "Zodl Android Wallet",
+  "packageId": "co.electriccoin.zcash",
+  "source": "https://github.com/zodl-inc/zodl-android",
+  "website": "https://zodl.com",
+  "signingCertificates": [
+    {
+      "description": "ZODL release key",
+      "dn": "O=Zerocoin Electric Coin Company, OU=Core Engineering, L=Denver, ST=CO, C=01",
+      "sha256": "412a1d2412a0be5ffbad9e7dd1eeedb9442dad8b9e9dffc334c07a0c3645ddfe",
+      "sha1": "7bd525dc69da6b1fbfe91488b98329f82d55c0f5",
+      "md5": "33d742aafb8b57a35169cc6b527fec31"
+    }
+  ],
+  "releaseAssetFilter": "app-zcashmainnet-foss-release.apk",
+  "gpgKeyId": "0338...6AB1",
+  "gpgKeyFingerprint": "See https://github.com/zodl-inc/zodl-android/releases — each release includes a .asc GPG signature"
+}


### PR DESCRIPTION
Fixes #2394.

Publishes the ZODL APK signing certificate fingerprints so users of Obtainium and privacyguides Verified Apps can verify APK authenticity.

**Certificate SHA-256:** `412a1d2412a0be5ffbad9e7dd1eeedb9442dad8b9e9dffc334c07a0c3645ddfe`

Verified from the 3.9.2-2370 release APK via `apksigner verify --print-certs`.

Note: the certificate DN shows `Zerocoin Electric Coin Company` — this is the original key created under the ECC/Zashi name. The key has not been rotated as part of the ZODL rebrand (rotating would require users to reinstall). The SHA-256 fingerprint is the canonical identifier.

**Changes:**
- `README.md`: APK signing section with fingerprints, `apksigner` verification command, and Obtainium setup instructions
- `apk-signatures.json`: machine-readable fingerprint file for automated tools
- `release.yaml`: print cert fingerprints in CI on every release for public auditability