### PR TITLE
MOB-1740: Turn OLED into a checkbox instead of a fourth radio option

### DIFF
--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/theme/AppearanceMode.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/theme/AppearanceMode.kt
@@ -1,19 +1,13 @@
 package co.electriccoin.zcash.ui.design.theme
 
 /**
- * The user's chosen appearance for the app. [SYSTEM] follows the device's light/dark setting and never
- * auto-resolves to [OLED] - pure black is always an explicit choice.
+ * The user's chosen light/dark appearance for the app. [SYSTEM] follows the device's setting.
+ *
+ * Pure black (OLED) is not a value here - it's an independent on/off modifier ([ZcashTheme]'s `isOledEnabled`)
+ * layered on top of whichever mode resolves to dark, since it only ever makes sense alongside a dark appearance.
  */
 enum class AppearanceMode {
     SYSTEM,
     LIGHT,
     DARK,
-    OLED,
 }
-
-/**
- * Whether [this] forces a dark appearance unconditionally, independent of the system setting. [AppearanceMode.SYSTEM]
- * defers to the platform instead and is not covered here.
- */
-val AppearanceMode.forcesDark: Boolean
-    get() = this == AppearanceMode.DARK || this == AppearanceMode.OLED

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/theme/ZcashTheme.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/theme/ZcashTheme.kt
@@ -49,9 +49,12 @@ import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypographyInternal
  *
  * @param forceDarkMode Set this to true to force the app to use the dark mode theme, which is helpful, e.g.,
  * for the compose previews. The user's [appearanceMode] light/dark choice is ignored while this is true, but
- * its OLED-ness (pure black vs. classic dark) still applies.
- * @param appearanceMode The user's chosen appearance. Defaults to the value provided by an enclosing
+ * [isOledEnabled] still applies.
+ * @param appearanceMode The user's chosen light/dark appearance. Defaults to the value provided by an enclosing
  * [ZcashTheme] so that nested, always-dark screens inherit the user's choice.
