### PR TITLE
MOB-1740: Force -night resource resolution to match the resolved theme

### DIFF
--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/theme/ZcashTheme.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/theme/ZcashTheme.kt
@@ -1,6 +1,7 @@
 package co.electriccoin.zcash.ui.design.theme
 
 import android.graphics.Color
+import android.view.ContextThemeWrapper
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.LocalActivity
@@ -15,8 +16,13 @@ import androidx.compose.material3.RippleDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import co.electriccoin.zcash.ui.design.LocalKeyboardManager
+import co.electriccoin.zcash.ui.design.component.ConfigurationOverride
+import co.electriccoin.zcash.ui.design.component.UiMode
 import co.electriccoin.zcash.ui.design.rememberKeyboardManager
 import co.electriccoin.zcash.ui.design.theme.balances.LocalBalancesAvailable
 import co.electriccoin.zcash.ui.design.theme.colors.DarkZashiColorsInternal
@@ -94,8 +100,44 @@ fun ZcashTheme(
             MaterialTheme(
                 colorScheme = baseColors,
                 typography = PrimaryTypography,
-                content = content
-            )
+            ) {
+                // Compose color locals above don't affect resource-qualifier resolution (drawable-night,
+                // values-night, ...) - that's driven by the real Configuration.uiMode, which otherwise
+                // stays whatever the device's actual light/dark setting is. Force it to match the resolved
+                // theme so -night assets aren't picked while rendering the light palette (or vice versa)
+                // whenever appearanceMode/forceDarkMode diverges from the system setting.
+                //
+                // Deliberately NOT the ConfigurationOverride composable (which wraps LocalContext via
+                // Context.createConfigurationContext) - on an Activity context that returns a context
+                // wrapping the Activity's *internal* base context, one level deeper than
+                // ContextWrapper.baseContext expects, which breaks LocalContext.componentActivity()'s
+                // single-level unwrap (KoinActivityViewModel.kt) for every screen below. ContextThemeWrapper
+                // + applyOverrideConfiguration keeps baseContext pointing at the Activity itself, matching
+                // the same safe pattern Override.kt already uses to wrap this same content root for tests.
+                val currentConfiguration = LocalConfiguration.current
+                val resolvedConfiguration =
+                    remember(currentConfiguration, useDarkMode) {
+                        ConfigurationOverride(
+                            uiMode = if (useDarkMode) UiMode.Dark else UiMode.Light,
+                            locale = null
+                        ).newConfiguration(currentConfiguration)
+                    }
+                val activityContext = LocalContext.current
+                val resolvedContext =
+                    remember(activityContext, resolvedConfiguration) {
+                        object : ContextThemeWrapper(activityContext, null) {
+                            init {
+                                applyOverrideConfiguration(resolvedConfiguration)
+                            }
+                        }
+                    }
+                CompositionLocalProvider(
+                    LocalConfiguration provides resolvedConfiguration,
+                    LocalContext provides resolvedContext
+                ) {
+                    content()
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #2447. Reported after manually testing the new AppearanceMode selector: forcing **Light** on a device with the **system in dark mode** left several icons washed-out/near-invisible (e.g. the Home screen's Receive/Send/Pay/Swap icons).

## Root cause

Compose color locals (`MaterialTheme.colorScheme`, `ZashiColors`) don't affect **resource-qualifier resolution** — `drawable-night`/`values-night` assets are picked from the real `Configuration.uiMode`, which stays whatever the device's actual light/dark setting is. Confirmed concretely: `ic_home_receive.xml` has a light variant (`strokeColor="#282622"`, near-black) and a `-night` variant (`strokeColor="#E8E8E8"`, near-white). With the system in dark mode and the app forced to Light, the resource system still picks the near-white `-night` icon, which then renders on the now-light background → invisible.

This was always a latent bug in `forceDarkMode` screens (QR scanner, etc.) too — it just never had a way to be *reached* before, since app theme could never diverge from system before this feature (dark was always either "system dark" or "OLED-on-system-dark"). Once `AppearanceMode` lets Light/Dark/OLED persist independent of the system setting, the mismatch becomes visible.

## Fix

Override `LocalConfiguration`/`LocalContext` inside `ZcashTheme` to match the resolved theme, using `ContextThemeWrapper` + `applyOverrideConfiguration` — the same safe pattern `Override.kt` already uses to wrap this exact content root for automated tests.

**Deliberately not** the existing `ConfigurationOverride` composable (`ui-design-lib/.../component/ConfigurationOverride.kt`, used narrowly today for the fullscreen QR dialog): on an Activity context, `Context.createConfigurationContext(...)` returns a context wrapping the Activity's *internal* base context — one level deeper than `ContextWrapper.baseContext` expects. That broke `LocalContext.componentActivity()`'s single-level unwrap (`KoinActivityViewModel.kt:50`) for every screen below, and reproduced as a real on-device crash before I switched approaches:

```
java.lang.ClassCastException: Context is not a ComponentActivity
	at co.electriccoin.zcash.di.KoinActivityViewModelKt.componentActivity(KoinActivityViewModel.kt:50)
```

`ContextThemeWrapper(activityContext, null).apply { applyOverrideConfiguration(...) }` keeps `baseContext` pointing directly at the Activity, so that unwrap still succeeds.

## Test plan

- [x] `./gradlew :zodl-android:ui-lib:testZcashmainnetStoreDebugUnitTest :zodl-android:ui-design-lib:testDebugUnitTest` — all pass
- [x] `./gradlew :zodl-android:ktlint` — clean
- [x] Built DIM, installed on an emulator with system dark mode, forced **Light** in Advanced Settings → Theme: confirmed no crash, Home screen Receive/Send/Pay/Swap icons now render correctly (dark strokes on light background) instead of near-invisible
- [ ] Manually re-verify the always-dark screens (QR scanner, etc.) on both system-light and system-dark devices, since this fix also changes their resource resolution as a side effect (previously silently wrong in the same way, just unreached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)