### PR TITLE
MOB-1733: Unify bottom sheet background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Changed:
 
+- Bottom sheets across the app now share one background color.
 - Coinholder Polling now loads its trusted configuration through the resilient voting config gateway, so a GitHub outage no longer blocks
   configuration loading while the mirrored copy is available.
 

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/component/MigrationPreparationDetailsBottomSheet.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/component/MigrationPreparationDetailsBottomSheet.kt
@@ -104,7 +104,7 @@ fun MigrationPreparationDetailsBottomSheet(details: MigrationPreparationDetails?
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .background(ZashiColors.Surfaces.bgSecondary, RoundedCornerShape(12.dp))
+                        .background(ZashiColors.Surfaces.bgPrimary, RoundedCornerShape(12.dp))
                         .padding(12.dp),
             ) {
                 Text(

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/privacy/MigrationPrivacyArgs.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/privacy/MigrationPrivacyArgs.kt
@@ -122,7 +122,7 @@ fun MigrationPrivacyView(
 @Composable
 private fun TorToggleCard(state: CheckboxState) {
     Surface(
-        color = ZashiColors.Surfaces.bgSecondary,
+        color = ZashiColors.Surfaces.bgPrimary,
         border = BorderStroke(1.dp, Color.Transparent),
         shape = RoundedCornerShape(ZashiDimensions.Radius.radiusXl),
         onClick = state.onClick,

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/chainconfig/VoteChainConfigView.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/chainconfig/VoteChainConfigView.kt
@@ -180,7 +180,7 @@ private fun ChainItem(state: VoteChainConfigItemState) {
                     onClick = state.radioButtonState.onClick
                 ),
         shape = RoundedCornerShape(ZashiDimensions.Radius.radius2xl),
-        color = if (isSelected) ZashiColors.Surfaces.bgPrimary else ZashiColors.Surfaces.bgSecondary,
+        color = ZashiColors.Surfaces.bgPrimary,
         border =
             if (isSelected) {
                 BorderStroke(1.dp, ZashiColors.Surfaces.bgAlt)
@@ -337,7 +337,7 @@ private fun AddCustomSourceButton(state: VoteChainConfigState) {
             ),
         defaultTertiaryColors =
             ZashiButtonDefaults.tertiaryColors(
-                containerColor = ZashiColors.Surfaces.bgSecondary,
+                containerColor = ZashiColors.Surfaces.bgPrimary,
                 contentColor = ZashiColors.Text.textPrimary
             ),
         content = { scope ->
@@ -508,7 +508,7 @@ private fun SheetHeader(state: VoteChainConfigEditorState) {
         )
         Surface(
             shape = CircleShape,
-            color = ZashiColors.Surfaces.bgSecondary,
+            color = ZashiColors.Surfaces.bgPrimary,
             modifier =
                 Modifier
                     .align(Alignment.CenterStart)
@@ -541,7 +541,7 @@ private fun sheetTextFieldColors(isFocusedByDefault: Boolean) =
         textColor = ZashiColors.Text.textPrimary,
         borderColor = if (isFocusedByDefault) ZashiColors.Surfaces.bgAlt else Color.Unspecified,
         focusedBorderColor = ZashiColors.Surfaces.bgAlt,
-        containerColor = if (isFocusedByDefault) ZashiColors.Surfaces.bgPrimary else ZashiColors.Surfaces.bgSecondary,
+        containerColor = ZashiColors.Surfaces.bgPrimary,
         focusedContainerColor = ZashiColors.Surfaces.bgPrimary,
         placeholderColor = ZashiColors.Text.textTertiary
     )

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/polldescription/VotePollDescriptionView.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/polldescription/VotePollDescriptionView.kt
@@ -59,7 +59,7 @@ fun VotePollDescriptionView(
                 )
                 Surface(
                     shape = CircleShape,
-                    color = ZashiColors.Surfaces.bgSecondary,
+                    color = ZashiColors.Surfaces.bgPrimary,
                     modifier =
                         Modifier
                             .align(Alignment.CenterStart)

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/proposaldetail/bottomsheet/PollEndedBottomSheet.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/proposaldetail/bottomsheet/PollEndedBottomSheet.kt
@@ -23,6 +23,7 @@ import co.electriccoin.zcash.ui.design.component.ButtonState
 import co.electriccoin.zcash.ui.design.component.ButtonStyle
 import co.electriccoin.zcash.ui.design.component.VerticalSpacer
 import co.electriccoin.zcash.ui.design.component.ZashiButton
+import co.electriccoin.zcash.ui.design.component.ZashiModalBottomSheetDefaults
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.dimensions.ZashiDimensions
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
@@ -41,7 +42,7 @@ fun PollEndedBottomSheet(
     ModalBottomSheet(
         onDismissRequest = onClose,
         sheetState = sheetState,
-        containerColor = ZashiColors.Surfaces.bgPrimary,
+        containerColor = ZashiModalBottomSheetDefaults.ContainerColor,
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiConfirmationBottomSheet.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiConfirmationBottomSheet.kt
@@ -40,12 +40,6 @@ fun ZashiConfirmationBottomSheet(state: ZashiConfirmationState?) {
                 RoundedCornerShape(34.dp)
             } else {
                 ZashiModalBottomSheetDefaults.SheetShape
-            },
-        containerColor =
-            if (state?.style == ZashiConfirmationStyle.UNVERIFIED_POLL_WARNING) {
-                ZashiColors.Surfaces.bgSecondary
-            } else {
-                ZashiModalBottomSheetDefaults.ContainerColor
             }
     ) { innerState ->
         ConfirmationContent(

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiInScreenModalBottomSheet.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiInScreenModalBottomSheet.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
@@ -31,7 +30,6 @@ fun <T : ModalBottomSheetState> ZashiInScreenModalBottomSheet(
     modifier: Modifier = Modifier,
     sheetState: SheetState = rememberInScreenModalBottomSheetState(),
     shape: Shape = ZashiModalBottomSheetDefaults.SheetShape,
-    containerColor: Color = ZashiModalBottomSheetDefaults.ContainerColor,
     dragHandle: @Composable (() -> Unit)? = { ZashiModalBottomSheetDragHandle() },
     content: @Composable ColumnScope.(T) -> Unit = {},
 ) {
@@ -43,7 +41,6 @@ fun <T : ModalBottomSheetState> ZashiInScreenModalBottomSheet(
             modifier = modifier,
             sheetState = sheetState,
             shape = shape,
-            containerColor = containerColor,
             properties = ModalBottomSheetProperties(shouldDismissOnBackPress = false),
             dragHandle = dragHandle
         ) {

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiModalBottomSheet.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiModalBottomSheet.kt
@@ -44,7 +44,6 @@ fun ZashiModalBottomSheet(
     sheetGesturesEnabled: Boolean = true,
     sheetState: SheetState = rememberModalBottomSheetState(),
     shape: Shape = ZashiModalBottomSheetDefaults.SheetShape,
-    containerColor: Color = ZashiModalBottomSheetDefaults.ContainerColor,
     properties: ModalBottomSheetProperties = ModalBottomSheetDefaults.properties,
     dragHandle: @Composable (() -> Unit)? = { ZashiModalBottomSheetDragHandle() },
     content: @Composable ColumnScope.() -> Unit,
@@ -56,7 +55,7 @@ fun ZashiModalBottomSheet(
         sheetGesturesEnabled = sheetGesturesEnabled,
         scrimColor = scrimColor,
         shape = shape,
-        containerColor = containerColor,
+        containerColor = ZashiModalBottomSheetDefaults.ContainerColor,
         dragHandle = dragHandle,
         properties = properties,
         content = content,
@@ -140,7 +139,7 @@ object ZashiModalBottomSheetDefaults {
         get() = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
     val ContainerColor: Color
         @Composable
-        get() = ZashiColors.Surfaces.bgPrimary
+        get() = ZashiColors.Surfaces.bgSecondary
     val ContentColor: Color
         @Composable
         get() = ZashiColors.Text.textPrimary

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiScreenModalBottomSheet.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiScreenModalBottomSheet.kt
@@ -43,7 +43,6 @@ fun <T : ModalBottomSheetState> ZashiScreenModalBottomSheet(
     properties: ModalBottomSheetProperties = ModalBottomSheetDefaults.properties,
     sheetState: SheetState = rememberScreenModalBottomSheetState(),
     shape: Shape = ZashiModalBottomSheetDefaults.SheetShape,
-    containerColor: Color = ZashiModalBottomSheetDefaults.ContainerColor,
     dragHandle: @Composable (() -> Unit)? = { ZashiModalBottomSheetDragHandle() },
     content: @Composable ColumnScope.(state: T, contentPadding: PaddingValues) -> Unit = { _, _ -> },
 ) {
@@ -73,7 +72,6 @@ fun <T : ModalBottomSheetState> ZashiScreenModalBottomSheet(
             sheetGesturesEnabled = sheetGesturesEnabled,
             scrimColor = Color.Transparent,
             shape = shape,
-            containerColor = containerColor,
             dragHandle = dragHandle,
             content = {
                 BackHandler {
@@ -113,7 +111,6 @@ fun ZashiScreenModalBottomSheet(
     onDismissRequest: () -> Unit,
     sheetState: SheetState = rememberScreenModalBottomSheetState(),
     shape: Shape = ZashiModalBottomSheetDefaults.SheetShape,
-    containerColor: Color = ZashiModalBottomSheetDefaults.ContainerColor,
     content: @Composable ColumnScope.(contentPadding: PaddingValues) -> Unit = {},
 ) {
     ZashiScreenModalBottomSheet(
@@ -127,7 +124,6 @@ fun ZashiScreenModalBottomSheet(
             },
         sheetState = sheetState,
         shape = shape,
-        containerColor = containerColor,
         content = { _, contentPadding ->
             content(contentPadding)
             HookupKeyboardController()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/accountlist/AccountListView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/accountlist/AccountListView.kt
@@ -235,7 +235,7 @@ private fun ZashiAccountListItem(
         trailing = null,
         color =
             if (state.isSelected) {
-                ZashiColors.Surfaces.bgSecondary
+                ZashiColors.Surfaces.bgPrimary
             } else {
                 Color.Transparent
             },

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/accountlist/AccountListView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/accountlist/AccountListView.kt
@@ -141,7 +141,7 @@ private fun ZashiKeystonePromoListItem(
     contentPadding: PaddingValues = PaddingValues(24.dp),
     colors: ZashiListItemColors =
         ZashiListItemDefaults.primaryColors(
-            backgroundColor = ZashiColors.Surfaces.bgTertiary
+            backgroundColor = ZashiColors.Surfaces.bgPrimary
         ),
     below: @Composable ColumnScope.(Modifier) -> Unit = {
         Image(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/balances/breakdown/BalanceBreakdownView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/balances/breakdown/BalanceBreakdownView.kt
@@ -42,7 +42,6 @@ fun BalanceBreakdownView(
     ZashiScreenModalBottomSheet(
         state = state,
         sheetState = sheetState,
-        containerColor = ZashiColors.Surfaces.bgSecondary,
         content = { state, contentPadding ->
             BottomSheetContent(state, contentPadding, modifier = Modifier.weight(1f, false))
         },


### PR DESCRIPTION
<!-- Write any additional comments here when opening the pull request -->

## Summary

Bottom sheets across the app showed two different background colors: most used `bgPrimary` (white), while a couple (balance breakdown, unverified-poll warning) used `bgSecondary` (light gray). Investigation against the current Figma spec settled the direction: the design's sheet surface is the light-gray glass (`bgSecondary`-equivalent) with white `bgPrimary` cards inside, so the `bgSecondary` sheets were design-compliant and the majority `bgPrimary` sheets were the outdated side.

This PR unifies **toward `ZashiColors.Surfaces.bgSecondary`** (`#F4F4F4` light / `#3B3839` dark):

- Flips `ZashiModalBottomSheetDefaults.ContainerColor` to `bgSecondary`.
- Removes the `containerColor` override parameter from `ZashiModalBottomSheet`, `ZashiScreenModalBottomSheet`, and `ZashiInScreenModalBottomSheet` so no call site can diverge from the shared default again.
- Fixes the handful of inner surfaces (cards, close buttons, list rows, text fields) that would otherwise blend into the new `bgSecondary` sheet background, flipping them to `bgPrimary` to preserve contrast.

The full glass effect, 34dp radius, and the Q3 rebrand palette are explicitly out of scope for this fix.

### Before / after
- Before: two sheet background colors coexisted (`bgPrimary` on most sheets, `bgSecondary` on balance breakdown / unverified-poll warning).
- After: every Zashi sheet shares one `bgSecondary` background, matching the current Figma spec.

### Links
- Slack thread: https://zodl.slack.com/archives/C0B4F0CUWMC/p1786951076302139
- Figma: file `1aeq8gleYh9Yr1l33TwELR` "PR App Designs Q3 '26", node `6753-46426` "Balance Sheet (Default)"
- Linear: https://linear.app/zodl/issue/MOB-1733

Fixes MOB-1733

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [ ] **Run the app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._

🤖 Generated with [Claude Code](https://claude.com/claude-code)