### PR TITLE
fix(fdroid): wait for GitLab pipeline + purge CF cache on publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -203,40 +203,92 @@ jobs:
   # release tag, so the right APK version gets published. All the AWS Secrets
   # Manager / keystore / fdroidserver / git-push work now lives in GitLab CI.
   #
-  # Best-effort: a failed trigger must not fail the release.
+  # Triggers the GitLab Pages F-Droid pipeline, waits for it to finish,
+  # and purges the Cloudflare cache on success so clients get fresh APK+index.
   publish_to_fdroid:
     needs: [release]
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: Trigger GitLab Pages F-Droid publish
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+        with:
+          role-to-assume: ${{ secrets.AWS_RELEASE_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Trigger GitLab Pages F-Droid publish and wait
         env:
           GITLAB_FDROID_TRIGGER_TOKEN: ${{ secrets.GITLAB_FDROID_TRIGGER_TOKEN }}
-          # Project id + target ref live in repo variables so they can be updated
-          # in one place if the GitLab project is recreated or the pipeline moves
-          # to an environment branch (review: noop-sk). Default to the known
-          # values if the vars are unset, so the step still works pre-config.
           GITLAB_FDROID_PROJECT_ID: ${{ vars.GITLAB_FDROID_PROJECT_ID || '83433564' }}
           GITLAB_FDROID_REF: ${{ vars.GITLAB_FDROID_REF || 'main' }}
-          # On `release: published` GITHUB_REF_NAME is the tag; on a manual
-          # recovery dispatch it is the workflow's branch (e.g. main), so prefer
-          # the explicit input tag when present.
           APK_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           echo "Triggering GitLab F-Droid pipeline for ${APK_TAG}"
-          # -m 30 bounds the wait: without it, an unreachable GitLab would block
-          # until the runner's job-level timeout (~6h) fires (review: noop-sk).
           HTTP_CODE=$(curl -s -m 30 -o /tmp/trigger.json -w '%{http_code}' \
             -X POST "https://gitlab.com/api/v4/projects/${GITLAB_FDROID_PROJECT_ID}/trigger/pipeline" \
             -F token="${GITLAB_FDROID_TRIGGER_TOKEN}" \
             -F "ref=${GITLAB_FDROID_REF}" \
             -F "variables[APK_TAG]=${APK_TAG}")
-          cat /tmp/trigger.json
-          echo
-          if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
-            echo "GitLab pipeline triggered: $(jq -r '.web_url // empty' /tmp/trigger.json)"
-          else
-            # Publishing is best-effort -- never fail the release on a trigger error.
-            echo "::warning::GitLab F-Droid trigger returned HTTP ${HTTP_CODE}; F-Droid publish skipped. Re-run manually if needed."
+          cat /tmp/trigger.json && echo
+
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "::error::GitLab F-Droid trigger returned HTTP ${HTTP_CODE}"
+            exit 1
           fi
+
+          PIPELINE_ID=$(jq -r '.id' /tmp/trigger.json)
+          PIPELINE_URL=$(jq -r '.web_url' /tmp/trigger.json)
+          echo "GitLab pipeline ${PIPELINE_ID} triggered: ${PIPELINE_URL}"
+          echo "PIPELINE_ID=${PIPELINE_ID}" >> "$GITHUB_ENV"
+
+          # Poll until the pipeline finishes (max 15 min)
+          for i in $(seq 1 90); do
+            sleep 10
+            STATUS=$(curl -s -m 10 \
+              "https://gitlab.com/api/v4/projects/${GITLAB_FDROID_PROJECT_ID}/pipelines/${PIPELINE_ID}" \
+              -H "PRIVATE-TOKEN: ${GITLAB_FDROID_TRIGGER_TOKEN}" \
+              | jq -r '.status // "unknown"')
+            echo "  [${i}] pipeline status: ${STATUS}"
+            case "$STATUS" in
+              success)
+                echo "GitLab pipeline succeeded."
+                exit 0
+                ;;
+              failed|canceled|skipped)
+                echo "::error::GitLab F-Droid pipeline ${STATUS}: ${PIPELINE_URL}"
+                exit 1
+                ;;
+              created|waiting_for_resource|preparing|pending|running|scheduled)
+                ;;
+              *)
+                echo "::warning::Unknown pipeline status '${STATUS}', continuing to wait"
+                ;;
+            esac
+          done
+          echo "::error::GitLab F-Droid pipeline did not finish within 15 min: ${PIPELINE_URL}"
+          exit 1
+
+      - name: Purge Cloudflare cache for foss.zodl.com
+        run: |
+          CF_ZONE=$(aws secretsmanager get-secret-value \
+            --secret-id /infra/cloudflare/api_token \
+            --query SecretString --output text)
+          # Fetch zone ID for zodl.com
+          ZONE_ID=$(curl -s "https://api.cloudflare.com/client/v4/zones?name=zodl.com" \
+            -H "Authorization: Bearer ${CF_ZONE}" \
+            | jq -r '.result[0].id')
+          # Purge APK + index files
+          RESULT=$(curl -s -X POST \
+            "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/purge_cache" \
+            -H "Authorization: Bearer ${CF_ZONE}" \
+            -H "Content-Type: application/json" \
+            --data '{
+              "files": [
+                "https://foss.zodl.com/fdroid/repo/app-zcashmainnet-foss-release-full-externallibs.apk",
+                "https://foss.zodl.com/fdroid/repo/app-zcashmainnet-foss-release.apk",
+                "https://foss.zodl.com/fdroid/repo/index-v2.json",
+                "https://foss.zodl.com/fdroid/repo/entry.jar"
+              ]
+            }')
+          echo "CF purge result: $(echo $RESULT | jq -r '.success')"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -210,6 +210,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write  # Required for AWS OIDC
+
     steps:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
