### PR TITLE
Fix Keystone voting PCZT scan silently looping forever

### DIFF
--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepository.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepository.kt
@@ -352,6 +352,7 @@ class VotingKeystoneRepositoryImpl(
         // crate's own submission result.
         pendingRequest.decodeExpectedRk()?.let { rk ->
             persistKeystoneSignatureCrateSide(
+                accountUuid = accountUuid,
                 roundId = roundId,
                 bundleIndex = bundleIndex,
                 keystoneSig = spendAuthSig,
@@ -370,6 +371,7 @@ class VotingKeystoneRepositoryImpl(
     }
 
     private suspend fun persistKeystoneSignatureCrateSide(
+        accountUuid: String,
         roundId: String,
         bundleIndex: Int,
         keystoneSig: ByteArray,
@@ -377,9 +379,11 @@ class VotingKeystoneRepositoryImpl(
         rk: ByteArray
     ) {
         val votingDbPath = resolveVotingDbPath()
+        val networkId = synchronizerProvider.getSynchronizer().network.toVotingNetworkId()
         val dbHandle = votingCryptoClient.openVotingDb(votingDbPath)
         check(dbHandle != 0L) { "Failed to open voting DB at $votingDbPath" }
         try {
+            votingCryptoClient.setWalletId(dbHandle, accountUuid, networkId)
             votingCryptoClient.storeKeystoneSignature(
                 dbHandle = dbHandle,
                 roundId = roundId,

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/scankeystone/viewmodel/ScanKeystoneVotingPCZTViewModel.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/scankeystone/viewmodel/ScanKeystoneVotingPCZTViewModel.kt
@@ -2,6 +2,7 @@ package co.electriccoin.zcash.ui.screen.voting.scankeystone.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import co.electriccoin.zcash.spackle.Twig
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.repository.VotingKeystoneDuplicateSignatureException
@@ -41,6 +42,7 @@ internal class ScanKeystoneVotingPCZTViewModel(
             )
         )
 
+    @Suppress("TooGenericExceptionCaught")
     fun onScanned(result: String) =
         viewModelScope.launch {
             try {
@@ -87,7 +89,8 @@ internal class ScanKeystoneVotingPCZTViewModel(
                 }
             } catch (_: InvalidKeystonePCZTQRException) {
                 validationState.update { ScanValidationState.INVALID }
-            } catch (_: Exception) {
+            } catch (exception: Exception) {
+                Twig.warn(exception) { "Keystone voting PCZT scan failed" }
                 validationState.update { ScanValidationState.INVALID }
             }
         }

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepositoryTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepositoryTest.kt
@@ -634,6 +634,7 @@ class VotingKeystoneRepositoryTest {
         var extractSpendAuthCalls = 0
         val openVotingDbCalls = mutableListOf<String>()
         val closeVotingDbCalls = mutableListOf<Long>()
+        val setWalletIdCalls = mutableListOf<SetWalletIdCall>()
         val storeKeystoneSignatureCalls = mutableListOf<StoreKeystoneSignatureCall>()
 
         val client: VotingCryptoClient =
@@ -662,6 +663,16 @@ class VotingKeystoneRepositoryTest {
                         Unit
                     }
 
+                    "setWalletId" -> {
+                        setWalletIdCalls +=
+                            SetWalletIdCall(
+                                dbHandle = args.valueAt(0),
+                                walletId = args.valueAt(1),
+                                networkId = args.valueAt(2)
+                            )
+                        Unit
+                    }
+
                     "storeKeystoneSignature" -> {
                         storeKeystoneSignatureCalls +=
                             StoreKeystoneSignatureCall(
@@ -682,6 +693,12 @@ class VotingKeystoneRepositoryTest {
             } as VotingCryptoClient
     }
 
+    private data class SetWalletIdCall(
+        val dbHandle: Long,
+        val walletId: String,
+        val networkId: Int
+    )
+
     private data class StoreKeystoneSignatureCall(
         val dbHandle: Long,
         val roundId: String,
@@ -698,7 +715,10 @@ class VotingKeystoneRepositoryTest {
         override val synchronizer: StateFlow<Synchronizer?> = MutableStateFlow(null)
         override val walletBalances: Flow<Map<AccountUuid, AccountBalance>?> = flowOf(null)
 
-        override suspend fun getSynchronizer(): Synchronizer = unsupported()
+        private val fakeSynchronizer: Synchronizer =
+            mockk<Synchronizer>(relaxed = true).also { every { it.network } returns ZcashNetwork.Mainnet }
+
+        override suspend fun getSynchronizer(): Synchronizer = fakeSynchronizer
 
         override suspend fun getSynchronizerOrNull(): Synchronizer? = unsupported()
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/ParseKeystonePCZTUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/ParseKeystonePCZTUseCase.kt
@@ -55,6 +55,7 @@ abstract class BaseKeystoneScanner(
                                 isFinished = true
                             )
                         } catch (e: Exception) {
+                            Twig.warn(e) { "Keystone scan onSuccess(ur) failed, resetting decoder" }
                             @Suppress("TooGenericExceptionCaught", "SwallowedException")
                             try {
                                 keystoneSDKProvider.resetQRDecoder()


### PR DESCRIPTION
## Summary
- `VotingKeystoneRepository.persistKeystoneSignatureCrateSide()` opened a voting DB handle via `openVotingDb()` but never called `setWalletId()` before passing that handle to `storeKeystoneSignature()`. `openVotingDb()` only reserves a handle number and records the DB path — the native session is created and registered in `VotingCryptoClientImpl`'s `sessions` map only inside `setWalletId()`. Every other call site (`createPcztEncoder`, `PrepareVotingRoundUseCase`, `SubmitVotesUseCase`, `SkipRemainingKeystoneBundlesUseCase`, `TrackVotingSharesUseCase`, `VotingProofPrecomputeRepository`) already followed `open -> setWalletId -> use -> close` correctly; this one skipped the middle step.
- The resulting `IllegalStateException("Voting DB handle is not open: $dbHandle")` was caught by `BaseKeystoneScanner`, which silently reset the animated-QR decoder state back to 0% progress without logging anything. Result: on the CHP coinholder-voting "Scan Signature" screen, a correctly-signed Keystone PCZT could never actually be applied — the scan looped 0% → 100% → silently reset to 0% forever, with zero error surfaced anywhere (UI or logs). Reproduced on a fresh install with a real Keystone device, confirmed fixed the same way.
- Also promotes the temporary diagnostic logging used to find this into two permanent one-line `Twig.warn` calls at the two points that were swallowing the exception (`BaseKeystoneScanner`'s `onSuccess(ur)` catch in `ParseKeystonePCZTUseCase.kt`, and `ScanKeystoneVotingPCZTViewModel`'s generic catch), so a future failure on this path shows up in logs instead of requiring live instrumentation to diagnose. Audited every other `openVotingDb` call site and every other catch-and-reset loop in the voting/Keystone-scan code for the same two failure shapes — no other instances found.

## Test plan
- [x] `feature-voting` unit tests (incl. updated `VotingKeystoneRepositoryTest` covering the new `setWalletId` call)
- [x] `ui-lib` unit tests
- [x] ktlint + detektAll clean
- [x] On-device: fresh install, real Keystone hardware, full CHP voting round — Scan Signature no longer loops, signature applies, vote submits successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)