### PR TITLE
MOB-1748: UI nits from 3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed:
 
-- We polished several UI details: the swap quote review header now blends into the screen background, the Activity header frost fades out more
-  gently, the Terms of Service icon matches the Privacy Policy one, and the Ironwood migration screens scroll properly on small displays.
+- We polished several UI details: the swap quote review header now stands out from the sheet background, the Activity header turns frosted
+  sooner so it stays readable while you scroll, the Terms of Service icon matches the Privacy Policy one, and the Ironwood migration screens
+  scroll properly on small displays.
 - Shielded coinholder polling works again after the voting infrastructure's v1.3.0 upgrade: the app now reads the PIR polynomial length from the
   voting configuration, verifies the new round-attestation signature format, and submits vote shares with the round binding the voting server
   requires. Rounds signed with the old attestation format are no longer shown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed:
 
+- We polished several UI details: the swap quote review header now blends into the screen background, the Activity header frost fades out more
+  gently, the Terms of Service icon matches the Privacy Policy one, and the Ironwood migration screens scroll properly on small displays.
 - Shielded coinholder polling works again after the voting infrastructure's v1.3.0 upgrade: the app now reads the PIR polynomial length from the
   voting configuration, verifies the new round-attestation signature format, and submits vote shares with the round binding the voting server
   requires. Rounds signed with the old attestation format are no longer shown.

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteScreen.kt
@@ -133,61 +133,57 @@ fun MigrationCompleteView(state: MigrationCompleteState) {
                         .scaffoldPadding(padding),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
+                Spacer(Modifier.weight(1f))
+                Image(
+                    painter = painterResource(co.electriccoin.zcash.migration.R.drawable.ic_migration_complete),
+                    contentDescription = null,
+                    modifier = Modifier.size(52.dp),
+                )
+                Spacer(Modifier.height(24.dp))
+                Text(
+                    text = stringRes(DesignR.string.migrationComplete_title).getValue(),
+                    style = ZashiTypography.header5,
+                    fontWeight = FontWeight.SemiBold,
+                    color = ZashiColors.Text.textPrimary,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = stringRes(DesignR.string.migrationComplete_subtitle).getValue(),
+                    style = ZashiTypography.textSm,
+                    color = ZashiColors.Text.textTertiary,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(Modifier.height(24.dp))
                 Column(
-                    Modifier.weight(1f),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(16.dp))
+                            .background(ZashiColors.Surfaces.bgSecondary)
+                            .padding(20.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
-                    Image(
-                        painter = painterResource(co.electriccoin.zcash.migration.R.drawable.ic_migration_complete),
-                        contentDescription = null,
-                        modifier = Modifier.size(52.dp),
+                    SummaryRow(
+                        label = stringRes(DesignR.string.migrationComplete_totalTransferredLabel).getValue(),
+                        value = state.totalTransferred.getValue(),
                     )
-                    Spacer(Modifier.height(24.dp))
-                    Text(
-                        text = stringRes(DesignR.string.migrationComplete_title).getValue(),
-                        style = ZashiTypography.header5,
-                        fontWeight = FontWeight.SemiBold,
-                        color = ZashiColors.Text.textPrimary,
-                        textAlign = TextAlign.Center,
-                    )
-                    Spacer(Modifier.height(4.dp))
-                    Text(
-                        text = stringRes(DesignR.string.migrationComplete_subtitle).getValue(),
-                        style = ZashiTypography.textSm,
-                        color = ZashiColors.Text.textTertiary,
-                        textAlign = TextAlign.Center,
-                    )
-                    Spacer(Modifier.height(24.dp))
-                    Column(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .clip(RoundedCornerShape(16.dp))
-                                .background(ZashiColors.Surfaces.bgSecondary)
-                                .padding(20.dp),
-                        verticalArrangement = Arrangement.spacedBy(10.dp),
-                    ) {
+                    state.remainingDust?.let { dust ->
                         SummaryRow(
-                            label = stringRes(DesignR.string.migrationComplete_totalTransferredLabel).getValue(),
-                            value = state.totalTransferred.getValue(),
-                        )
-                        state.remainingDust?.let { dust ->
-                            SummaryRow(
-                                label = stringRes(DesignR.string.migrationComplete_remainingDustLabel).getValue(),
-                                value = dust.getValue(),
-                            )
-                        }
-                        SummaryRow(
-                            label = stringRes(DesignR.string.migrationComplete_transfersLabel).getValue(),
-                            value = state.transfersProgress.getValue(),
-                        )
-                        SummaryRow(
-                            label = stringRes(DesignR.string.migrationComplete_durationLabel).getValue(),
-                            value = state.duration.getValue(),
+                            label = stringRes(DesignR.string.migrationComplete_remainingDustLabel).getValue(),
+                            value = dust.getValue(),
                         )
                     }
+                    SummaryRow(
+                        label = stringRes(DesignR.string.migrationComplete_transfersLabel).getValue(),
+                        value = state.transfersProgress.getValue(),
+                    )
+                    SummaryRow(
+                        label = stringRes(DesignR.string.migrationComplete_durationLabel).getValue(),
+                        value = state.duration.getValue(),
+                    )
                 }
+                Spacer(Modifier.weight(1f))
                 when {
                     state.remainingDust == null -> {
                         ZashiButton(

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/progress/MigrationProgressScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/progress/MigrationProgressScreen.kt
@@ -84,6 +84,7 @@ fun MigrationProgressView(state: MigrationProgressState) {
             modifier =
                 Modifier
                     .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
                     .scaffoldPadding(padding),
         ) {
             Text(
@@ -104,11 +105,7 @@ fun MigrationProgressView(state: MigrationProgressState) {
                 Spacer(Modifier.height(20.dp))
             }
 
-            Column(
-                Modifier
-                    .weight(1f)
-                    .verticalScroll(rememberScrollState())
-            ) {
+            Column {
                 // A multi-step note-split collapses into a single "Split Balance" row with a
                 // "Show details" sheet (Figma "PR App Designs Q3'26" node 5207:16023, 2026-08-03,
                 // mirroring MigrationReviewScreen's identical threshold) — state.preparations is
@@ -176,6 +173,8 @@ fun MigrationProgressView(state: MigrationProgressState) {
                     )
                 }
             }
+
+            Spacer(Modifier.weight(1f))
 
             // No Send-now / Re-schedule buttons: the engine drives execution and the foreground
             // pass sends silently while this screen is open — the screen is a pure live status

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/restart/MigrationRestartView.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/restart/MigrationRestartView.kt
@@ -102,6 +102,7 @@ fun MigrationRestartView(state: MigrationRestartState) {
                 SummaryCard(state)
                 Spacer(Modifier.height(8.dp))
                 WarningCard(state.warning.getValue())
+                Spacer(Modifier.height(12.dp))
                 Spacer(Modifier.weight(1f))
                 SupportRow(state.support.getValue())
                 Spacer(Modifier.height(12.dp))

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/scheduled/MigrationScheduledState.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/scheduled/MigrationScheduledState.kt
@@ -89,49 +89,45 @@ internal fun MigrationSchedulingView() {
                     .scaffoldPadding(padding),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            Spacer(Modifier.weight(1f))
+            Image(
+                painter = painterResource(R.drawable.ic_fist_punch),
+                contentDescription = null,
+                modifier = Modifier.size(120.dp),
+            )
+            Spacer(Modifier.height(24.dp))
+            Text(
+                text = stringRes(DesignR.string.migrationScheduled_schedulingTitle).getValue(),
+                style = ZashiTypography.header5,
+                fontWeight = FontWeight.SemiBold,
+                color = ZashiColors.Text.textPrimary,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = stringRes(DesignR.string.migrationScheduled_schedulingSubtitle).getValue(),
+                style = ZashiTypography.textSm,
+                color = ZashiColors.Text.textTertiary,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(24.dp))
             Column(
-                Modifier.weight(1f),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(ZashiColors.Surfaces.bgSecondary)
+                        .padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                Image(
-                    painter = painterResource(R.drawable.ic_fist_punch),
-                    contentDescription = null,
-                    modifier = Modifier.size(120.dp),
+                SkeletonSummaryRow(
+                    label = stringRes(DesignR.string.migrationScheduled_totalToTransferLabel).getValue()
                 )
-                Spacer(Modifier.height(24.dp))
-                Text(
-                    text = stringRes(DesignR.string.migrationScheduled_schedulingTitle).getValue(),
-                    style = ZashiTypography.header5,
-                    fontWeight = FontWeight.SemiBold,
-                    color = ZashiColors.Text.textPrimary,
-                    textAlign = TextAlign.Center,
-                )
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    text = stringRes(DesignR.string.migrationScheduled_schedulingSubtitle).getValue(),
-                    style = ZashiTypography.textSm,
-                    color = ZashiColors.Text.textTertiary,
-                    textAlign = TextAlign.Center,
-                )
-                Spacer(Modifier.height(24.dp))
-                Column(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(16.dp))
-                            .background(ZashiColors.Surfaces.bgSecondary)
-                            .padding(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(10.dp),
-                ) {
-                    SkeletonSummaryRow(
-                        label = stringRes(DesignR.string.migrationScheduled_totalToTransferLabel).getValue()
-                    )
-                    SkeletonSummaryRow(label = stringRes(DesignR.string.migrationScheduled_poolLabel).getValue())
-                    SkeletonSummaryRow(label = stringRes(DesignR.string.migrationScheduled_transfersLabel).getValue())
-                    SkeletonSummaryRow(label = stringRes(DesignR.string.migrationScheduled_durationLabel).getValue())
-                }
+                SkeletonSummaryRow(label = stringRes(DesignR.string.migrationScheduled_poolLabel).getValue())
+                SkeletonSummaryRow(label = stringRes(DesignR.string.migrationScheduled_transfersLabel).getValue())
+                SkeletonSummaryRow(label = stringRes(DesignR.string.migrationScheduled_durationLabel).getValue())
             }
+            Spacer(Modifier.weight(1f))
             ZashiButton(
                 state =
                     ButtonState(
@@ -181,67 +177,63 @@ fun MigrationScheduledView(state: MigrationScheduledState) {
                     .scaffoldPadding(padding),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            Spacer(Modifier.weight(1f))
+            Image(
+                painter = painterResource(R.drawable.ic_fist_punch),
+                contentDescription = null,
+                modifier = Modifier.size(120.dp),
+            )
+            Spacer(Modifier.height(24.dp))
+            Text(
+                text = stringRes(DesignR.string.migrationScheduled_doneTitle).getValue(),
+                style = ZashiTypography.header5,
+                fontWeight = FontWeight.SemiBold,
+                color = ZashiColors.Text.textPrimary,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = stringRes(DesignR.string.migrationScheduled_doneSubtitle).getValue(),
+                style = ZashiTypography.textSm,
+                color = ZashiColors.Text.textTertiary,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(24.dp))
             Column(
-                Modifier.weight(1f),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(ZashiColors.Surfaces.bgSecondary)
+                        .padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                Image(
-                    painter = painterResource(R.drawable.ic_fist_punch),
-                    contentDescription = null,
-                    modifier = Modifier.size(120.dp),
+                SummaryRow(
+                    label = stringRes(DesignR.string.migrationScheduled_totalToTransferLabel).getValue(),
+                    value = state.totalAmount.getValue(),
                 )
-                Spacer(Modifier.height(24.dp))
-                Text(
-                    text = stringRes(DesignR.string.migrationScheduled_doneTitle).getValue(),
-                    style = ZashiTypography.header5,
-                    fontWeight = FontWeight.SemiBold,
-                    color = ZashiColors.Text.textPrimary,
-                    textAlign = TextAlign.Center,
+                SummaryRow(
+                    label = stringRes(DesignR.string.migrationScheduled_poolLabel).getValue(),
+                    value = stringRes(DesignR.string.migrationScheduled_poolValue).getValue(),
                 )
-                Spacer(Modifier.height(4.dp))
+                SummaryRow(
+                    label = stringRes(DesignR.string.migrationScheduled_transfersLabel).getValue(),
+                    value = state.transfersProgress.getValue(),
+                )
+                SummaryRow(
+                    label = stringRes(DesignR.string.migrationScheduled_durationLabel).getValue(),
+                    value = state.duration.getValue(),
+                )
+            }
+            state.backgroundHint?.let {
+                Spacer(Modifier.height(12.dp))
                 Text(
-                    text = stringRes(DesignR.string.migrationScheduled_doneSubtitle).getValue(),
+                    text = it.getValue(),
                     style = ZashiTypography.textSm,
                     color = ZashiColors.Text.textTertiary,
-                    textAlign = TextAlign.Center,
                 )
-                Spacer(Modifier.height(24.dp))
-                Column(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(16.dp))
-                            .background(ZashiColors.Surfaces.bgSecondary)
-                            .padding(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(10.dp),
-                ) {
-                    SummaryRow(
-                        label = stringRes(DesignR.string.migrationScheduled_totalToTransferLabel).getValue(),
-                        value = state.totalAmount.getValue(),
-                    )
-                    SummaryRow(
-                        label = stringRes(DesignR.string.migrationScheduled_poolLabel).getValue(),
-                        value = stringRes(DesignR.string.migrationScheduled_poolValue).getValue(),
-                    )
-                    SummaryRow(
-                        label = stringRes(DesignR.string.migrationScheduled_transfersLabel).getValue(),
-                        value = state.transfersProgress.getValue(),
-                    )
-                    SummaryRow(
-                        label = stringRes(DesignR.string.migrationScheduled_durationLabel).getValue(),
-                        value = state.duration.getValue(),
-                    )
-                }
-                state.backgroundHint?.let {
-                    Spacer(Modifier.height(12.dp))
-                    Text(
-                        text = it.getValue(),
-                        style = ZashiTypography.textSm,
-                        color = ZashiColors.Text.textTertiary,
-                    )
-                }
             }
+            Spacer(Modifier.weight(1f))
             ZashiButton(
                 state = ButtonState(text = stringRes(DesignR.string.migration_status_done), onClick = state.onDone),
                 modifier = Modifier.fillMaxWidth(),

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/success/MigrationSuccessState.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/success/MigrationSuccessState.kt
@@ -1,7 +1,6 @@
 package co.electriccoin.zcash.ui.screen.migration.success
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -71,32 +70,28 @@ fun MigrationSuccessView(state: MigrationSuccessState) {
                     .scaffoldPadding(padding),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Image(
-                    painter = painterResource(R.drawable.ic_fist_punch),
-                    contentDescription = null,
-                    modifier = Modifier.size(148.dp),
-                )
-                Spacer(Modifier.height(24.dp))
-                Text(
-                    text = stringRes(DesignR.string.migrationSuccess_title).getValue(),
-                    style = ZashiTypography.header5,
-                    fontWeight = FontWeight.SemiBold,
-                    color = ZashiColors.Text.textPrimary,
-                    textAlign = TextAlign.Center,
-                )
-                Spacer(Modifier.height(4.dp))
-                Text(
-                    text = stringRes(DesignR.string.migrationSuccess_subtitle).getValue(),
-                    style = ZashiTypography.textSm,
-                    color = ZashiColors.Text.textTertiary,
-                    textAlign = TextAlign.Center,
-                )
-            }
+            Spacer(Modifier.weight(1f))
+            Image(
+                painter = painterResource(R.drawable.ic_fist_punch),
+                contentDescription = null,
+                modifier = Modifier.size(148.dp),
+            )
+            Spacer(Modifier.height(24.dp))
+            Text(
+                text = stringRes(DesignR.string.migrationSuccess_title).getValue(),
+                style = ZashiTypography.header5,
+                fontWeight = FontWeight.SemiBold,
+                color = ZashiColors.Text.textPrimary,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = stringRes(DesignR.string.migrationSuccess_subtitle).getValue(),
+                style = ZashiTypography.textSm,
+                color = ZashiColors.Text.textTertiary,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.weight(1f))
             state.onViewTransaction?.let { onView ->
                 ZashiButton(
                     state =

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiFrost.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiFrost.kt
@@ -35,6 +35,19 @@ private val FooterBlurIntensityStops =
     )
 
 /**
+ * The footer's blur curve mirrored top-down: full blur from the top edge through the middle of the
+ * header, then a steep ramp down to nothing at the bottom edge. Pass it to [zashiFrostedHeader] on
+ * screens whose header holds content that has to stay readable over the list scrolling underneath.
+ */
+val HeaderBlurIntensityStops =
+    listOf(
+        0f to 1f,
+        FOOTER_BLUR_PLATEAU_FRACTION to 1f,
+        1f - FOOTER_BLUR_RAMP_FRACTION to FOOTER_BLUR_RAMP_INTENSITY,
+        1f to 0f
+    )
+
+/**
  * Creates the state which connects a frosted bar to the content scrolling underneath it. Pass the
  * same instance to [zashiFrostedHeader] / [zashiFrostedFooter] and [zashiFrostSource].
  */
@@ -57,23 +70,59 @@ fun rememberZashiFrostState(): HazeState = rememberHazeState()
  * ignoring [frostColor] — a transparent fallback would show the content unblurred on those
  * devices. Surfaces whose resting background is not bgPrimary (a bottom sheet, for instance) pass
  * their own background as [fallbackColor] so the bar disappears into them.
+ *
+ * By default the blur strength follows a plain two-point gradient, full at the top edge and gone at
+ * the bottom one. Passing [intensityStops] switches it to a multi-stop curve instead, mapping a
+ * fraction of the header's height (0f = top edge, 1f = bottom edge) to a blur intensity at that
+ * line and interpolating linearly between stops; [HeaderBlurIntensityStops] holds the header
+ * mirror of the footer's curve, which keeps a strong blur under the header's own content and only
+ * ramps away just above its bottom edge. As in [zashiFrostedFooter], only the blur follows the
+ * stops: the tint becomes a plain top-ramp gradient and the noise grain is dropped, so the frost
+ * does not repaint the header's resting colors.
  */
 @Composable
 fun Modifier.zashiFrostedHeader(
     hazeState: HazeState,
     frostColor: Color = ZashiColors.Surfaces.bgPrimary,
-    fallbackColor: Color = ZashiColors.Surfaces.bgPrimary
-): Modifier =
-    zashiFrost(
+    fallbackColor: Color = ZashiColors.Surfaces.bgPrimary,
+    intensityStops: List<Pair<Float, Float>>? = null
+): Modifier {
+    if (intensityStops == null) {
+        return zashiFrost(
+            hazeState = hazeState,
+            frostColor = frostColor,
+            fallbackColor = fallbackColor,
+            progressive =
+                HazeProgressive.verticalGradient(
+                    startIntensity = 1f,
+                    endIntensity = 0f
+                )
+        )
+    }
+    val tintColor = frostColor.copy(alpha = frostColor.alpha * FROST_TINT_ALPHA)
+    return zashiFrost(
         hazeState = hazeState,
         frostColor = frostColor,
         fallbackColor = fallbackColor,
         progressive =
-            HazeProgressive.verticalGradient(
-                startIntensity = 1f,
-                endIntensity = 0f
-            )
+            HazeProgressive.Brush(
+                Brush.verticalGradient(
+                    colorStops =
+                        intensityStops
+                            .map { (fraction, intensity) -> fraction to Color.White.copy(alpha = intensity) }
+                            .toTypedArray()
+                )
+            ),
+        tint =
+            HazeTint(
+                Brush.verticalGradient(
+                    0f to tintColor,
+                    1f to tintColor.copy(alpha = 0f)
+                )
+            ),
+        noiseFactor = 0f
     )
+}
 
 /**
  * Renders a frosted footer: the mirror image of [zashiFrostedHeader], fading in from the top edge of

--- a/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiSwapQuoteHeader.kt
+++ b/ui-design-lib/src/main/java/co/electriccoin/zcash/ui/design/component/ZashiSwapQuoteHeader.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import co.electriccoin.zcash.ui.design.R
@@ -25,12 +26,13 @@ import co.electriccoin.zcash.ui.design.util.stringResByDynamicCurrencyNumber
 @Composable
 fun ZashiSwapQuoteHeader(
     state: SwapQuoteHeaderState,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    color: Color = ZashiColors.Surfaces.bgSecondary
 ) {
     Surface(
         modifier = modifier,
         shape = RoundedCornerShape(ZashiDimensions.Radius.radius2xl),
-        color = ZashiColors.Surfaces.bgSecondary
+        color = color
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/about/view/AboutView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/about/view/AboutView.kt
@@ -1,5 +1,6 @@
 package co.electriccoin.zcash.ui.screen.about.view
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -8,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -25,6 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -215,7 +218,14 @@ fun AboutMainContent(
                     bigIcon = imageRes(R.drawable.ic_terms_of_use),
                     title = stringRes(stringResource(R.string.about_termsOfUse)),
                     onClick = onTermsOfUse
+                ),
+            leading = { modifier ->
+                Image(
+                    modifier = modifier.size(40.dp),
+                    painter = painterResource(R.drawable.ic_terms_of_use),
+                    contentDescription = stringResource(R.string.about_termsOfUse)
                 )
+            }
         )
 
         Spacer(Modifier.weight(1f))

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/quote/SwapQuoteView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/quote/SwapQuoteView.kt
@@ -177,7 +177,8 @@ private fun Success(
                         SwapQuoteHeaderState(
                             from = state.from,
                             to = state.to
-                        )
+                        ),
+                    color = ZashiColors.Surfaces.bgPrimary
                 )
             }
             Spacer(32.dp)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactionhistory/ActivityHistoryView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/transactionhistory/ActivityHistoryView.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.unit.dp
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.appbar.ZashiMainTopAppBarState
 import co.electriccoin.zcash.ui.design.component.BlankBgScaffold
+import co.electriccoin.zcash.ui.design.component.HeaderBlurIntensityStops
 import co.electriccoin.zcash.ui.design.component.IconButtonState
 import co.electriccoin.zcash.ui.design.component.TextFieldState
 import co.electriccoin.zcash.ui.design.component.ZashiHorizontalDivider
@@ -88,7 +89,7 @@ fun ActivityHistoryView(
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .zashiFrostedHeader(hazeState)
+                        .zashiFrostedHeader(hazeState, intensityStops = HeaderBlurIntensityStops)
             ) {
                 TransactionHistoryAppBar(
                     mainAppBarState = mainAppBarState,


### PR DESCRIPTION
Fixes MOB-1748.

Five UI nits from the 3.10.0 build, one commit each, targeting the new `maint/v3.10.x` line:

- **Review Quote sheet** — the From/To quote header used `Surfaces.bgSecondary`, the same color as the sheet background, so it disappeared. `ZashiSwapQuoteHeader` gained a `color` parameter (default unchanged for its other three call sites) and the Review Quote sheet passes `Surfaces.bgPrimary`.
- **Activity header frost** — the header now supports the footer's stepped blur-intensity curve (`HeaderBlurIntensityStops`, the footer curve mirrored top-down) so content blurs away sooner under the search bar and month header. Opt-in via a new `intensityStops` parameter on `zashiFrostedHeader`; only the Activity screen passes it, every other header keeps the previous two-point gradient.
- **About screen** — the Terms of Service row got an explicit 40 dp leading slot, matching the Privacy Policy icon instead of falling back to the 48 dp default.
- **Restart Migration** — a fixed 12 dp spacer above the "If restarting doesn't resolve the issue…" text, which previously sat flush against the warning card on full screens.
- **Migration screens scroll** — Migration Progress had no outer scroll at all; Complete, Scheduled (both variants), and Success had `verticalScroll` neutralized by a `weight(1f)` centered inner column that capped content at viewport height. All now use the standard scrollable-column idiom with weighted spacers for centering/CTA pinning.

Screenshots of the issues are attached to the Linear ticket.

Verified: `assembleZcashmainnetStoreDebug`, `ktlint`, `detektAll`, and unit tests for `ui-design-lib`, `ui-lib`, and `feature-migration` all pass; RIM build installed and smoke-checked on a device.

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [ ] **Run the app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
