### PR TITLE
fix(migration): gate custom-server Tor warning on the endpoint, not on manual mode

### DIFF
--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetMigrationPrivacyOrReviewDestinationUseCase.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetMigrationPrivacyOrReviewDestinationUseCase.kt
@@ -9,9 +9,11 @@ import co.electriccoin.zcash.ui.screen.migration.privacy.MigrationPrivacyArgs
 import co.electriccoin.zcash.ui.screen.migration.review.MigrationReviewArgs
 
 /**
- * A custom (non-automatic) server can't broadcast the migration transaction over Tor at all —
- * unlike the global Tor toggle, this isn't a preference to honor, so it takes priority over the
- * toggle check below and is shown regardless of whether Tor is already the user's global setting.
+ * A custom (non-bundled) server can't broadcast the migration transaction over Tor at all — unlike
+ * the global Tor toggle, this isn't a preference to honor, so it takes priority over the toggle
+ * check below and is shown regardless of whether Tor is already the user's global setting. Note
+ * this is narrower than "manual mode": manually pinning one of our own bundled servers is still
+ * fine for Tor broadcast, so the check is on the endpoint itself, not just automatic-vs-manual.
  *
  * Otherwise, the Tor sheet only has something to offer when Tor isn't already the user's global
  * setting — if it's already on, both migration entry points skip straight past it. What "past it"
@@ -25,7 +27,7 @@ class GetMigrationPrivacyOrReviewDestinationUseCase(
     private val automaticServerRepository: AutomaticServerRepository,
 ) {
     suspend operator fun invoke(mode: MigrationMode): Any {
-        if (!automaticServerRepository.isServerAutomatic()) return MigrationCustomServerTorArgs(mode = mode)
+        if (automaticServerRepository.isServerCustom()) return MigrationCustomServerTorArgs(mode = mode)
         val torAlreadyOn = isTorEnabledStorageProvider.get() == true
         return when (mode) {
             MigrationMode.IMMEDIATE -> {

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/chooseserver/ChooseServerSelectionTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/chooseserver/ChooseServerSelectionTest.kt
@@ -227,6 +227,8 @@ private fun createViewModel(
 
             override suspend fun isServerAutomatic() = false
 
+            override suspend fun isServerCustom() = false
+
             override fun init() = Unit
         }
     return ChooseServerVM(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ServerSelectionPolicy.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ServerSelectionPolicy.kt
@@ -18,3 +18,13 @@ internal fun resolveIsServerSelectionAutomatic(
     currentEndpoint: LightWalletEndpoint?,
     knownEndpoints: List<LightWalletEndpoint>
 ): Boolean = isAutomaticPreference ?: (currentEndpoint == null || currentEndpoint in knownEndpoints)
+
+/**
+ * Whether [endpoint] is a custom, non-bundled endpoint rather than one of [knownEndpoints]. Shared by
+ * [co.electriccoin.zcash.ui.common.repository.AutomaticServerRepository] and
+ * [co.electriccoin.zcash.ui.screen.chooseserver.ChooseServerVM] so they can never disagree.
+ */
+internal fun resolveIsEndpointCustom(
+    endpoint: LightWalletEndpoint,
+    knownEndpoints: List<LightWalletEndpoint>
+): Boolean = endpoint !in knownEndpoints

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
@@ -1,5 +1,6 @@
 package co.electriccoin.zcash.ui.common.repository
 
+import co.electriccoin.zcash.ui.common.datasource.resolveIsEndpointCustom
 import co.electriccoin.zcash.ui.common.datasource.resolveIsServerSelectionAutomatic
 import co.electriccoin.zcash.ui.common.provider.ApplicationStateProvider
 import co.electriccoin.zcash.ui.common.provider.IsServerSelectionAutomaticProvider
@@ -24,6 +25,8 @@ interface AutomaticServerRepository {
     val isServerAutomatic: Flow<Boolean>
 
     suspend fun isServerAutomatic(): Boolean
+
+    suspend fun isServerCustom(): Boolean
 
     fun init()
 }
@@ -78,6 +81,14 @@ class AutomaticServerRepositoryImpl(
             currentEndpoint = currentEndpoint,
             knownEndpoints = lightWalletEndpointProvider.getEndpoints()
         )
