### PR TITLE
MOB-1739: Expressive spring press feedback across interactive components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added:
+
+- Buttons, rows, and other interactive elements now respond to touch with a subtle expressive press animation.
+
 ### Changed:
 
 - Bottom sheets across the app now share one background color.

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Checkbox.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/Checkbox.kt
@@ -1,14 +1,17 @@
 package co.electriccoin.zcash.ui.design.component
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -19,6 +22,8 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
+import co.electriccoin.zcash.ui.design.util.PressMorphDefaults
+import co.electriccoin.zcash.ui.design.util.pressMorph
 
 @Preview
 @Composable
@@ -74,13 +79,19 @@ fun LabeledCheckBox(
 ) {
     val (checkedState, setCheckedState) = rememberSaveable { mutableStateOf(checked) }
 
+    val interactionSource = remember { MutableInteractionSource() }
+
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier =
             modifier.then(
                 Modifier
+                    .pressMorph(interactionSource, PressMorphDefaults.PRESSED_SCALE_SUBTLE)
                     .clip(RoundedCornerShape(ZcashTheme.dimens.regularRippleEffectCorner))
-                    .clickable {
+                    .clickable(
+                        interactionSource = interactionSource,
+                        indication = ripple()
+                    ) {
                         setCheckedState(!checkedState)
                         onCheckedChange(!checkedState)
                     }

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/SwitchWithLabel.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/SwitchWithLabel.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.semantics.Role
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
+import co.electriccoin.zcash.ui.design.util.PressMorphDefaults
+import co.electriccoin.zcash.ui.design.util.pressMorph
 
 @Composable
 fun SwitchWithLabel(
@@ -26,6 +28,7 @@ fun SwitchWithLabel(
     ConstraintLayout(
         modifier =
             modifier
+                .pressMorph(interactionSource, PressMorphDefaults.PRESSED_SCALE_SUBTLE)
                 .clickable(
                     interactionSource = interactionSource,
                     // disable ripple

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiAssetCard.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiAssetCard.kt
@@ -31,29 +31,32 @@ import co.electriccoin.zcash.ui.design.util.StringResourceColor
 import co.electriccoin.zcash.ui.design.util.StyledStringStyle
 import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.imageRes
+import co.electriccoin.zcash.ui.design.util.pressMorph
 import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.design.util.withStyle
 import com.valentinilk.shimmer.shimmer
 
 @Composable
 fun ZashiAssetCard(state: AssetCardState, modifier: Modifier = Modifier) {
+    val interactionSource = remember { MutableInteractionSource() }
+
     Card(
-        modifier = modifier,
+        modifier = modifier.pressMorph(interactionSource),
         onClick = state.onClick.takeIf { state.isEnabled }
     ) {
-        Content(state)
+        Content(state, interactionSource)
     }
 }
 
 @Composable
-private fun Content(state: AssetCardState) {
+private fun Content(state: AssetCardState, interactionSource: MutableInteractionSource) {
     val onClick = state.onClick
     val clickModifier =
         if (onClick != null) {
             Modifier.clickable(
                 onClick = onClick,
                 indication = null,
-                interactionSource = remember { MutableInteractionSource() }
+                interactionSource = interactionSource
             )
         } else {
             Modifier

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiBigIconButton.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiBigIconButton.kt
@@ -33,6 +33,7 @@ import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
 import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.orDark
+import co.electriccoin.zcash.ui.design.util.pressMorph
 import co.electriccoin.zcash.ui.design.util.stringRes
 
 @Suppress("MagicNumber")
@@ -63,7 +64,7 @@ fun ZashiBigIconButton(
             Modifier.background(darkBgGradient)
 
     Surface(
-        modifier = modifier,
+        modifier = modifier.pressMorph(interactionSource),
         onClick = state.onClick,
         color = ZashiColors.Surfaces.bgPrimary,
         shape = RoundedCornerShape(22.dp),

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiButton.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiButton.kt
@@ -3,6 +3,7 @@ package co.electriccoin.zcash.ui.design.component
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
@@ -43,6 +44,7 @@ import co.electriccoin.zcash.ui.design.theme.colors.ZashiColorsInternal
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
 import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.design.util.getValue
+import co.electriccoin.zcash.ui.design.util.pressMorph
 import co.electriccoin.zcash.ui.design.util.steppedRotation
 import co.electriccoin.zcash.ui.design.util.stringRes
 
@@ -165,6 +167,8 @@ fun ZashiButton(
 
     val haptic = LocalHapticFeedback.current
 
+    val interactionSource = remember { MutableInteractionSource() }
+
     Button(
         onClick =
             if (state.hapticFeedbackType != null) {
@@ -175,7 +179,8 @@ fun ZashiButton(
             } else {
                 state.onClick
             },
-        modifier = modifier,
+        modifier = modifier.pressMorph(interactionSource),
+        interactionSource = interactionSource,
         shape = shape,
         contentPadding = contentPadding,
         enabled = state.isEnabled,

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiCardButton.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiCardButton.kt
@@ -3,6 +3,7 @@ package co.electriccoin.zcash.ui.design.component
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,7 +11,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -22,7 +25,9 @@ import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.dimensions.ZashiDimensions
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
+import co.electriccoin.zcash.ui.design.util.PressMorphDefaults
 import co.electriccoin.zcash.ui.design.util.getValue
+import co.electriccoin.zcash.ui.design.util.pressMorph
 import co.electriccoin.zcash.ui.design.util.stringRes
 
 @Composable
@@ -32,10 +37,17 @@ fun ZashiCardButton(
 ) {
     val haptic = LocalHapticFeedback.current
 
+    val interactionSource = remember { MutableInteractionSource() }
+
     Surface(
         modifier =
             modifier
-                .clickable(enabled = state.isEnabled) {
+                .pressMorph(interactionSource, PressMorphDefaults.PRESSED_SCALE_SUBTLE)
+                .clickable(
+                    enabled = state.isEnabled,
+                    interactionSource = interactionSource,
+                    indication = ripple()
+                ) {
                     if (state.hapticFeedbackType != null) {
                         runCatching { haptic.performHapticFeedback(state.hapticFeedbackType) }
                     }

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiCheckbox.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiCheckbox.kt
@@ -7,6 +7,7 @@ import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -32,8 +34,10 @@ import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.dimensions.ZashiDimensions
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
+import co.electriccoin.zcash.ui.design.util.PressMorphDefaults
 import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.design.util.getValue
+import co.electriccoin.zcash.ui.design.util.pressMorph
 import co.electriccoin.zcash.ui.design.util.stringRes
 
 @Composable
@@ -69,12 +73,18 @@ fun ZashiCheckbox(
     contentPadding: PaddingValues = ZashiCheckboxDefaults.contentPadding,
     textStyles: CheckboxTextStyles = ZashiCheckboxDefaults.textStyles()
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+
     Row(
         modifier =
             modifier
+                .pressMorph(interactionSource, PressMorphDefaults.PRESSED_SCALE_SUBTLE)
                 .clip(RoundedCornerShape(8.dp))
-                .clickable(onClick = state.onClick)
-                .padding(contentPadding)
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = ripple(),
+                    onClick = state.onClick
+                ).padding(contentPadding)
     ) {
         ZashiCheckboxIndicator(state.isChecked)
 

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiChipButton.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiChipButton.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,8 +14,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -31,6 +34,7 @@ import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
 import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.design.util.getValue
+import co.electriccoin.zcash.ui.design.util.pressMorph
 import co.electriccoin.zcash.ui.design.util.stringRes
 
 @Composable
@@ -47,15 +51,21 @@ fun ZashiChipButton(
 ) {
     val normalizedColor by animateColorAsState(color)
     val normalizedTextColor by animateColorAsState(textStyle.color)
+    val interactionSource = remember { MutableInteractionSource() }
     Surface(
-        modifier = modifier,
+        modifier = modifier.pressMorph(interactionSource),
         shape = shape,
         border = border,
         color = normalizedColor,
     ) {
         Row(
             modifier =
-                Modifier.clickable(onClick = state.onClick, enabled = state.isEnabled) then
+                Modifier.clickable(
+                    onClick = state.onClick,
+                    enabled = state.isEnabled,
+                    interactionSource = interactionSource,
+                    indication = ripple()
+                ) then
                     Modifier.padding
                         (contentPadding),
             verticalAlignment = Alignment.CenterVertically

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiIconButton.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiIconButton.kt
@@ -37,6 +37,7 @@ import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
 import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.design.util.getValue
+import co.electriccoin.zcash.ui.design.util.pressMorph
 import co.electriccoin.zcash.ui.design.util.stringRes
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -47,8 +48,10 @@ fun ZashiIconButton(
 ) {
     val haptic = LocalHapticFeedback.current
 
+    val interactionSource = remember { MutableInteractionSource() }
+
     Box(
-        modifier = modifier
+        modifier = modifier.pressMorph(interactionSource)
     ) {
         Box(
             modifier =
@@ -74,7 +77,7 @@ fun ZashiIconButton(
                             },
                         enabled = state.isEnabled,
                         role = Role.Button,
-                        interactionSource = remember { MutableInteractionSource() },
+                        interactionSource = interactionSource,
                         indication = ripple(bounded = false, radius = 24.dp)
                     ),
             contentAlignment = Alignment.Center
@@ -116,9 +119,11 @@ fun ZashiImageButton(
 ) {
     val haptic = LocalHapticFeedback.current
 
+    val interactionSource = remember { MutableInteractionSource() }
+
     Box(
         modifier =
-            modifier.combinedClickable(
+            modifier.pressMorph(interactionSource).combinedClickable(
                 onClick = {
                     state.hapticFeedbackType?.let {
                         runCatching { haptic.performHapticFeedback(it) }
@@ -134,7 +139,7 @@ fun ZashiImageButton(
                             it()
                         }
                     },
-                interactionSource = remember { MutableInteractionSource() },
+                interactionSource = interactionSource,
                 indication = null,
                 enabled = state.isEnabled
             )

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiPicker.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiPicker.kt
@@ -3,6 +3,7 @@ package co.electriccoin.zcash.ui.design.component
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.offset
@@ -13,6 +14,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -29,9 +31,11 @@ import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.dimensions.ZashiDimensions
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
 import co.electriccoin.zcash.ui.design.util.ImageResource
+import co.electriccoin.zcash.ui.design.util.PressMorphDefaults
 import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.imageRes
+import co.electriccoin.zcash.ui.design.util.pressMorph
 import co.electriccoin.zcash.ui.design.util.stringRes
 
 @Composable
@@ -44,9 +48,12 @@ fun ZashiPicker(
     )
     val borderColor = if (state.isEnabled) Color.Unspecified else ZashiColors.Inputs.Disabled.stroke
 
+    val interactionSource = remember { MutableInteractionSource() }
+
     Surface(
-        modifier = modifier,
+        modifier = modifier.pressMorph(interactionSource, PressMorphDefaults.PRESSED_SCALE_SUBTLE),
         onClick = { if (state.isEnabled) state.onClick() },
+        interactionSource = interactionSource,
         shape = RoundedCornerShape(ZashiDimensions.Radius.radiusLg),
         color = bgColor,
         border = if (borderColor.isUnspecified) null else BorderStroke(1.dp, borderColor)

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiRadioButton.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiRadioButton.kt
@@ -39,8 +39,10 @@ import co.electriccoin.zcash.ui.design.newcomponent.PreviewScreens
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
+import co.electriccoin.zcash.ui.design.util.PressMorphDefaults
 import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.design.util.getValue
+import co.electriccoin.zcash.ui.design.util.pressMorph
 import co.electriccoin.zcash.ui.design.util.stringRes
 
 @Suppress("LongParameterList", "LongMethod")
@@ -56,14 +58,17 @@ fun ZashiRadioButton(
 ) {
     val haptic = LocalHapticFeedback.current
 
+    val interactionSource = remember { MutableInteractionSource() }
+
     Row(
         modifier =
             modifier
+                .pressMorph(interactionSource, PressMorphDefaults.PRESSED_SCALE_SUBTLE)
                 .clip(RoundedCornerShape(12.dp))
                 .clickable(
                     enabled = state.isEnabled,
                     indication = if (isRippleEnabled) ripple() else null,
-                    interactionSource = remember { MutableInteractionSource() },
+                    interactionSource = interactionSource,
                     onClick =
                         if (state.hapticFeedbackType != null) {
                             {

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiTextButton.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiTextButton.kt
@@ -1,15 +1,18 @@
 package co.electriccoin.zcash.ui.design.component
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
+import co.electriccoin.zcash.ui.design.util.pressMorph
 
 @Composable
 fun ZashiTextButton(
@@ -19,9 +22,12 @@ fun ZashiTextButton(
     colors: ButtonColors = ZashiTextButtonDefaults.colors(),
     content: @Composable RowScope.() -> Unit
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+
     TextButton(
         onClick = onClick,
-        modifier = modifier,
+        modifier = modifier.pressMorph(interactionSource),
+        interactionSource = interactionSource,
         shape = RoundedCornerShape(12.dp),
         enabled = enabled,
         colors = colors,

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/listitem/BaseListItem.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/listitem/BaseListItem.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
+import co.electriccoin.zcash.ui.design.util.PressMorphDefaults
+import co.electriccoin.zcash.ui.design.util.pressMorph
 
 @Composable
 fun BaseListItem(
@@ -37,8 +39,10 @@ fun BaseListItem(
     color: Color = Color.Transparent,
     content: @Composable (Modifier) -> Unit,
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+
     Surface(
-        modifier = modifier,
+        modifier = modifier.pressMorph(interactionSource, PressMorphDefaults.PRESSED_SCALE_SUBTLE),
         shape = shape,
         color = color,
         border = border,
@@ -46,7 +50,7 @@ fun BaseListItem(
         tonalElevation = 0.dp,
     ) {
         Box(
-            modifier = clickableModifier(remember { MutableInteractionSource() }, onClick)
+            modifier = clickableModifier(interactionSource, onClick)
         ) {
             Column {
                 Row(

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/listitem/checkbox/ZashiExpandedCheckboxListItem.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/listitem/checkbox/ZashiExpandedCheckboxListItem.kt
@@ -34,10 +34,12 @@ import co.electriccoin.zcash.ui.design.newcomponent.PreviewScreens
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
+import co.electriccoin.zcash.ui.design.util.PressMorphDefaults
 import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.design.util.StyledStringResource
 import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.imageRes
+import co.electriccoin.zcash.ui.design.util.pressMorph
 import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.design.util.withStyle
 
@@ -136,8 +138,10 @@ private fun ExpandedBaseListItem(
     border: BorderStroke? = null,
     content: @Composable (Modifier) -> Unit,
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+
     Surface(
-        modifier = modifier,
+        modifier = modifier.pressMorph(interactionSource, PressMorphDefaults.PRESSED_SCALE_SUBTLE),
         shape = shape,
         color = Color.Transparent,
         border = border,
@@ -146,7 +150,7 @@ private fun ExpandedBaseListItem(
     ) {
         Column(
             modifier =
-                clickableModifier(remember { MutableInteractionSource() }, onClick)
+                clickableModifier(interactionSource, onClick)
                     .padding(contentPadding)
         ) {
             Row(

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/theme/ZcashTheme.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/theme/ZcashTheme.kt
@@ -6,12 +6,12 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.compose.LocalActivity
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.ripple.RippleAlpha
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalRippleConfiguration
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RippleConfiguration
-import androidx.compose.material3.RippleDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -116,7 +116,16 @@ object ZcashTheme {
 @OptIn(ExperimentalMaterial3Api::class)
 private val MaterialRippleConfig: RippleConfiguration
     @Composable
-    get() = RippleConfiguration(color = LocalContentColor.current, rippleAlpha = RippleDefaults.RippleAlpha)
+    get() = RippleConfiguration(color = LocalContentColor.current, rippleAlpha = SubtleRippleAlpha)
+
+@Suppress("MagicNumber")
+private val SubtleRippleAlpha =
+    RippleAlpha(
+        draggedAlpha = 0.08f,
+        focusedAlpha = 0.05f,
+        hoveredAlpha = 0.04f,
+        pressedAlpha = 0.05f
+    )
 
 @Suppress("MagicNumber")
 private val DefaultLightScrim = Color.argb(0xe6, 0xFF, 0xFF, 0xFF)

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/util/PressMorph.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/util/PressMorph.kt
@@ -1,0 +1,59 @@
+package co.electriccoin.zcash.ui.design.util
+
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+
+/**
+ * Scales the whole composable down with a spring while [interactionSource] reports a press, and springs it back on
+ * release.
+ *
+ * Place this at the front of the component-internal modifier chain, i.e. immediately after the caller's `modifier`,
+ * so that the entire visual - background, border, ripple and content - scales as a single layer.
+ *
+ * @param pressedScale the scale the composable shrinks to while pressed; use
+ * [PressMorphDefaults.PRESSED_SCALE_SUBTLE] for full-width rows and cards.
+ */
+@Composable
+fun Modifier.pressMorph(
+    interactionSource: InteractionSource,
+    pressedScale: Float = PressMorphDefaults.PRESSED_SCALE
+): Modifier {
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) pressedScale else PressMorphDefaults.UNPRESSED_SCALE,
+        animationSpec = if (isPressed) PressMorphDefaults.pressSpring else PressMorphDefaults.releaseSpring,
+        label = "pressMorphScale"
+    )
+    return this.graphicsLayer {
+        scaleX = scale
+        scaleY = scale
+    }
+}
+
+object PressMorphDefaults {
+    const val UNPRESSED_SCALE = 1f
+
+    const val PRESSED_SCALE = 0.97f
+
+    const val PRESSED_SCALE_SUBTLE = 0.985f
+
+    val pressSpring: AnimationSpec<Float> =
+        spring(
+            stiffness = Spring.StiffnessHigh,
+            dampingRatio = Spring.DampingRatioMediumBouncy
+        )
+
+    val releaseSpring: AnimationSpec<Float> =
+        spring(
+            stiffness = Spring.StiffnessMediumLow,
+            dampingRatio = Spring.DampingRatioMediumBouncy
+        )
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/view/SendView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/view/SendView.kt
@@ -78,6 +78,7 @@ import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
 import co.electriccoin.zcash.ui.design.util.StringResource.Companion.NUMBER_FORMAT_LOCALE
 import co.electriccoin.zcash.ui.design.util.getString
 import co.electriccoin.zcash.ui.design.util.getValue
+import co.electriccoin.zcash.ui.design.util.pressMorph
 import co.electriccoin.zcash.ui.design.util.scaffoldPadding
 import co.electriccoin.zcash.ui.design.util.stringResByFiatDisplayName
 import co.electriccoin.zcash.ui.screen.balances.BalanceWidget
@@ -464,17 +465,21 @@ fun SendFormAddressTextField(
             suffix =
                 if (hasCameraFeature) {
                     {
+                        val addressBookInteractionSource = remember { MutableInteractionSource() }
+                        val scannerInteractionSource = remember { MutableInteractionSource() }
+
                         Row(
                             verticalAlignment = Alignment.Top
                         ) {
                             Image(
                                 modifier =
                                     Modifier
+                                        .pressMorph(addressBookInteractionSource)
                                         .clickable(
                                             onClick = sendAddressBookState.onButtonClick,
                                             role = Role.Button,
                                             indication = ripple(radius = 4.dp),
-                                            interactionSource = remember { MutableInteractionSource() }
+                                            interactionSource = addressBookInteractionSource
                                         ).testTag(SendTag.SEND_ADDRESS_BOOK_BUTTON),
                                 painter = painterResource(sendAddressBookState.mode.icon),
                                 contentDescription = stringResource(R.string.send_address_book_content_description),
@@ -485,11 +490,12 @@ fun SendFormAddressTextField(
                             Image(
                                 modifier =
                                     Modifier
+                                        .pressMorph(scannerInteractionSource)
                                         .clickable(
                                             onClick = onQrScannerOpen,
                                             role = Role.Button,
                                             indication = ripple(radius = 4.dp),
-                                            interactionSource = remember { MutableInteractionSource() }
+                                            interactionSource = scannerInteractionSource
                                         ).testTag(SendTag.SEND_SCAN_BUTTON),
                                 painter = painterResource(R.drawable.qr_code_icon),
                                 contentDescription = stringResource(R.string.send_scan_content_description),

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactiondetail/infoitems/TransactionDetailInfoColumn.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactiondetail/infoitems/TransactionDetailInfoColumn.kt
@@ -20,8 +20,10 @@ import co.electriccoin.zcash.ui.design.newcomponent.PreviewScreens
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
+import co.electriccoin.zcash.ui.design.util.PressMorphDefaults
 import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.design.util.getValue
+import co.electriccoin.zcash.ui.design.util.pressMorph
 import co.electriccoin.zcash.ui.design.util.stringRes
 
 @Composable
@@ -29,14 +31,17 @@ fun TransactionDetailInfoColumn(
     state: TransactionDetailInfoColumnState,
     modifier: Modifier = Modifier
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
     val clickModifier =
         if (state.onClick != null) {
-            Modifier.clickable(
-                indication = ripple(),
-                interactionSource = remember { MutableInteractionSource() },
-                onClick = state.onClick,
-                role = Role.Button,
-            )
+            Modifier
+                .pressMorph(interactionSource, PressMorphDefaults.PRESSED_SCALE_SUBTLE)
+                .clickable(
+                    indication = ripple(),
+                    interactionSource = interactionSource,
+                    onClick = state.onClick,
+                    role = Role.Button,
+                )
         } else {
             Modifier
         }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactiondetail/infoitems/TransactionDetailInfoMemo.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactiondetail/infoitems/TransactionDetailInfoMemo.kt
@@ -38,8 +38,10 @@ import co.electriccoin.zcash.ui.design.newcomponent.PreviewScreens
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
+import co.electriccoin.zcash.ui.design.util.PressMorphDefaults
 import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.design.util.getValue
+import co.electriccoin.zcash.ui.design.util.pressMorph
 import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.screen.transactiondetail.info.TransactionDetailMemoState
 import co.electriccoin.zcash.ui.screen.transactiondetail.info.TransactionDetailMemosState
@@ -179,12 +181,16 @@ private fun TransactionDetailInfoMemo(
     state: TransactionDetailInfoMemoState,
     modifier: Modifier = Modifier
 ) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val bottomButtonInteractionSource = remember { MutableInteractionSource() }
+
     Surface(
         modifier =
-            modifier then
-                Modifier.clickable(
+            modifier
+                .pressMorph(interactionSource, PressMorphDefaults.PRESSED_SCALE_SUBTLE)
+                .clickable(
                     indication = ripple(),
-                    interactionSource = remember { MutableInteractionSource() },
+                    interactionSource = interactionSource,
                     onClick = state.onClick,
                     role = Role.Button,
                 ),
@@ -216,10 +222,11 @@ private fun TransactionDetailInfoMemo(
                 Row(
                     modifier =
                         Modifier
+                            .pressMorph(bottomButtonInteractionSource, PressMorphDefaults.PRESSED_SCALE_SUBTLE)
                             .fillMaxWidth()
                             .clickable(
                                 indication = ripple(),
-                                interactionSource = remember { MutableInteractionSource() },
+                                interactionSource = bottomButtonInteractionSource,
                                 onClick = state.bottomButton.onClick,
                                 role = Role.Button,
                             ).padding(12.dp),

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactionhistory/Activity.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactionhistory/Activity.kt
@@ -40,10 +40,12 @@ import co.electriccoin.zcash.ui.design.theme.ZcashTheme
 import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
 import co.electriccoin.zcash.ui.design.util.Itemizable
+import co.electriccoin.zcash.ui.design.util.PressMorphDefaults
 import co.electriccoin.zcash.ui.design.util.StringResource
 import co.electriccoin.zcash.ui.design.util.StyledStringResource
 import co.electriccoin.zcash.ui.design.util.getValue
 import co.electriccoin.zcash.ui.design.util.orHiddenString
+import co.electriccoin.zcash.ui.design.util.pressMorph
 import co.electriccoin.zcash.ui.design.util.stringRes
 
 @Composable
@@ -56,6 +58,8 @@ fun Activity(
         state.onDisplayed()
     }
 
+    val interactionSource = remember { MutableInteractionSource() }
+
     Surface(
         modifier = modifier,
         shape = RoundedCornerShape(16.dp),
@@ -66,9 +70,10 @@ fun Activity(
         Row(
             modifier =
                 Modifier
+                    .pressMorph(interactionSource, PressMorphDefaults.PRESSED_SCALE_SUBTLE)
                     .clickable(
                         indication = ripple(),
-                        interactionSource = remember { MutableInteractionSource() },
+                        interactionSource = interactionSource,
                         onClick = state.onClick,
                         role = Role.Button,
                     ).padding(contentPadding),


### PR DESCRIPTION
## Summary

Adds a spring-based "expressive" press feedback modifier and wires it across interactive components.

* Adds `Modifier.pressMorph`: scale-only spring press feedback, with a deliberately slow release at `StiffnessMediumLow`.
* Wires it across all interactive Zashi components, plus subtle ripple alphas (`SubtleRippleAlpha`).
* Expressive M3 APIs are internal to Material3, so this is hand-rolled rather than using the framework's Expressive components.

Part of MOB-1724 — implements MOB-1739.

## Test plan

- [ ] `./gradlew :zashi-android:ktlintFormat` — no reformat
- [ ] `./gradlew :zashi-android:app:assembleZcashmainnetStoreDebug` — builds
- [ ] Manually verify press feedback (scale + release timing) across buttons, rows, and other interactive components throughout the app

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [ ] **Run the app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
