### PR TITLE
ci(e2e): run the smoke emulators on SwANGLE instead of SwiftShader

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -250,6 +250,16 @@ jobs:
           api-level: 35
           arch: x86_64
           profile: pixel_6
+          # Default emulator-options with `-gpu swiftshader_indirect`
+          # swapped for `swangle_indirect`. Since #2442 put Haze
+          # backdrop blur on most screens, SwiftShader's host renderer
+          # loses graphics buffers under the RenderEffect load and
+          # takes the whole emulator process down mid-suite ("Failed to
+          # find ColorBuffer: N", then every later flow fails with
+          # "0 devices connected"). SwANGLE is the more robust
+          # headless backend; if the crash recurs, gate Haze's blur off
+          # on emulators in ZashiFrost.kt instead.
+          emulator-options: -no-window -gpu swangle_indirect -no-snapshot -noaudio -no-boot-anim
           script: |
             adb install apk/*.apk
             chmod +x zodl-qa/scripts/run-smoke-android.sh
@@ -338,6 +348,9 @@ jobs:
           api-level: 35
           arch: x86_64
           profile: pixel_6
+          # See the e2e-android job above for why the GPU backend is
+          # pinned to SwANGLE rather than the default SwiftShader.
+          emulator-options: -no-window -gpu swangle_indirect -no-snapshot -noaudio -no-boot-anim
           script: |
             adb install apk/*.apk
             chmod +x keystone-simulator/simulator


### PR DESCRIPTION
The Android smoke suite has been red on every PR since #2442 (MOB-1738,
frosted-glass Haze headers/footers) merged, and the failure is not in the
flows — the emulator process itself dies mid-run.

Signature, identical across `e2e-android (phase 1)`, `(phase 2)` and `Keystone`:

```
ERROR        | Failed to find ColorBuffer: 189
java.io.IOException: Command failed (host:transport:emulator-5554): device 'emulator-5554' not found
Not enough devices connected (0) to run the requested number of shards (1).
adb -s emulator-5554 emu kill → could not connect to TCP port 5554: Connection refused
```

`Failed to find ColorBuffer` comes from the emulator's host renderer (gfxstream +
SwiftShader), and qemu is gone afterwards rather than hung. The crash points are
all frosted screens: phases 1 and Keystone die on `tapOn HOME_MORE`
(`MoreView.kt`, `zashiFrostedHeader` + `zashiFrostSource`), phase 2 on the
birthday-height screen's Restore button (`RestoreHeightView.kt`). SwiftShader
loses graphics buffers under Haze's `RenderEffect` load and takes the emulator
down with it.

Timeline matches exactly — last green e2e runs are the two from 19 Aug ~11:00
UTC, both predating #2442 (merged 18:17 UTC that day); every run since whose
merge ref contains it fails this way, including the v3.10.0 release PR (#2454).

This pins both emulator steps to `-gpu swangle_indirect`, otherwise leaving the
action's default `emulator-options` untouched. If the crash recurs on SwANGLE,
the app-side fix is to turn Haze's blur off on emulators in `ZashiFrost.kt`,
which already has an opaque-bar fallback path for devices where blur is
unavailable.