+    }
+
+    // Manual mode alone doesn't mean the endpoint is custom, since manual mode also covers pinning
+    // one of our own bundled servers — see resolveIsEndpointCustom.
+    override suspend fun isServerCustom(): Boolean {
+        if (isServerAutomatic()) return false
+        val endpoint = persistableWalletProvider.getPersistableWallet()?.endpoint ?: return false
+        return resolveIsEndpointCustom(endpoint, lightWalletEndpointProvider.getEndpoints())
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/chooseserver/ChooseServerVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/chooseserver/ChooseServerVM.kt
@@ -10,6 +10,7 @@ import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.component.EndpointTextFieldInnerState
 import co.electriccoin.zcash.ui.common.component.EndpointTextFieldState
+import co.electriccoin.zcash.ui.common.datasource.resolveIsEndpointCustom
 import co.electriccoin.zcash.ui.common.model.FastestServersState
 import co.electriccoin.zcash.ui.common.provider.LightWalletEndpointProvider
 import co.electriccoin.zcash.ui.common.usecase.GetAutomaticEndpointUseCase
@@ -203,7 +204,7 @@ class ChooseServerVM(
                         InnerState.Persisted(
                             endpoint = endpoint,
                             isAutomatic = isAutomatic,
-                            isCustomEndpoint = endpoint !in inner.availableServers,
+                            isCustomEndpoint = resolveIsEndpointCustom(endpoint, inner.availableServers),
                         )
                     inner.copy(
                         persisted = persisted,

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/ServerSelectionPolicyTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/ServerSelectionPolicyTest.kt
@@ -78,6 +78,19 @@ class ServerSelectionPolicyTest {
         )
     }
 
+    @Test
+    fun bundledEndpointIsNotCustom() {
+        assertEquals(false, resolveIsEndpointCustom(endpoint = bundled.first(), knownEndpoints = bundled))
+    }
+
+    @Test
+    fun nonBundledEndpointIsCustom() {
+        assertEquals(
+            true,
+            resolveIsEndpointCustom(endpoint = endpoint("custom.example.com"), knownEndpoints = bundled)
+        )
+    }
+
     private fun endpoint(host: String) =
         LightWalletEndpoint(
             host = host,

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepositoryTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepositoryTest.kt
@@ -83,6 +83,41 @@ class AutomaticServerRepositoryTest {
             assertEquals(true, repository.isServerAutomatic())
         }
 
+    @Test
+    fun automaticIsNeverCustom() =
+        runTest {
+            coEvery { isAutomaticProvider.get() } returns true
+            assertEquals(false, repository.isServerCustom())
+        }
+
+    @Test
+    fun manualWithBundledEndpointIsNotCustom() =
+        runTest {
+            coEvery { isAutomaticProvider.get() } returns false
+            coEvery { persistableWalletProvider.getPersistableWallet() } returns wallet(known.last())
+
+            assertEquals(false, repository.isServerCustom())
+        }
+
+    @Test
+    fun manualWithNonBundledEndpointIsCustom() =
+        runTest {
+            coEvery { isAutomaticProvider.get() } returns false
+            coEvery { persistableWalletProvider.getPersistableWallet() } returns
+                wallet(endpoint("custom.example.com"))
+
+            assertEquals(true, repository.isServerCustom())
+        }
+
+    @Test
+    fun manualWithoutWalletIsNotCustom() =
+        runTest {
+            coEvery { isAutomaticProvider.get() } returns false
+            coEvery { persistableWalletProvider.getPersistableWallet() } returns null
+
+            assertEquals(false, repository.isServerCustom())
+        }
+
     private fun wallet(walletEndpoint: LightWalletEndpoint) =
         mockk<PersistableWallet> { every { endpoint } returns walletEndpoint }
 


### PR DESCRIPTION
## Summary
- The migration "custom server, Tor won't work" bottom sheet was gated on `AutomaticServerRepository.isServerAutomatic()` being false — i.e. on Manual mode in general. Manual mode also covers manually pinning one of our own bundled servers, which isn't a "custom server" in the sense the sheet's copy describes.
- Reported by Milan: he had a bundled server manually selected (not a self-typed endpoint) and still hit the "custom server, Tor won't work" warning during migration.
- Adds `resolveIsEndpointCustom()` to `ServerSelectionPolicy.kt` (the existing single-source-of-truth file for Automatic/Manual resolution), and uses it from both `AutomaticServerRepository.isServerCustom()` (new, used by `GetMigrationPrivacyOrReviewDestinationUseCase` to gate the Tor sheet) and `ChooseServerVM` (replacing its own inline `endpoint !in knownEndpoints` check), so the two call sites can't drift apart again.

## Test plan
- [x] `:ui-lib:compileZcashmainnetInternalDebugKotlin` / `:feature-migration:compileZcashmainnetInternalDebugKotlin` — build succeeds
- [x] `AutomaticServerRepositoryTest` (new `isServerCustom()` cases) — pass
- [x] `ServerSelectionPolicyTest` (new `resolveIsEndpointCustom()` cases) — pass
- [ ] Manual repro on device: select a bundled server manually in Server Setup, then start migration — confirm the Tor warning no longer appears (custom endpoint should still trigger it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)