@@ -220,6 +222,10 @@ jobs:
       - name: Trigger GitLab Pages F-Droid publish and wait
         env:
           GITLAB_FDROID_TRIGGER_TOKEN: ${{ secrets.GITLAB_FDROID_TRIGGER_TOKEN }}
+          # GITLAB_PAT is a project/personal access token with api read scope,
+          # used for polling pipeline status. Trigger tokens are scoped only to
+          # POST .../trigger/pipeline and cannot authenticate API reads.
+          GITLAB_PAT: ${{ secrets.GITLAB_PAT }}
           GITLAB_FDROID_PROJECT_ID: ${{ vars.GITLAB_FDROID_PROJECT_ID || '83433564' }}
           GITLAB_FDROID_REF: ${{ vars.GITLAB_FDROID_REF || 'main' }}
           APK_TAG: ${{ inputs.tag || github.ref_name }}
@@ -240,14 +246,15 @@ jobs:
           PIPELINE_ID=$(jq -r '.id' /tmp/trigger.json)
           PIPELINE_URL=$(jq -r '.web_url' /tmp/trigger.json)
           echo "GitLab pipeline ${PIPELINE_ID} triggered: ${PIPELINE_URL}"
-          echo "PIPELINE_ID=${PIPELINE_ID}" >> "$GITHUB_ENV"
 
-          # Poll until the pipeline finishes (max 15 min)
+          # Poll until the pipeline finishes (max 15 min, 10s intervals).
+          # Uses GITLAB_PAT (read-scoped) — GITLAB_FDROID_TRIGGER_TOKEN is a
+          # pipeline trigger token, not valid as a PRIVATE-TOKEN API credential.
           for i in $(seq 1 90); do
             sleep 10
             STATUS=$(curl -s -m 10 \
               "https://gitlab.com/api/v4/projects/${GITLAB_FDROID_PROJECT_ID}/pipelines/${PIPELINE_ID}" \
-              -H "PRIVATE-TOKEN: ${GITLAB_FDROID_TRIGGER_TOKEN}" \
+              -H "PRIVATE-TOKEN: ${GITLAB_PAT}" \
               | jq -r '.status // "unknown"')
             echo "  [${i}] pipeline status: ${STATUS}"
             case "$STATUS" in
@@ -271,17 +278,22 @@ jobs:
 
       - name: Purge Cloudflare cache for foss.zodl.com
         run: |
-          CF_ZONE=$(aws secretsmanager get-secret-value \
+          CF_API_TOKEN=$(aws secretsmanager get-secret-value \
             --secret-id /infra/cloudflare/api_token \
             --query SecretString --output text)
-          # Fetch zone ID for zodl.com
+          echo "::add-mask::${CF_API_TOKEN}"
+
           ZONE_ID=$(curl -s "https://api.cloudflare.com/client/v4/zones?name=zodl.com" \
-            -H "Authorization: Bearer ${CF_ZONE}" \
-            | jq -r '.result[0].id')
-          # Purge APK + index files
-          RESULT=$(curl -s -X POST \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            | jq -r '.result[0].id // empty')
+          if [ -z "${ZONE_ID}" ]; then
+            echo "::error::Could not resolve Cloudflare zone ID for zodl.com"
+            exit 1
+          fi
+
+          PURGE_SUCCESS=$(curl -s -X POST \
             "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/purge_cache" \
-            -H "Authorization: Bearer ${CF_ZONE}" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
             -H "Content-Type: application/json" \
             --data '{
               "files": [
@@ -290,5 +302,9 @@ jobs:
                 "https://foss.zodl.com/fdroid/repo/index-v2.json",
                 "https://foss.zodl.com/fdroid/repo/entry.jar"
               ]
-            }')
-          echo "CF purge result: $(echo $RESULT | jq -r '.success')"
+            }' | jq -r '.success')
+          echo "CF purge result: ${PURGE_SUCCESS}"
+          if [ "${PURGE_SUCCESS}" != "true" ]; then
+            echo "::error::Cloudflare cache purge failed"
+            exit 1
+          fi


### PR DESCRIPTION
## Problem

F-Droid users were getting 416 (invalid range) and hash-mismatch errors because:
1. The `publish_to_fdroid` job only fired the GitLab trigger and moved on — silent failures went unnoticed
2. Releases 3.9.0, 3.9.1, 3.9.2 all had their GitLab pipelines fail silently, leaving the index stuck at 3.8.1
3. CF cache served the stale APK even after manual fix

## Fix

- **Poll GitLab pipeline** until success/failure (max 15 min, 10s intervals) — fails the GH job if GitLab fails, making the problem immediately visible
- **Purge Cloudflare cache** after successful publish for APK + index-v2.json + entry.jar — no more stale caches

## Test plan
- [ ] Run workflow dispatch for next release, verify GitLab polling appears in logs
- [ ] Verify CF purge step runs after GitLab success