### PR TITLE
Revert the voting-shim SDK compile params in VotingCryptoClient

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingCryptoClient.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingCryptoClient.kt
@@ -773,7 +773,7 @@ class VotingCryptoClientImpl : VotingCryptoClient {
     ): VotingDelegationPirPrecomputeResult =
         withContext(Dispatchers.IO) {
             db(dbHandle)
-                .precomputeDelegationPir(roundId, bundleIndex, pirServerUrl, 0, 0, 0, notesJson.toJniNoteInfos())
+                .precomputeDelegationPir(roundId, bundleIndex, pirServerUrl, notesJson.toJniNoteInfos())
                 .toAppModel()
         }
 
@@ -796,9 +796,6 @@ class VotingCryptoClientImpl : VotingCryptoClient {
                     roundId,
                     bundleIndex,
                     pirServerUrl,
-                    0,
-                    0,
-                    0,
                     notesJson.toJniNoteInfos(),
                     fvkBytes,
                     hotkeySeed,


### PR DESCRIPTION
## Summary

Companion PR to zcash/zcash-android-wallet-sdk#2183, which reverts the
`zcash_voting` re-enable that was accidentally merged onto SDK
`maint/v3.0.x` via #2157/#2161.

SDK PR #2157 added three required `Int` params (`pirDepth`,
`pirTier0Layers`, `pirTier1Layers`) to
`VotingRustBackend.VotingDb.precomputeDelegationPir` and
`buildAndProveDelegation`. Commit 227ee1e09 shimmed both call sites in
`VotingCryptoClient.kt` with `0, 0, 0` (the `PirLayout::UNKNOWN`
sentinel) purely to keep this line compiling against
`3.0.2-SNAPSHOT`.

Now that the SDK side reverts those signatures back to their pre-#2157
shape, this shim is stale and needs to go with it — otherwise the extra
args no longer match any overload.

CHP voting is dead code on this app line either way (`VOTING_ENABLED =
false` in `MoreVM.kt`) — this is a compile-signature fix only, no
behavior change.

## ⚠️ Sequencing — do not merge yet

This depends on zcash/zcash-android-wallet-sdk#2183 merging first and
`3.0.2-SNAPSHOT` being republished from the reverted `maint/v3.0.x`
(same version string, same `LIBRARY_VERSION=3.0.2` — no
`gradle.properties` bump needed here, just a fresh snapshot resolve).
Merging this before that happens will break the `maint/v3.9.x` build.

## Test plan

- [ ] zcash/zcash-android-wallet-sdk#2183 merged and `3.0.2-SNAPSHOT`
      republished
- [ ] `./gradlew :app:compileZcashmainnetInternalDebugKotlin` (or
      equivalent) green against the refreshed snapshot
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)