+ * @param isOledEnabled Whether pure black should be used whenever the theme resolves to dark. Independent of
+ * [appearanceMode] - it applies under [AppearanceMode.DARK] just as much as under [AppearanceMode.SYSTEM]
+ * resolving to dark. Defaults to the value provided by an enclosing [ZcashTheme].
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -59,13 +62,14 @@ fun ZcashTheme(
     forceDarkMode: Boolean = false,
     balancesAvailable: Boolean = true,
     appearanceMode: AppearanceMode = LocalAppearanceMode.current,
+    isOledEnabled: Boolean = LocalOledEnabled.current,
     content: @Composable () -> Unit
 ) {
     val useDarkMode =
         forceDarkMode ||
-            appearanceMode.forcesDark ||
+            appearanceMode == AppearanceMode.DARK ||
             (appearanceMode == AppearanceMode.SYSTEM && isSystemInDarkTheme())
-    val useOledDark = appearanceMode == AppearanceMode.OLED
+    val useOledDark = useDarkMode && isOledEnabled
     val baseColors =
         when {
             useOledDark -> OledColorPalette
@@ -94,6 +98,7 @@ fun ZcashTheme(
         LocalRippleConfiguration provides MaterialRippleConfig,
         LocalBalancesAvailable provides balancesAvailable,
         LocalAppearanceMode provides appearanceMode,
+        LocalOledEnabled provides isOledEnabled,
         LocalKeyboardManager provides rememberKeyboardManager()
     ) {
         ProvideDimens {
@@ -203,3 +208,6 @@ private val DefaultOledScrim = Color.argb(0x80, 0x00, 0x00, 0x00)
 
 @Suppress("CompositionLocalAllowlist")
 val LocalAppearanceMode = staticCompositionLocalOf { AppearanceMode.SYSTEM }
+
+@Suppress("CompositionLocalAllowlist")
+val LocalOledEnabled = staticCompositionLocalOf { false }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/di/ProviderModule.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/di/ProviderModule.kt
@@ -27,6 +27,8 @@ import co.electriccoin.zcash.ui.common.provider.IsIronwoodAnnouncementShownStora
 import co.electriccoin.zcash.ui.common.provider.IsIronwoodAnnouncementShownStorageProviderImpl
 import co.electriccoin.zcash.ui.common.provider.IsKeepScreenOnDuringRestoreProvider
 import co.electriccoin.zcash.ui.common.provider.IsKeepScreenOnDuringRestoreProviderImpl
+import co.electriccoin.zcash.ui.common.provider.IsOledEnabledStorageProvider
+import co.electriccoin.zcash.ui.common.provider.IsOledEnabledStorageProviderImpl
 import co.electriccoin.zcash.ui.common.provider.IsServerSelectionAutomaticProvider
 import co.electriccoin.zcash.ui.common.provider.IsServerSelectionAutomaticProviderImpl
 import co.electriccoin.zcash.ui.common.provider.IsTorEnabledStorageProvider
@@ -107,6 +109,7 @@ val providerModule =
             HasSeenHowToVoteKeystoneStorageProvider::class
         singleOf(::IsTorEnabledStorageProviderImpl) bind IsTorEnabledStorageProvider::class
         singleOf(::AppearanceModeStorageProviderImpl) bind AppearanceModeStorageProvider::class
+        singleOf(::IsOledEnabledStorageProviderImpl) bind IsOledEnabledStorageProvider::class
         singleOf(::BlockchainProviderImpl) bind BlockchainProvider::class
         singleOf(::TokenIconProviderImpl) bind TokenIconProvider::class
         singleOf(::TokenNameProviderImpl) bind TokenNameProvider::class

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/MainActivity.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/MainActivity.kt
@@ -169,9 +169,11 @@ class MainActivity : FragmentActivity() {
             Override(configurationOverrideFlow) {
                 val isHideBalances by oldHomeViewModel.isHideBalances.collectAsStateWithLifecycle()
                 val appearanceMode by oldHomeViewModel.appearanceMode.collectAsStateWithLifecycle()
+                val isOledEnabled by oldHomeViewModel.isOledEnabled.collectAsStateWithLifecycle()
                 ZcashTheme(
                     balancesAvailable = isHideBalances == false,
-                    appearanceMode = appearanceMode
+                    appearanceMode = appearanceMode,
+                    isOledEnabled = isOledEnabled
                 ) {
                     BlankSurface(
                         Modifier

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/Navigator.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/Navigator.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavOptionsBuilder
 import androidx.navigation.serialization.generateHashCode
 import co.electriccoin.zcash.ui.common.provider.AppearanceModeStorageProvider
 import co.electriccoin.zcash.ui.common.provider.ApplicationStateProvider
+import co.electriccoin.zcash.ui.common.provider.IsOledEnabledStorageProvider
 import co.electriccoin.zcash.ui.common.provider.getOrSystem
 import co.electriccoin.zcash.ui.design.KeyboardManager
 import co.electriccoin.zcash.ui.screen.ExternalUrl
@@ -30,6 +31,7 @@ class NavigatorImpl(
     private val keyboardManager: KeyboardManager,
     private val applicationStateProvider: ApplicationStateProvider,
     private val appearanceModeStorageProvider: AppearanceModeStorageProvider,
+    private val isOledEnabledStorageProvider: IsOledEnabledStorageProvider,
 ) : Navigator {
     override suspend fun executeCommand(command: NavigationCommand) {
         keyboardManager.close()
@@ -182,7 +184,8 @@ class NavigatorImpl(
         WebBrowserUtil.startActivity(
             activity = activity,
             url = route.url,
-            appearanceMode = appearanceModeStorageProvider.getOrSystem()
+            appearanceMode = appearanceModeStorageProvider.getOrSystem(),
+            isOledEnabled = isOledEnabledStorageProvider.get() == true
         )
     }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/RootNavGraph.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/RootNavGraph.kt
@@ -10,6 +10,7 @@ import co.electriccoin.zcash.ui.common.compose.LocalActivity
 import co.electriccoin.zcash.ui.common.migration.MigrationAppHooks
 import co.electriccoin.zcash.ui.common.provider.AppearanceModeStorageProvider
 import co.electriccoin.zcash.ui.common.provider.ApplicationStateProvider
+import co.electriccoin.zcash.ui.common.provider.IsOledEnabledStorageProvider
 import co.electriccoin.zcash.ui.common.viewmodel.SecretState
 import co.electriccoin.zcash.ui.common.viewmodel.WalletViewModel
 import co.electriccoin.zcash.ui.design.LocalKeyboardManager
@@ -35,6 +36,7 @@ fun RootNavGraph(
     val navigationRouter = koinInject<NavigationRouter>()
     val applicationStateProvider = koinInject<ApplicationStateProvider>()
     val appearanceModeStorageProvider = koinInject<AppearanceModeStorageProvider>()
+    val isOledEnabledStorageProvider = koinInject<IsOledEnabledStorageProvider>()
     val migrationAppHooks = koinInject<MigrationAppHooks>()
     val navController = LocalNavController.current
     val activity = LocalActivity.current
@@ -45,7 +47,8 @@ fun RootNavGraph(
             flexaViewModel,
             keyboardManager,
             applicationStateProvider,
-            appearanceModeStorageProvider
+            appearanceModeStorageProvider,
+            isOledEnabledStorageProvider
         ) {
             NavigatorImpl(
                 activity = activity,
@@ -53,7 +56,8 @@ fun RootNavGraph(
                 flexaViewModel = flexaViewModel,
                 keyboardManager = keyboardManager,
                 applicationStateProvider = applicationStateProvider,
-                appearanceModeStorageProvider = appearanceModeStorageProvider
+                appearanceModeStorageProvider = appearanceModeStorageProvider,
+                isOledEnabledStorageProvider = isOledEnabledStorageProvider
             )
         }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/IsOledEnabledStorageProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/IsOledEnabledStorageProvider.kt
@@ -1,0 +1,17 @@
+package co.electriccoin.zcash.ui.common.provider
+
+import co.electriccoin.zcash.preference.StandardPreferenceProvider
+import co.electriccoin.zcash.preference.model.entry.PreferenceKey
+
+/**
+ * Whether pure black (OLED) should be used whenever the resolved [AppearanceMode][co.electriccoin.zcash.ui.design.theme.AppearanceMode]
+ * is dark. Independent of the mode itself - a null (never chosen) value resolves to false.
+ */
+interface IsOledEnabledStorageProvider : NullableBooleanStorageProvider
+
+class IsOledEnabledStorageProviderImpl(
+    override val preferenceHolder: StandardPreferenceProvider,
+) : BaseNullableBooleanStorageProvider(
+        key = PreferenceKey("is_oled_enabled"),
+    ),
+    IsOledEnabledStorageProvider

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SetAppearanceModeUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SetAppearanceModeUseCase.kt
@@ -2,14 +2,20 @@ package co.electriccoin.zcash.ui.common.usecase
 
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.common.provider.AppearanceModeStorageProvider
+import co.electriccoin.zcash.ui.common.provider.IsOledEnabledStorageProvider
 import co.electriccoin.zcash.ui.design.theme.AppearanceMode
 
 class SetAppearanceModeUseCase(
     private val navigationRouter: NavigationRouter,
     private val appearanceModeStorageProvider: AppearanceModeStorageProvider,
+    private val isOledEnabledStorageProvider: IsOledEnabledStorageProvider,
 ) {
-    suspend operator fun invoke(appearanceMode: AppearanceMode) {
+    suspend operator fun invoke(
+        appearanceMode: AppearanceMode,
+        isOledEnabled: Boolean
+    ) {
         appearanceModeStorageProvider.store(appearanceMode)
+        isOledEnabledStorageProvider.store(isOledEnabled)
         navigationRouter.back()
     }
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/OldHomeViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/OldHomeViewModel.kt
@@ -6,6 +6,7 @@ import cash.z.ecc.sdk.ANDROID_STATE_FLOW_TIMEOUT
 import co.electriccoin.zcash.preference.StandardPreferenceProvider
 import co.electriccoin.zcash.preference.model.entry.BooleanPreferenceDefault
 import co.electriccoin.zcash.ui.common.provider.AppearanceModeStorageProvider
+import co.electriccoin.zcash.ui.common.provider.IsOledEnabledStorageProvider
 import co.electriccoin.zcash.ui.design.theme.AppearanceMode
 import co.electriccoin.zcash.ui.preference.StandardPreferenceKeys
 import kotlinx.coroutines.flow.SharingStarted
@@ -19,6 +20,7 @@ import kotlinx.coroutines.flow.stateIn
 class OldHomeViewModel(
     private val standardPreferenceProvider: StandardPreferenceProvider,
     appearanceModeStorageProvider: AppearanceModeStorageProvider,
+    isOledEnabledStorageProvider: IsOledEnabledStorageProvider,
 ) : ViewModel() {
     /**
      * A flow of whether background sync is enabled
@@ -42,6 +44,19 @@ class OldHomeViewModel(
                 viewModelScope,
                 SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
                 AppearanceMode.SYSTEM
+            )
+
+    /**
+     * A flow of whether pure black (OLED) should be used whenever [appearanceMode] resolves to dark.
+     */
+    val isOledEnabled: StateFlow<Boolean> =
+        isOledEnabledStorageProvider
+            .observe()
+            .map { it == true }
+            .stateIn(
+                viewModelScope,
+                SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
+                false
             )
 
     private fun booleanStateFlow(default: BooleanPreferenceDefault): StateFlow<Boolean?> =

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/about/util/WebBrowserUtil.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/about/util/WebBrowserUtil.kt
@@ -13,14 +13,19 @@ object WebBrowserUtil {
     internal fun startActivity(
         activity: Activity,
         url: String,
-        appearanceMode: AppearanceMode
+        appearanceMode: AppearanceMode,
+        isOledEnabled: Boolean
     ) {
         val lightParams = colorSchemeParams(BrowserChromeColors.light)
         val darkParams =
-            colorSchemeParams(
-                if (appearanceMode == AppearanceMode.OLED) BrowserChromeColors.oledDark else BrowserChromeColors.dark
-            )
-        val colorSchemeBuilder =
+            colorSchemeParams(if (isOledEnabled) BrowserChromeColors.oledDark else BrowserChromeColors.dark)
+        val resolvedScheme =
+            when (appearanceMode) {
+                AppearanceMode.SYSTEM -> CustomTabsIntent.COLOR_SCHEME_SYSTEM
+                AppearanceMode.LIGHT -> CustomTabsIntent.COLOR_SCHEME_LIGHT
+                AppearanceMode.DARK -> CustomTabsIntent.COLOR_SCHEME_DARK
+            }
+        val intent =
             CustomTabsIntent
                 .Builder()
                 .setUrlBarHidingEnabled(true)
@@ -29,13 +34,8 @@ object WebBrowserUtil {
                 .setColorSchemeParams(CustomTabsIntent.COLOR_SCHEME_LIGHT, lightParams)
                 .setColorSchemeParams(CustomTabsIntent.COLOR_SCHEME_DARK, darkParams)
                 .setDefaultColorSchemeParams(lightParams)
-        val resolvedScheme =
-            when (appearanceMode) {
-                AppearanceMode.SYSTEM -> CustomTabsIntent.COLOR_SCHEME_SYSTEM
-                AppearanceMode.LIGHT -> CustomTabsIntent.COLOR_SCHEME_LIGHT
-                AppearanceMode.DARK, AppearanceMode.OLED -> CustomTabsIntent.COLOR_SCHEME_DARK
-            }
-        val intent = colorSchemeBuilder.setColorScheme(resolvedScheme).build()
+                .setColorScheme(resolvedScheme)
+                .build()
         runCatching {
             intent.launchUrl(activity, Uri.parse(url))
         }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/theme/settings/ThemeSettingsState.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/theme/settings/ThemeSettingsState.kt
@@ -5,6 +5,7 @@ import co.electriccoin.zcash.ui.design.theme.AppearanceMode
 
 internal data class ThemeSettingsState(
     val options: List<AppearanceModeOptionState>,
+    val oledCheckbox: OledCheckboxState,
     val saveButton: ButtonState,
     val onBack: () -> Unit,
 )
@@ -12,5 +13,15 @@ internal data class ThemeSettingsState(
 internal data class AppearanceModeOptionState(
     val mode: AppearanceMode,
     val isChecked: Boolean,
+    val onClick: () -> Unit,
+)
+
+/**
+ * [isEnabled] is false whenever the selected mode is [AppearanceMode.LIGHT] - pure black never applies to a
+ * theme that never renders dark, so the checkbox has nothing to modify in that case.
+ */
+internal data class OledCheckboxState(
+    val isChecked: Boolean,
+    val isEnabled: Boolean,
     val onClick: () -> Unit,
 )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/theme/settings/ThemeSettingsVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/theme/settings/ThemeSettingsVM.kt
@@ -7,6 +7,7 @@ import cash.z.ecc.sdk.ANDROID_STATE_FLOW_TIMEOUT
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.provider.AppearanceModeStorageProvider
+import co.electriccoin.zcash.ui.common.provider.IsOledEnabledStorageProvider
 import co.electriccoin.zcash.ui.common.provider.getOrSystem
 import co.electriccoin.zcash.ui.common.usecase.SetAppearanceModeUseCase
 import co.electriccoin.zcash.ui.design.component.ButtonState
@@ -15,7 +16,7 @@ import co.electriccoin.zcash.ui.design.util.stringRes
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.WhileSubscribed
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -23,15 +24,17 @@ import kotlinx.coroutines.launch
 internal class ThemeSettingsVM(
     private val navigationRouter: NavigationRouter,
     private val appearanceModeStorageProvider: AppearanceModeStorageProvider,
+    private val isOledEnabledStorageProvider: IsOledEnabledStorageProvider,
     private val setAppearanceMode: SetAppearanceModeUseCase,
 ) : ViewModel() {
     private var originalMode = AppearanceMode.SYSTEM
+    private var originalOledEnabled = false
 
     private val selectedMode = MutableStateFlow(AppearanceMode.SYSTEM)
+    private val selectedOledEnabled = MutableStateFlow(false)
 
     val state =
-        selectedMode
-            .map(::createState)
+        combine(selectedMode, selectedOledEnabled, ::createState)
             .stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
@@ -41,33 +44,48 @@ internal class ThemeSettingsVM(
     init {
         viewModelScope.launch {
             originalMode = appearanceModeStorageProvider.getOrSystem()
+            originalOledEnabled = isOledEnabledStorageProvider.get() == true
             selectedMode.update { originalMode }
+            selectedOledEnabled.update { originalOledEnabled }
         }
     }
 
-    private fun createState(selected: AppearanceMode) =
-        ThemeSettingsState(
-            options =
-                AppearanceMode.entries.map { mode ->
-                    AppearanceModeOptionState(
-                        mode = mode,
-                        isChecked = mode == selected,
-                        onClick = { onOptionClick(mode) }
-                    )
-                },
-            saveButton =
-                ButtonState(
-                    stringRes(R.string.currencyConversion_saveBtn),
-                    onClick = ::onSaveClick,
-                    isEnabled = selected != originalMode,
-                    hapticFeedbackType = HapticFeedbackType.Confirm
-                ),
-            onBack = ::onBack
-        )
+    private fun createState(
+        selectedMode: AppearanceMode,
+        oledEnabled: Boolean
+    ) = ThemeSettingsState(
+        options =
+            AppearanceMode.entries.map { mode ->
+                AppearanceModeOptionState(
+                    mode = mode,
+                    isChecked = mode == selectedMode,
+                    onClick = { onModeClick(mode) }
+                )
+            },
+        oledCheckbox =
+            OledCheckboxState(
+                isChecked = oledEnabled,
+                isEnabled = selectedMode != AppearanceMode.LIGHT,
+                onClick = ::onOledClick
+            ),
+        saveButton =
+            ButtonState(
+                stringRes(R.string.currencyConversion_saveBtn),
+                onClick = ::onSaveClick,
+                isEnabled = selectedMode != originalMode || oledEnabled != originalOledEnabled,
+                hapticFeedbackType = HapticFeedbackType.Confirm
+            ),
+        onBack = ::onBack
+    )
 
     private fun onBack() = navigationRouter.back()
 
-    private fun onOptionClick(mode: AppearanceMode) = selectedMode.update { mode }
+    private fun onModeClick(mode: AppearanceMode) = selectedMode.update { mode }
 
-    private fun onSaveClick() = viewModelScope.launch { setAppearanceMode(selectedMode.value) }
+    private fun onOledClick() = selectedOledEnabled.update { !it }
+
+    private fun onSaveClick() =
+        viewModelScope.launch {
+            setAppearanceMode(selectedMode.value, selectedOledEnabled.value)
+        }
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/theme/settings/ThemeSettingsView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/theme/settings/ThemeSettingsView.kt
@@ -1,20 +1,22 @@
 package co.electriccoin.zcash.ui.screen.theme.settings
 
-import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.design.component.BlankSurface
 import co.electriccoin.zcash.ui.design.component.ButtonState
+import co.electriccoin.zcash.ui.design.component.CheckboxState
 import co.electriccoin.zcash.ui.design.component.ZashiBaseSettingsOptIn
 import co.electriccoin.zcash.ui.design.component.ZashiButton
 import co.electriccoin.zcash.ui.design.component.ZashiButtonDefaults
+import co.electriccoin.zcash.ui.design.component.ZashiCheckbox
 import co.electriccoin.zcash.ui.design.newcomponent.PreviewScreens
 import co.electriccoin.zcash.ui.design.theme.AppearanceMode
 import co.electriccoin.zcash.ui.design.theme.ZcashTheme
@@ -22,6 +24,8 @@ import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
 import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
 import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.screen.exchangerate.settings.Option
+
+private const val DISABLED_ALPHA = 0.4f
 
 @Composable
 internal fun ThemeSettingsView(state: ThemeSettingsState) {
@@ -50,6 +54,20 @@ internal fun ThemeSettingsView(state: ThemeSettingsState) {
                     onClick = option.onClick
                 )
             }
+            Spacer(modifier = Modifier.height(20.dp))
+            ZashiCheckbox(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .alpha(if (state.oledCheckbox.isEnabled) 1f else DISABLED_ALPHA),
+                state =
+                    CheckboxState(
+                        title = stringRes(R.string.theme_settings_option_oled),
+                        subtitle = stringRes(R.string.theme_settings_option_oled_desc),
+                        isChecked = state.oledCheckbox.isChecked,
+                        onClick = if (state.oledCheckbox.isEnabled) state.oledCheckbox.onClick else ({}),
+                    ),
+            )
         },
         footer = {
             ZashiButton(
@@ -67,14 +85,11 @@ private val AppearanceMode.labels: Pair<Int, Int>
             AppearanceMode.SYSTEM -> R.string.theme_settings_option_system to R.string.theme_settings_option_system_desc
             AppearanceMode.LIGHT -> R.string.theme_settings_option_light to R.string.theme_settings_option_light_desc
             AppearanceMode.DARK -> R.string.theme_settings_option_classic to R.string.theme_settings_option_classic_desc
-            AppearanceMode.OLED -> R.string.theme_settings_option_oled to R.string.theme_settings_option_oled_desc
         }
 
-@get:StringRes
 private val AppearanceMode.titleRes: Int
     get() = labels.first
 
-@get:StringRes
 private val AppearanceMode.subtitleRes: Int
     get() = labels.second
 
@@ -84,7 +99,7 @@ private val AppearanceMode.subtitleRes: Int
 private fun ThemeSettingsPreview() =
     ZcashTheme {
         BlankSurface {
-            ThemeSettingsView(state = previewState(AppearanceMode.SYSTEM))
+            ThemeSettingsView(state = previewState(selected = AppearanceMode.SYSTEM, oledChecked = false))
         }
     }
 
@@ -92,26 +107,45 @@ private fun ThemeSettingsPreview() =
 @PreviewScreens
 @Composable
 private fun ThemeSettingsOledPreview() =
-    ZcashTheme(forceDarkMode = true, appearanceMode = AppearanceMode.OLED) {
+    ZcashTheme(forceDarkMode = true, isOledEnabled = true) {
         BlankSurface {
-            ThemeSettingsView(state = previewState(AppearanceMode.OLED))
+            ThemeSettingsView(state = previewState(selected = AppearanceMode.DARK, oledChecked = true))
         }
     }
 
-private fun previewState(selected: AppearanceMode) =
-    ThemeSettingsState(
-        options =
-            AppearanceMode.entries.map { mode ->
-                AppearanceModeOptionState(
-                    mode = mode,
-                    isChecked = mode == selected,
-                    onClick = {}
-                )
-            },
-        saveButton =
-            ButtonState(
-                text = stringRes(R.string.currencyConversion_saveBtn),
+@Suppress("UnusedPrivateMember")
+@PreviewScreens
+@Composable
+private fun ThemeSettingsLightPreview() =
+    ZcashTheme {
+        BlankSurface {
+            ThemeSettingsView(state = previewState(selected = AppearanceMode.LIGHT, oledChecked = false, oledEnabled = false))
+        }
+    }
+
+private fun previewState(
+    selected: AppearanceMode,
+    oledChecked: Boolean,
+    oledEnabled: Boolean = selected != AppearanceMode.LIGHT,
+) = ThemeSettingsState(
+    options =
+        AppearanceMode.entries.map { mode ->
+            AppearanceModeOptionState(
+                mode = mode,
+                isChecked = mode == selected,
                 onClick = {}
-            ),
-        onBack = {}
-    )
+            )
+        },
+    oledCheckbox =
+        OledCheckboxState(
+            isChecked = oledChecked,
+            isEnabled = oledEnabled,
+            onClick = {}
+        ),
+    saveButton =
+        ButtonState(
+            text = stringRes(R.string.currencyConversion_saveBtn),
+            onClick = {}
+        ),
+    onBack = {}
+)

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/screen/theme/settings/ThemeSettingsVMTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/screen/theme/settings/ThemeSettingsVMTest.kt
@@ -5,6 +5,7 @@ import co.electriccoin.zcash.ui.BaseNavigationCommand
 import co.electriccoin.zcash.ui.NavigationCommand
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.common.provider.AppearanceModeStorageProvider
+import co.electriccoin.zcash.ui.common.provider.IsOledEnabledStorageProvider
 import co.electriccoin.zcash.ui.common.usecase.SetAppearanceModeUseCase
 import co.electriccoin.zcash.ui.design.theme.AppearanceMode
 import kotlinx.coroutines.Dispatchers
@@ -29,10 +30,11 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * The Theme settings screen (MOB-1724): the stored preference decides which of the four options
- * (System/Light/Dark/OLED) is checked, Save only becomes available once the selection differs from the
- * stored one, and saving persists the choice and pops the screen. A never-chosen (null) preference
- * resolves to System.
+ * The Theme settings screen (MOB-1724): the stored appearance mode (System/Light/Dark) decides which
+ * radio option is checked. The OLED checkbox is a separate on/off modifier - enabled whenever the
+ * selected mode isn't Light (Light never renders dark, so pure black would never apply), unrelated to
+ * whether the mode itself changed. Save enables when either the mode or the OLED choice differs from
+ * what's stored, and persists both together.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class ThemeSettingsVMTest {
@@ -50,92 +52,107 @@ class ThemeSettingsVMTest {
     }
 
     @Test
-    fun neverChosenSelectsSystemWithSaveDisabled() =
+    fun neverChosenSelectsSystemWithOledUncheckedAndSaveDisabled() =
         runTest(dispatcher) {
-            val vm = startedVm(provider = FakeAppearanceModeStorageProvider(stored = null))
+            val vm = startedVm(modeProvider = FakeAppearanceModeStorageProvider(stored = null))
 
             val state = requireNotNull(vm.state.value)
             assertSingleSelection(state, AppearanceMode.SYSTEM)
+            assertFalse(state.oledCheckbox.isChecked)
+            assertTrue(state.oledCheckbox.isEnabled)
             assertFalse(state.saveButton.isEnabled)
         }
 
     @Test
-    fun storedLightSelectsLightWithSaveDisabled() =
+    fun storedOledEnabledIsReflectedInCheckbox() =
         runTest(dispatcher) {
-            val vm = startedVm(provider = FakeAppearanceModeStorageProvider(stored = AppearanceMode.LIGHT))
-
-            val state = requireNotNull(vm.state.value)
-            assertSingleSelection(state, AppearanceMode.LIGHT)
-            assertFalse(state.saveButton.isEnabled)
-        }
-
-    @Test
-    fun storedDarkSelectsDarkWithSaveDisabled() =
-        runTest(dispatcher) {
-            val vm = startedVm(provider = FakeAppearanceModeStorageProvider(stored = AppearanceMode.DARK))
+            val vm =
+                startedVm(
+                    modeProvider = FakeAppearanceModeStorageProvider(stored = AppearanceMode.DARK),
+                    oledProvider = FakeIsOledEnabledStorageProvider(stored = true)
+                )
 
             val state = requireNotNull(vm.state.value)
             assertSingleSelection(state, AppearanceMode.DARK)
+            assertTrue(state.oledCheckbox.isChecked)
+            assertTrue(state.oledCheckbox.isEnabled)
             assertFalse(state.saveButton.isEnabled)
         }
 
     @Test
-    fun storedOledSelectsOledWithSaveDisabled() =
+    fun oledCheckboxIsDisabledWhenLightIsSelected() =
         runTest(dispatcher) {
-            val vm = startedVm(provider = FakeAppearanceModeStorageProvider(stored = AppearanceMode.OLED))
+            val vm = startedVm(modeProvider = FakeAppearanceModeStorageProvider(stored = AppearanceMode.LIGHT))
 
             val state = requireNotNull(vm.state.value)
-            assertSingleSelection(state, AppearanceMode.OLED)
-            assertFalse(state.saveButton.isEnabled)
+            assertSingleSelection(state, AppearanceMode.LIGHT)
+            assertFalse(state.oledCheckbox.isEnabled)
         }
 
     @Test
-    fun togglingBackAndForthDisablesSaveAgain() =
+    fun oledCheckboxBecomesDisabledAfterSwitchingToLight() =
         runTest(dispatcher) {
-            val vm = startedVm(provider = FakeAppearanceModeStorageProvider(stored = null))
+            val vm =
+                startedVm(
+                    modeProvider = FakeAppearanceModeStorageProvider(stored = AppearanceMode.DARK),
+                    oledProvider = FakeIsOledEnabledStorageProvider(stored = true)
+                )
 
-            optionFor(requireNotNull(vm.state.value), AppearanceMode.OLED).onClick()
+            optionFor(requireNotNull(vm.state.value), AppearanceMode.LIGHT).onClick()
             advanceUntilIdle()
 
-            val oledSelected = requireNotNull(vm.state.value)
-            assertSingleSelection(oledSelected, AppearanceMode.OLED)
-            assertTrue(oledSelected.saveButton.isEnabled)
-
-            optionFor(oledSelected, AppearanceMode.SYSTEM).onClick()
-            advanceUntilIdle()
-
-            val systemSelected = requireNotNull(vm.state.value)
-            assertSingleSelection(systemSelected, AppearanceMode.SYSTEM)
-            assertFalse(systemSelected.saveButton.isEnabled)
+            val state = requireNotNull(vm.state.value)
+            assertSingleSelection(state, AppearanceMode.LIGHT)
+            assertFalse(state.oledCheckbox.isEnabled)
         }
 
     @Test
-    fun savingOledPersistsTheChoiceAndNavigatesBack() =
+    fun togglingOledAloneEnablesSave() =
         runTest(dispatcher) {
-            val provider = FakeAppearanceModeStorageProvider(stored = null)
+            val vm = startedVm(modeProvider = FakeAppearanceModeStorageProvider(stored = AppearanceMode.DARK))
+
+            requireNotNull(vm.state.value).oledCheckbox.onClick()
+            advanceUntilIdle()
+
+            val state = requireNotNull(vm.state.value)
+            assertSingleSelection(state, AppearanceMode.DARK)
+            assertTrue(state.oledCheckbox.isChecked)
+            assertTrue(state.saveButton.isEnabled)
+        }
+
+    @Test
+    fun savingPersistsBothModeAndOledChoiceAndNavigatesBack() =
+        runTest(dispatcher) {
+            val modeProvider = FakeAppearanceModeStorageProvider(stored = null)
+            val oledProvider = FakeIsOledEnabledStorageProvider(stored = null)
             val router = FakeNavigationRouter()
-            val vm = startedVm(provider = provider, router = router)
+            val vm = startedVm(modeProvider = modeProvider, oledProvider = oledProvider, router = router)
 
-            optionFor(requireNotNull(vm.state.value), AppearanceMode.OLED).onClick()
+            optionFor(requireNotNull(vm.state.value), AppearanceMode.DARK).onClick()
+            advanceUntilIdle()
+            requireNotNull(vm.state.value).oledCheckbox.onClick()
             advanceUntilIdle()
             requireNotNull(vm.state.value).saveButton.onClick()
             advanceUntilIdle()
 
-            assertEquals(AppearanceMode.OLED, provider.stored)
+            assertEquals(AppearanceMode.DARK, modeProvider.stored)
+            assertEquals(true, oledProvider.stored)
             assertEquals(1, router.backCount)
         }
 
     @Test
     fun backDismissesWithoutChangingAnything() =
         runTest(dispatcher) {
-            val provider = FakeAppearanceModeStorageProvider(stored = null)
+            val modeProvider = FakeAppearanceModeStorageProvider(stored = null)
+            val oledProvider = FakeIsOledEnabledStorageProvider(stored = null)
             val router = FakeNavigationRouter()
-            val vm = startedVm(provider = provider, router = router)
+            val vm = startedVm(modeProvider = modeProvider, oledProvider = oledProvider, router = router)
 
             requireNotNull(vm.state.value).onBack()
 
             assertEquals(1, router.backCount)
-            assertNull(provider.stored)
+            assertNull(modeProvider.stored)
+            assertNull(oledProvider.stored)
         }
 
     private fun assertSingleSelection(
@@ -157,14 +174,16 @@ class ThemeSettingsVMTest {
     ) = state.options.first { it.mode == mode }
 
     private fun TestScope.startedVm(
-        provider: FakeAppearanceModeStorageProvider = FakeAppearanceModeStorageProvider(stored = null),
+        modeProvider: FakeAppearanceModeStorageProvider = FakeAppearanceModeStorageProvider(stored = null),
+        oledProvider: FakeIsOledEnabledStorageProvider = FakeIsOledEnabledStorageProvider(stored = null),
         router: FakeNavigationRouter = FakeNavigationRouter(),
     ): ThemeSettingsVM {
         val vm =
             ThemeSettingsVM(
                 navigationRouter = router,
-                appearanceModeStorageProvider = provider,
-                setAppearanceMode = SetAppearanceModeUseCase(router, provider)
+                appearanceModeStorageProvider = modeProvider,
+                isOledEnabledStorageProvider = oledProvider,
+                setAppearanceMode = SetAppearanceModeUseCase(router, modeProvider, oledProvider)
             )
         backgroundScope.launch { vm.state.collect { } }
         advanceUntilIdle()
@@ -185,6 +204,25 @@ private class FakeAppearanceModeStorageProvider(
     }
 
     override fun observe(): Flow<AppearanceMode?> = emptyFlow()
+
+    override suspend fun clear() {
+        stored = null
+    }
+}
+
+private class FakeIsOledEnabledStorageProvider(
+    stored: Boolean?
+) : IsOledEnabledStorageProvider {
+    var stored: Boolean? = stored
+        private set
+
+    override suspend fun get(): Boolean? = stored
+
+    override suspend fun store(amount: Boolean) {
+        stored = amount
+    }
+
+    override fun observe(): Flow<Boolean?> = emptyFlow()
 
     override suspend fun clear() {
         stored = null


### PR DESCRIPTION
## Summary

Requested change to the Theme settings UX from #2447: pure black (OLED) shouldn't be a standalone fourth radio option — it only ever makes sense as a modifier on top of whichever choice already renders dark.

- `AppearanceMode` drops `OLED` and is now just `SYSTEM` / `LIGHT` / `DARK`.
- OLED-ness becomes an independent, separately-persisted boolean (`IsOledEnabledStorageProvider`, new key `is_oled_enabled`), applied by `ZcashTheme` whenever the resolved theme is dark — reachable from **both** `System` (when the device itself is dark) and `Dark`, not tied to a single radio value like before.
- Theme settings screen: 3-option radio list (System / Light / Dark) + a "Pure black" checkbox below, **disabled whenever Light is selected** — a theme that never renders dark has nothing for the checkbox to modify.

## Why System can carry OLED again

The previous 4-way design (#2447) deliberately made OLED an explicit-only radio choice, unreachable from System, specifically to avoid re-introducing "system-driven pure-black" as an implicit combination. This PR reverses that specific call per direct product feedback: `System` + `Pure black` checked is now exactly "follow the device's light/dark setting, but use true black instead of charcoal whenever it's dark" — the same combination the original OLED-only design (before the 4-way rework) already supported.

## Test plan

- [x] `./gradlew :zodl-android:ui-lib:testZcashmainnetStoreDebugUnitTest :zodl-android:ui-design-lib:testDebugUnitTest` — all pass (7/7 in `ThemeSettingsVMTest`, covering: checkbox reflects stored OLED value, checkbox disables when Light is selected, checkbox re-disables after switching to Light mid-session, toggling OLED alone enables Save, saving persists both values together)
- [x] `./gradlew :zodl-android:ktlint` — clean
- [x] Built DIM, installed on an emulator, walked the full flow by hand: selected Light → checkbox greys out; selected Classic dark → checkbox re-enables; checked Pure black → Save; app immediately renders pure black. No crash, verified via logcat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)