### PR TITLE
E2E: Add home.syncComplete testTag to fix Android smoke suite (main)

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/HomeState.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/HomeState.kt
@@ -7,5 +7,6 @@ data class HomeState(
     val secondButton: BigIconButtonState,
     val thirdButton: BigIconButtonState,
     val fourthButton: BigIconButtonState,
-    val message: HomeMessageState?
+    val message: HomeMessageState?,
+    val isSyncComplete: Boolean
 )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/HomeTags.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/HomeTags.kt
@@ -5,4 +5,9 @@ object HomeTags {
     const val RECEIVE = "RECEIVE"
     const val PAY = "HOME_PAY"
     const val SWAP = "HOME_SWAP"
+
+    // Mirrors iOS's AccessibilityID.Home.syncComplete/.syncPending — an always-present,
+    // invisible marker e2e flows can poll for instead of scraping the sync banner's text.
+    const val SYNC_COMPLETE = "home.syncComplete"
+    const val SYNC_PENDING = "home.syncPending"
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/HomeVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/HomeVM.kt
@@ -2,9 +2,11 @@ package co.electriccoin.zcash.ui.screen.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.sdk.ANDROID_STATE_FLOW_TIMEOUT
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.R
+import co.electriccoin.zcash.ui.common.datasource.WalletSnapshotDataSource
 import co.electriccoin.zcash.ui.common.migration.MigrationHomeMessageSource
 import co.electriccoin.zcash.ui.common.provider.ShieldFundsInfoProvider
 import co.electriccoin.zcash.ui.common.repository.HomeMessageData
@@ -70,6 +72,7 @@ class HomeVM(
     private val votingHomeHooks: VotingHomeHooks,
     private val migrationHomeMessageSource: MigrationHomeMessageSource,
     private val homeMessageMapper: HomeMessageMapper,
+    walletSnapshotDataSource: WalletSnapshotDataSource,
 ) : ViewModel() {
     private var hasSyncErrorBeenShown = false
     private var hasRestoreSuccessBeenShown = false
@@ -113,14 +116,25 @@ class HomeVM(
                 initialValue = null
             )
 
+    // Mirrors iOS's SmartBannerStore.isSyncComplete — SYNCED is the SDK's sole "caught up
+    // with the chain tip" status, independent of any banner (e.g. Migration Required) that
+    // may still be showing on top of a fully-synced wallet.
+    private val isSyncComplete: Flow<Boolean> =
+        walletSnapshotDataSource
+            .observe()
+            .map { it?.status == Synchronizer.Status.SYNCED }
+
     val state: StateFlow<HomeState?> =
-        messageState
-            .map { createState(it) }
-            .stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
-                initialValue = null
-            )
+        combine(
+            messageState,
+            isSyncComplete
+        ) { messageState, isSyncComplete ->
+            createState(messageState, isSyncComplete)
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
+            initialValue = null
+        )
 
     val uiLifecyclePipeline =
         combine(
@@ -159,34 +173,37 @@ class HomeVM(
 
     private var onSwapButtonClick: Job? = null
 
-    private fun createState(messageState: HomeMessageState?) =
-        HomeState(
-            firstButton =
-                BigIconButtonState(
-                    text = stringRes(R.string.tabs_receive),
-                    icon = R.drawable.ic_home_receive,
-                    onClick = ::onReceiveButtonClick,
-                ),
-            secondButton =
-                BigIconButtonState(
-                    text = stringRes(R.string.tabs_send),
-                    icon = R.drawable.ic_home_send,
-                    onClick = ::onSendButtonClick,
-                ),
-            thirdButton =
-                BigIconButtonState(
-                    text = stringRes(R.string.crosspay_pay),
-                    icon = R.drawable.ic_home_pay,
-                    onClick = ::onPayButtonClick,
-                ),
-            fourthButton =
-                BigIconButtonState(
-                    text = stringRes(R.string.swapAndPay_swap),
-                    icon = R.drawable.ic_home_swap,
-                    onClick = ::onSwapButtonClick,
-                ),
-            message = messageState
-        )
+    private fun createState(
+        messageState: HomeMessageState?,
+        isSyncComplete: Boolean
+    ) = HomeState(
+        firstButton =
+            BigIconButtonState(
+                text = stringRes(R.string.tabs_receive),
+                icon = R.drawable.ic_home_receive,
+                onClick = ::onReceiveButtonClick,
+            ),
+        secondButton =
+            BigIconButtonState(
+                text = stringRes(R.string.tabs_send),
+                icon = R.drawable.ic_home_send,
+                onClick = ::onSendButtonClick,
+            ),
+        thirdButton =
+            BigIconButtonState(
+                text = stringRes(R.string.crosspay_pay),
+                icon = R.drawable.ic_home_pay,
+                onClick = ::onPayButtonClick,
+            ),
+        fourthButton =
+            BigIconButtonState(
+                text = stringRes(R.string.swapAndPay_swap),
+                icon = R.drawable.ic_home_swap,
+                onClick = ::onSwapButtonClick,
+            ),
+        message = messageState,
+        isSyncComplete = isSyncComplete
+    )
 
     private fun createMessageState(data: HomeMessageData?, isShieldFundsInfoEnabled: Boolean) =
         when (data) {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/HomeView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/HomeView.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -76,6 +77,24 @@ private fun Content(
     Box(
         modifier = modifier,
     ) {
+        // Always-present, zero-size marker mirroring iOS's AccessibilityID.Home.syncComplete/
+        // .syncPending overlay. Gives e2e flows a positive, non-flaky signal for "wallet caught
+        // up with the chain tip" instead of asserting on the sync banner's text/visibility,
+        // which changes across states (Restoring/Resyncing/Syncing/gone) and can be replaced by
+        // unrelated banners (e.g. Migration Required) once sync is actually done.
+        //
+        // Deliberately NOT hidden from accessibility (no hideFromAccessibility()/
+        // invisibleToUser()) — that excludes a node from the accessibility tree, which is what
+        // Maestro's Android driver queries to resolve `id:` selectors, so a hidden node can never
+        // be found. iOS's equivalent overlay keeps itself in the accessibility tree for the same
+        // reason (.accessibilityElement(children: .ignore) + a label, not a hide call).
+        Box(
+            modifier =
+                Modifier
+                    .align(Alignment.TopStart)
+                    .size(1.dp)
+                    .testTag(if (state.isSyncComplete) HomeTags.SYNC_COMPLETE else HomeTags.SYNC_PENDING)
+        )
         Column(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -246,7 +265,8 @@ private fun Preview() {
                             icon = R.drawable.ic_home_buy,
                             onClick = {}
                         ),
-                    message = WalletErrorMessageState(onClick = {})
+                    message = WalletErrorMessageState(onClick = {}),
+                    isSyncComplete = true
                 )
         )
     }


### PR DESCRIPTION
## Summary
Same fix as #2428, ported onto `main`. `main` and `maint/v3.9.x` have diverged in `HomeVM.kt` (main still has the `VotingHomeHooks` abstraction; maint/v3.9.x inlined it), so this isn't a clean cherry-pick — the change was reapplied by hand against `main`'s current `HomeVM.kt` shape. `HomeState.kt`, `HomeTags.kt`, and `HomeView.kt` are byte-identical between the two branches, so those three carried over verbatim.

- The `restore-existing-wallet.yaml` smoke flow polls for `id: home.syncComplete`, which only ever existed as an iOS accessibilityIdentifier. Android's Home screen had no matching Compose testTag, so the assertion could never pass — this is what failed PR #2427 and #2429's `e2e-android (phase 2)` job.
- Adds `HomeTags.SYNC_COMPLETE`/`SYNC_PENDING` and a zero-size marker `Box` on Home whose testTag flips based on `Synchronizer.Status.SYNCED`, independent of whatever banner (e.g. Migration Required) is showing.
- Deliberately **not** hidden from accessibility (`hideFromAccessibility()`/`invisibleToUser()`) — that excludes a node from the accessibility tree, which is what Maestro's Android driver queries to resolve `id:` selectors. Found this the hard way on #2428's first CI run.

## Test plan
- [x] Confirmed on #2428 (maint/v3.9.x): `restore-existing-wallet.yaml` now passes (`exit=0`) instead of aborting the suite
- [ ] CI: `e2e-android (phase 2)` on this branch reaches "Wait for wallet sync to complete" and passes