### PR TITLE
ci: verify Android send-address paste flow

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,4 +1,5 @@
 name: E2E Smoke Tests
+# CI validation: exercise the zodl-qa Android send-address paste flow.
 
 on:
   pull_request:


### PR DESCRIPTION
Triggers the Android E2E smoke workflow to validate zodl-qa commit 8933a1c. The QA flow now pastes the unified address through the Maestro internal clipboard instead of sending 200 backspaces and typing 178 characters through the Android IME.