### PR TITLE
MOB-1750: handle sub-0.01 ZEC Orchard residue for restored/self-migrated wallets

### DIFF
--- a/feature-migration/src/main/java/co/electriccoin/zcash/migration/FeatureMigrationImpls.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/migration/FeatureMigrationImpls.kt
@@ -249,7 +249,7 @@ class MigrationNavContributorImpl : MigrationNavContributor {
             composable<MigrationSendingArgs> { MigrationSendingScreen() }
             composable<MigrationSuccessArgs> { MigrationSuccessScreen(it.toRoute()) }
             composable<MigrationScheduledArgs> { MigrationScheduledScreen() }
-            composable<MigrationCompleteArgs> { MigrationCompleteScreen() }
+            composable<MigrationCompleteArgs> { MigrationCompleteScreen(it.toRoute()) }
             composable<MigrationProgressArgs> { MigrationProgressScreen() }
             composable<MigrationTransferInvalidArgs> { MigrationTransferInvalidScreen() }
             composable<MigrationRestartArgs> { MigrationRestartScreen() }

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/repository/MigrationHomeMessageData.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/repository/MigrationHomeMessageData.kt
@@ -25,4 +25,12 @@ data class MigrationHomeMessageData(
     // generic message again. attentionRangeText is only meaningful for TRANSFER_EXPIRED.
     val attentionKind: MigrationAttentionKind? = null,
     val attentionRangeText: String? = null,
+    // MOB-1750: true when this Complete banner comes from the RESIDUE branch (a small leftover
+    // Orchard balance not tied to an unseen in-app migration celebration) rather than the one-time
+    // post-migration celebration — drives both the home banner's "X ZEC left in Orchard" copy and
+    // MigrationCompleteScreen's reduced summary card (no Transfers/Duration rows).
+    val isResidueOnly: Boolean = false,
+    // The live Orchard balance at decision time. Only meaningful when [isResidueOnly] is true — the
+    // home banner needs the amount for its title; the celebration branch's copy is static.
+    val residualBalanceZatoshi: Long = 0L,
 ) : MigrationHomeMessage()

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
@@ -41,6 +41,14 @@ import co.electriccoin.zcash.ui.design.R as DesignR
 
 private const val PERCENT_MULTIPLIER = 100
 
+/** The banner phase + title/subtitle override for one [MigrationMessageState] — replaces an
+ * anonymous [Triple] so each field is named at the call site instead of positional. */
+private data class BannerCopy(
+    val phase: MigrationBannerPhase,
+    val title: String?,
+    val subtitle: String?,
+)
+
 /**
  * The home-banner source, fully LIVE off the engine — no plan cache anywhere (see
  * `spec/2026-07-30-plan-cache-elimination-proposal.md`): counts come from the engine's transfer
@@ -137,18 +145,18 @@ class MigrationHomeMessageSourceImpl(
             }
         // Spec §6.2/§6.3 — takes priority over the ordinary phases below: a plan needing
         // re-confirmation is more actionable than its last-known progress/completion state.
-        val (phase, title, subtitle) =
+        val bannerCopy =
             when (data.attentionKind) {
                 MigrationAttentionKind.PLAN_UPDATE -> {
-                    Triple(MigrationBannerPhase.ATTENTION, "Update migration plan", "Tap to review the details")
+                    BannerCopy(MigrationBannerPhase.ATTENTION, "Update migration plan", "Tap to review the details")
                 }
 
                 MigrationAttentionKind.TRANSFER_EXPIRED -> {
                     val range = data.attentionRangeText
-                    Triple(
-                        MigrationBannerPhase.ATTENTION,
-                        if (range != null) "Transfer $range expired" else "A transfer expired",
-                        "Tap to review the details",
+                    BannerCopy(
+                        phase = MigrationBannerPhase.ATTENTION,
+                        title = if (range != null) "Transfer $range expired" else "A transfer expired",
+                        subtitle = "Tap to review the details",
                     )
                 }
 
@@ -159,29 +167,29 @@ class MigrationHomeMessageSourceImpl(
                         // the "Migration complete" celebration title.
                         data.isComplete && data.isResidueOnly -> {
                             val amount = stringRes(Zatoshi(data.residualBalanceZatoshi)).getString(context)
-                            Triple(
-                                MigrationBannerPhase.COMPLETE,
-                                stringRes(DesignR.string.migrationHome_residueTitle, amount).getString(context),
-                                stringRes(DesignR.string.migrationHome_residueSubtitle).getString(context),
+                            BannerCopy(
+                                phase = MigrationBannerPhase.COMPLETE,
+                                title = stringRes(DesignR.string.migrationHome_residueTitle, amount).getString(context),
+                                subtitle = stringRes(DesignR.string.migrationHome_residueSubtitle).getString(context),
                             )
                         }
 
                         data.isComplete -> {
-                            Triple(MigrationBannerPhase.COMPLETE, null, "Tap to review the details")
+                            BannerCopy(MigrationBannerPhase.COMPLETE, null, "Tap to review the details")
                         }
 
                         // Spec §6.4: numbered per the due transfer, matching the convention used
                         // elsewhere (e.g. Progress's "Transfer ${completedCount + 1}").
                         data.isReadyToSend -> {
-                            Triple(
-                                MigrationBannerPhase.READY_TO_SEND,
-                                null,
-                                "Transfer ${data.completedCount + 1} is ready to send",
+                            BannerCopy(
+                                phase = MigrationBannerPhase.READY_TO_SEND,
+                                title = null,
+                                subtitle = "Transfer ${data.completedCount + 1} is ready to send",
                             )
                         }
 
                         !data.isRunActive -> {
-                            Triple(MigrationBannerPhase.REQUIRED, null, null)
+                            BannerCopy(MigrationBannerPhase.REQUIRED, null, null)
                         }
 
                         // MOB-1620: always the numeric count, including the 0-of-N case right
@@ -189,20 +197,21 @@ class MigrationHomeMessageSourceImpl(
                         // sending…" copy read as vaguer/stuck to Harry, and 0-based counts render
                         // fine ("0 of 5 transfers done ~0% complete").
                         else -> {
-                            Triple(
-                                MigrationBannerPhase.IN_PROGRESS,
-                                null,
-                                "${data.completedCount} of ${data.totalCount} transfers done" +
-                                    " ~ $percent% complete",
+                            BannerCopy(
+                                phase = MigrationBannerPhase.IN_PROGRESS,
+                                title = null,
+                                subtitle =
+                                    "${data.completedCount} of ${data.totalCount} transfers done" +
+                                        " ~ $percent% complete",
                             )
                         }
                     }
                 }
             }
         return MigrationMessageState(
-            phase = phase,
-            title = title,
-            progressLabel = subtitle,
+            phase = bannerCopy.phase,
+            title = bannerCopy.title,
+            progressLabel = bannerCopy.subtitle,
             progressPercent = percent.toFloat(),
             onClick = {
                 onMigrationMessageClick(

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
@@ -121,11 +121,21 @@ class MigrationHomeMessageSourceImpl(
                 val dustThreshold =
                     runCatching { getOrchardMigrationSdk().migrationDustThresholdZatoshi() }
                         .getOrDefault(MIGRATION_DUST_THRESHOLD_ZATOSHI)
+                // Kris Nuttycombe's per-note dust total (Slack, MOB-1750 follow-up): sum of each
+                // spendable Orchard note's value net of MARGINAL_FEE, not the raw aggregate
+                // balance — a wallet can hold a raw balance above dustThreshold made up entirely
+                // of notes too small individually to be worth spending. Falls back to the raw
+                // balance (old behavior) if the SDK call fails, same guard shape as dustThreshold.
+                val orchardBalanceZatoshi = orchardBalance?.value ?: 0L
+                val migratableOrchardTotal =
+                    runCatching { getOrchardMigrationSdk().migratableOrchardTotal() }
+                        .getOrDefault(orchardBalanceZatoshi)
                 migrationMessageFor(
                     sdkState = sdkState,
                     snapshot = snapshot,
                     hasSeenComplete = hasSeenComplete,
-                    orchardBalanceZatoshi = orchardBalance?.value ?: 0L,
+                    orchardBalanceZatoshi = orchardBalanceZatoshi,
+                    migratableOrchardTotalZatoshi = migratableOrchardTotal,
                     dustThresholdZatoshi = dustThreshold,
                     isBackgroundExecutionAvailable = isBackgroundExecutionAvailableProvider.isAvailable(),
                     hasOverdueTransfers = readout?.hasOverdueTransfers ?: false,
@@ -286,12 +296,21 @@ class MigrationHomeMessageSourceImpl(
  *
  * - round running                → engine InProgress (counts from [snapshot])
  * - celebration (campaign done)  → engine Complete && balance < RESIDUAL_MIN && !hasSeenComplete
- * - residue (lock/migrate-anyway)→ dust < balance < RESIDUAL_MIN && not running
+ * - residue (lock/migrate-anyway)→ migratable total > dust threshold && balance < RESIDUAL_MIN &&
+ *                                   not running
  * - next round / never migrated  → balance ≥ RESIDUAL_MIN && not running → "Migrate now"
  *
  * The "Complete && balance ≥ min ⇒ Migrate now" mapping is deliberately identical whether the
  * balance is a next Keystone round's residual or newly received funds — both need a migration, so
  * the ambiguity the old cleared-plan marker guarded against does not exist.
+ *
+ * The residue branch's lower bound is gated on [migratableOrchardTotalZatoshi] — Kris
+ * Nuttycombe's per-note total (sum of each spendable note's value net of MARGINAL_FEE, over notes
+ * whose value exceeds MARGINAL_FEE), not the raw [orchardBalanceZatoshi] — a raw balance can sit
+ * above [dustThresholdZatoshi] while being made up entirely of notes too small individually to be
+ * worth spending. The displayed amount ([MigrationHomeMessageData.residualBalanceZatoshi]) still
+ * uses the raw balance — the user's real, current Orchard balance — only the "is this worth
+ * prompting about" gate uses the net-of-fee total.
  */
 @Suppress("CyclomaticComplexMethod")
 internal fun migrationMessageFor(
@@ -299,6 +318,7 @@ internal fun migrationMessageFor(
     snapshot: LiveMigrationSnapshot?,
     hasSeenComplete: Boolean,
     orchardBalanceZatoshi: Long,
+    migratableOrchardTotalZatoshi: Long = orchardBalanceZatoshi,
     dustThresholdZatoshi: Long = MIGRATION_DUST_THRESHOLD_ZATOSHI,
     isBackgroundExecutionAvailable: Boolean = true,
     hasOverdueTransfers: Boolean = false,
@@ -386,8 +406,10 @@ internal fun migrationMessageFor(
         // as "migration completed" and route to MigrationCompleteScreen, whose residue flow lets
         // the user LOCK it or MIGRATE it anyway. The reported balance is the *spendable* Orchard
         // balance (locked notes excluded), so locking makes this stop firing on its own.
+        // Lower bound uses migratableOrchardTotalZatoshi (per-note, net of MARGINAL_FEE), not the
+        // raw balance — see the function doc.
         !midRunAttention &&
-            orchardBalanceZatoshi > dustThresholdZatoshi &&
+            migratableOrchardTotalZatoshi > dustThresholdZatoshi &&
             orchardBalanceZatoshi < MIGRATION_RESIDUAL_MIN_ZATOSHI -> {
             MigrationHomeMessageData(
                 isRunActive = false,

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
@@ -1,8 +1,10 @@
 package co.electriccoin.zcash.ui.common.usecase
 
+import android.content.Context
 import cash.z.ecc.android.sdk.AttentionReason
 import cash.z.ecc.android.sdk.MigrationBlocker
 import cash.z.ecc.android.sdk.MigrationState
+import cash.z.ecc.android.sdk.model.Zatoshi
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.migration.MigrationHomeMessageSource
@@ -19,6 +21,8 @@ import co.electriccoin.zcash.ui.common.provider.HasSeenMigrationCompleteStorageP
 import co.electriccoin.zcash.ui.common.provider.IsBackgroundExecutionAvailableProvider
 import co.electriccoin.zcash.ui.common.repository.MigrationHomeMessage
 import co.electriccoin.zcash.ui.common.repository.MigrationHomeMessageData
+import co.electriccoin.zcash.ui.design.util.getString
+import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.screen.home.HomeMessageState
 import co.electriccoin.zcash.ui.screen.home.migration.MigrationBannerPhase
 import co.electriccoin.zcash.ui.screen.home.migration.MigrationMessageState
@@ -33,6 +37,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlin.time.Clock
 import kotlin.time.Instant
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 private const val PERCENT_MULTIPLIER = 100
 
@@ -43,6 +48,7 @@ private const val PERCENT_MULTIPLIER = 100
  * live Orchard balance. The only persisted inputs are genuine UX flags (hasSeenComplete).
  */
 class MigrationHomeMessageSourceImpl(
+    private val context: Context,
     private val accountDataSource: AccountDataSource,
     private val getOrchardMigrationSdk: GetOrchardMigrationSdkUseCase,
     private val observeMigrationLiveReadout: ObserveMigrationLiveReadoutUseCase,
@@ -148,6 +154,18 @@ class MigrationHomeMessageSourceImpl(
 
                 null -> {
                     when {
+                        // MOB-1750: a small leftover Orchard balance not tied to an unseen in-app
+                        // migration celebration gets its own "X ZEC left in Orchard" copy instead of
+                        // the "Migration complete" celebration title.
+                        data.isComplete && data.isResidueOnly -> {
+                            val amount = stringRes(Zatoshi(data.residualBalanceZatoshi)).getString(context)
+                            Triple(
+                                MigrationBannerPhase.COMPLETE,
+                                stringRes(DesignR.string.migrationHome_residueTitle, amount).getString(context),
+                                stringRes(DesignR.string.migrationHome_residueSubtitle).getString(context),
+                            )
+                        }
+
                         data.isComplete -> {
                             Triple(MigrationBannerPhase.COMPLETE, null, "Tap to review the details")
                         }
@@ -192,6 +210,7 @@ class MigrationHomeMessageSourceImpl(
                     isComplete = data.isComplete,
                     isReadyToSend = data.isReadyToSend,
                     hasAttention = data.attentionKind != null,
+                    isResidueOnly = data.isResidueOnly,
                 )
             },
             onButtonClick = {
@@ -200,6 +219,7 @@ class MigrationHomeMessageSourceImpl(
                     isComplete = data.isComplete,
                     isReadyToSend = data.isReadyToSend,
                     hasAttention = data.attentionKind != null,
+                    isResidueOnly = data.isResidueOnly,
                 )
             },
         )
@@ -210,6 +230,7 @@ class MigrationHomeMessageSourceImpl(
         isComplete: Boolean,
         isReadyToSend: Boolean = false,
         hasAttention: Boolean = false,
+        isResidueOnly: Boolean = false,
     ) {
         when {
             // A plan needing re-confirmation (spec §6.2/§6.3) always routes to the Transfer Invalid
@@ -217,8 +238,9 @@ class MigrationHomeMessageSourceImpl(
             hasAttention -> navigationRouter.forward(MigrationTransferInvalidArgs)
 
             // Tapping the widget just opens the celebration screen — MigrationCompleteVM.onDone()
-            // owns the seen-flag decision.
-            isComplete -> navigationRouter.forward(MigrationCompleteArgs)
+            // owns the seen-flag decision. MOB-1750: isResidueOnly threads which copy/summary
+            // variant MigrationCompleteScreen should render.
+            isComplete -> navigationRouter.forward(MigrationCompleteArgs(isResidueOnly = isResidueOnly))
 
             // Ready-to-send routes to Progress too — everything is pre-signed, there is nothing
             // to review; Progress's foreground broadcast loop executes the step silently while
@@ -358,7 +380,12 @@ internal fun migrationMessageFor(
         !midRunAttention &&
             orchardBalanceZatoshi > dustThresholdZatoshi &&
             orchardBalanceZatoshi < MIGRATION_RESIDUAL_MIN_ZATOSHI -> {
-            MigrationHomeMessageData(isRunActive = false, isComplete = true)
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = orchardBalanceZatoshi,
+            )
         }
 
         // Migratable balance with no run in progress — covers "never migrated", "a Keystone round

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteScreen.kt
@@ -55,6 +55,7 @@ import co.electriccoin.zcash.ui.screen.common.PrivacyDisclaimerCard
 import co.electriccoin.zcash.ui.screen.migration.component.MigrationFailureBottomSheet
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
 import co.electriccoin.zcash.ui.design.R as DesignR
 
 data class MigrationCompleteState(
@@ -70,14 +71,20 @@ data class MigrationCompleteState(
     val isMigrating: Boolean = false,
     val isLocking: Boolean = false,
     val failureSheet: co.electriccoin.zcash.ui.common.model.migration.MigrationTransferFailureState? = null,
+    // MOB-1750: true for a small leftover Orchard balance not tied to an unseen in-app migration
+    // celebration ("You've moved to Ironwood" copy, no Transfers/Duration rows) — false for the
+    // original post-migration celebration variant ("Migration Complete"), unchanged.
+    val isResidueOnly: Boolean = false,
 )
 
 @Serializable
-data object MigrationCompleteArgs
+data class MigrationCompleteArgs(
+    val isResidueOnly: Boolean = false
+)
 
 @Composable
-fun MigrationCompleteScreen() {
-    val vm = koinViewModel<MigrationCompleteVM>()
+fun MigrationCompleteScreen(args: MigrationCompleteArgs) {
+    val vm = koinViewModel<MigrationCompleteVM> { parametersOf(args) }
     val state by vm.state.collectAsStateWithLifecycle()
     LceRenderer(
         state = state,
@@ -141,7 +148,14 @@ fun MigrationCompleteView(state: MigrationCompleteState) {
                 )
                 Spacer(Modifier.height(24.dp))
                 Text(
-                    text = stringRes(DesignR.string.migrationComplete_title).getValue(),
+                    text =
+                        stringRes(
+                            if (state.isResidueOnly) {
+                                DesignR.string.migrationComplete_residueTitle
+                            } else {
+                                DesignR.string.migrationComplete_title
+                            }
+                        ).getValue(),
                     style = ZashiTypography.header5,
                     fontWeight = FontWeight.SemiBold,
                     color = ZashiColors.Text.textPrimary,
@@ -149,40 +163,20 @@ fun MigrationCompleteView(state: MigrationCompleteState) {
                 )
                 Spacer(Modifier.height(4.dp))
                 Text(
-                    text = stringRes(DesignR.string.migrationComplete_subtitle).getValue(),
+                    text =
+                        stringRes(
+                            if (state.isResidueOnly) {
+                                DesignR.string.migrationComplete_residueSubtitle
+                            } else {
+                                DesignR.string.migrationComplete_subtitle
+                            }
+                        ).getValue(),
                     style = ZashiTypography.textSm,
                     color = ZashiColors.Text.textTertiary,
                     textAlign = TextAlign.Center,
                 )
                 Spacer(Modifier.height(24.dp))
-                Column(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(16.dp))
-                            .background(ZashiColors.Surfaces.bgSecondary)
-                            .padding(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(10.dp),
-                ) {
-                    SummaryRow(
-                        label = stringRes(DesignR.string.migrationComplete_totalTransferredLabel).getValue(),
-                        value = state.totalTransferred.getValue(),
-                    )
-                    state.remainingDust?.let { dust ->
-                        SummaryRow(
-                            label = stringRes(DesignR.string.migrationComplete_remainingDustLabel).getValue(),
-                            value = dust.getValue(),
-                        )
-                    }
-                    SummaryRow(
-                        label = stringRes(DesignR.string.migrationComplete_transfersLabel).getValue(),
-                        value = state.transfersProgress.getValue(),
-                    )
-                    SummaryRow(
-                        label = stringRes(DesignR.string.migrationComplete_durationLabel).getValue(),
-                        value = state.duration.getValue(),
-                    )
-                }
+                SummaryCard(state)
                 Spacer(Modifier.weight(1f))
                 when {
                     state.remainingDust == null -> {
@@ -216,7 +210,11 @@ fun MigrationCompleteView(state: MigrationCompleteState) {
                             title = stringRes(DesignR.string.migrationComplete_orchardBalanceRemainingTitle).getValue(),
                             body =
                                 stringRes(
-                                    DesignR.string.migrationComplete_orchardBalanceRemainingBody,
+                                    if (state.isResidueOnly) {
+                                        DesignR.string.migrationComplete_residueRecommendationBody
+                                    } else {
+                                        DesignR.string.migrationComplete_orchardBalanceRemainingBody
+                                    },
                                     state.remainingDust.getValue()
                                 ).getValue(),
                         )
@@ -267,6 +265,54 @@ fun MigrationCompleteView(state: MigrationCompleteState) {
         }
     }
     MigrationFailureBottomSheet(state.failureSheet)
+}
+
+@Composable
+private fun SummaryCard(state: MigrationCompleteState) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(ZashiColors.Surfaces.bgSecondary)
+                .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        if (state.isResidueOnly) {
+            // MOB-1750: reduced summary — no Transfers/Duration rows, since a residue not tied
+            // to an unseen in-app celebration has no round-trip campaign to report on (whether
+            // it's genuinely 0 sent-in-app, or an already-seen completion's leftover residue).
+            SummaryRow(
+                label = stringRes(DesignR.string.migrationComplete_inIronwoodLabel).getValue(),
+                value = state.totalTransferred.getValue(),
+            )
+            state.remainingDust?.let { dust ->
+                SummaryRow(
+                    label = stringRes(DesignR.string.migrationComplete_leftInOrchardLabel).getValue(),
+                    value = dust.getValue(),
+                )
+            }
+        } else {
+            SummaryRow(
+                label = stringRes(DesignR.string.migrationComplete_totalTransferredLabel).getValue(),
+                value = state.totalTransferred.getValue(),
+            )
+            state.remainingDust?.let { dust ->
+                SummaryRow(
+                    label = stringRes(DesignR.string.migrationComplete_remainingDustLabel).getValue(),
+                    value = dust.getValue(),
+                )
+            }
+            SummaryRow(
+                label = stringRes(DesignR.string.migrationComplete_transfersLabel).getValue(),
+                value = state.transfersProgress.getValue(),
+            )
+            SummaryRow(
+                label = stringRes(DesignR.string.migrationComplete_durationLabel).getValue(),
+                value = state.duration.getValue(),
+            )
+        }
+    }
 }
 
 @Composable
@@ -376,6 +422,27 @@ private fun PreviewNoDust() =
                     isDustLocked = false,
                     transfersProgress = stringRes("5 of 5 sent"),
                     duration = stringRes("~24 hours"),
+                    onDone = {},
+                    onMigrateAnyway = {},
+                    onLockBalance = {},
+                    onHelp = {},
+                )
+        )
+    }
+
+@PreviewScreens
+@Composable
+private fun PreviewResidueOnly() =
+    ZcashTheme {
+        MigrationCompleteView(
+            state =
+                MigrationCompleteState(
+                    totalTransferred = stringRes("12.45 ZEC"),
+                    remainingDust = stringRes("0.008 ZEC"),
+                    isDustLocked = false,
+                    transfersProgress = stringRes("0 of 0 sent"),
+                    duration = stringRes("~0 hours"),
+                    isResidueOnly = true,
                     onDone = {},
                     onMigrateAnyway = {},
                     onLockBalance = {},

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVM.kt
@@ -29,6 +29,7 @@ import co.electriccoin.zcash.ui.common.repository.BiometricsCancelledException
 import co.electriccoin.zcash.ui.common.repository.BiometricsFailureException
 import co.electriccoin.zcash.ui.common.repository.KeystoneProposalRepository
 import co.electriccoin.zcash.ui.common.usecase.ErrorMapperUseCase
+import co.electriccoin.zcash.ui.common.usecase.GetIronwoodBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardMigrationSdkUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetSelectedWalletAccountUseCase
@@ -50,6 +51,7 @@ import co.electriccoin.zcash.ui.design.R as DesignR
 class MigrationCompleteVM(
     private val args: MigrationCompleteArgs,
     private val getOrchardBalance: GetOrchardBalanceUseCase,
+    private val getIronwoodBalance: GetIronwoodBalanceUseCase,
     private val hasSeenMigrationCompleteStorageProvider: HasSeenMigrationCompleteStorageProvider,
     private val hasLockedOrchardDustStorageProvider: HasLockedOrchardDustStorageProvider,
     private val getSelectedWalletAccount: GetSelectedWalletAccountUseCase,
@@ -95,22 +97,41 @@ class MigrationCompleteVM(
 
     init {
         loadLce.execute {
-            // Read the REAL migration summary (amount migrated, transfer count, duration) from the
-            // ENGINE's persisted migration data — the single source of truth that survives
-            // completion. The app-side plan is cleared once migration finishes, so it can no longer
-            // supply these (it would read 0.000 ZEC / 0 of 0). Null-safe: a missing summary
-            // falls back to zeros.
-            val summary = getOrchardMigrationSdk().getMigrationSummary()
-            // Whatever's still in the real Orchard balance once every transfer has sent is the
-            // dust/residual left behind (below the migratable threshold, or an un-migrated
-            // opt-in residual — either way, it's what's actually still sitting in Orchard).
-            Summary(
-                totalTransferred = summary?.totalMigratedZatoshi ?: 0L,
-                totalCount = summary?.transferCount ?: 0,
-                firstAt = summary?.firstMinedEpochSeconds ?: 0L,
-                lastAt = summary?.lastMinedEpochSeconds ?: 0L,
-                dustZatoshi = getOrchardBalance().value,
-            )
+            // MOB-1750: the residue variant's "In Ironwood" row is the live Ironwood pool
+            // balance (GetIronwoodBalanceUseCase, same source GetBalancePoolsUseCase's Balance
+            // Breakdown sheet already uses) rather than the migration engine's own campaign-
+            // scoped bookkeeping — and the view never shows totalCount/duration for this variant
+            // (SummaryCard's residue branch omits those rows), so there's nothing to gain from
+            // reading getMigrationSummary() here at all. That engine summary can genuinely have
+            // no rows for this account (e.g. after a debug migration restart, or a residue not
+            // tied to any in-app-run campaign at all) even though the wallet's real Ironwood
+            // balance is very much nonzero — reading it here would show a misleading
+            // "0.000 ZEC" next to real prior "Migrated" activity.
+            if (args.isResidueOnly) {
+                Summary(
+                    totalTransferred = getIronwoodBalance().value,
+                    totalCount = 0,
+                    firstAt = 0L,
+                    lastAt = 0L,
+                    dustZatoshi = getOrchardBalance().value,
+                )
+            } else {
+                // Read the REAL migration summary (amount migrated, transfer count, duration)
+                // from the ENGINE's persisted migration data — the single source of truth that
+                // survives completion. The app-side plan is cleared once migration finishes, so
+                // it can no longer supply these (it would read 0.000 ZEC / 0 of 0). Null-safe: a
+                // missing summary falls back to zeros. "Total transferred" here is deliberately
+                // about *this specific completed campaign*, not the account's current Ironwood
+                // total (see the residue branch above for that).
+                val summary = getOrchardMigrationSdk().getMigrationSummary()
+                Summary(
+                    totalTransferred = summary?.totalMigratedZatoshi ?: 0L,
+                    totalCount = summary?.transferCount ?: 0,
+                    firstAt = summary?.firstMinedEpochSeconds ?: 0L,
+                    lastAt = summary?.lastMinedEpochSeconds ?: 0L,
+                    dustZatoshi = getOrchardBalance().value,
+                )
+            }
         }
         // Cancel the background chain and clear any leftover notification as soon as THIS screen
         // is shown, not deferred until the user taps "Got it" (the previous behavior — onDone()

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVM.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.withContext
 import co.electriccoin.zcash.ui.design.R as DesignR
 
 class MigrationCompleteVM(
+    private val args: MigrationCompleteArgs,
     private val getOrchardBalance: GetOrchardBalanceUseCase,
     private val hasSeenMigrationCompleteStorageProvider: HasSeenMigrationCompleteStorageProvider,
     private val hasLockedOrchardDustStorageProvider: HasLockedOrchardDustStorageProvider,
@@ -170,6 +171,7 @@ class MigrationCompleteVM(
                 ),
             isMigrating = isMigrating,
             isLocking = isLocking,
+            isResidueOnly = args.isResidueOnly,
             onDone = ::onDone,
             onMigrateAnyway = { migrateAnywayLce.guardLoading(::onMigrateAnyway) },
             onLockBalance = { lockLce.guardLoading(::onLockBalance) },

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/sending/MigrationSendingVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/sending/MigrationSendingVM.kt
@@ -170,7 +170,7 @@ class MigrationSendingVM(
                             // This was the plan's last transfer — one Migration Complete screen covers
                             // both this (foreground, just confirmed) and the background-completion case
                             // (CheckMigrationRecoveryUseCase, on next app open), rather than two.
-                            navigationRouter.forward(MigrationCompleteArgs)
+                            navigationRouter.forward(MigrationCompleteArgs())
                         } else {
                             navigationRouter.forward(MigrationSuccessArgs(r.txId.txIdString()))
                         }

--- a/feature-migration/src/test/java/co/electriccoin/zcash/di/MigrationKoinGraphSmokeTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/di/MigrationKoinGraphSmokeTest.kt
@@ -52,6 +52,7 @@ import co.electriccoin.zcash.ui.common.repository.ZashiProposalRepository
 import co.electriccoin.zcash.ui.common.usecase.ErrorMapperUseCase
 import co.electriccoin.zcash.ui.common.usecase.FinalizeMigrationScheduleUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetBalancePoolsUseCase
+import co.electriccoin.zcash.ui.common.usecase.GetIronwoodBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetMigrationPrivacyOrReviewDestinationUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardMigrationSdkUseCase
@@ -126,6 +127,7 @@ class MigrationKoinGraphSmokeTest {
                 factory { mockk<GetOrchardMigrationSdkUseCase>(relaxed = true) }
                 factory { mockk<GetSelectedWalletAccountUseCase>(relaxed = true) }
                 factory { mockk<GetOrchardBalanceUseCase>(relaxed = true) }
+                factory { mockk<GetIronwoodBalanceUseCase>(relaxed = true) }
                 factory { mockk<GetBalancePoolsUseCase>(relaxed = true) }
                 factory { mockk<LockOrchardBalanceUseCase>(relaxed = true) }
                 factory { mockk<FinalizeMigrationScheduleUseCase>(relaxed = true) }

--- a/feature-migration/src/test/java/co/electriccoin/zcash/di/MigrationKoinGraphSmokeTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/di/MigrationKoinGraphSmokeTest.kt
@@ -61,6 +61,7 @@ import co.electriccoin.zcash.ui.common.usecase.ScheduleNextMigrationWindowUseCas
 import co.electriccoin.zcash.ui.common.usecase.SubmitProposalUseCase
 import co.electriccoin.zcash.ui.common.usecase.ViewTransactionDetailAfterSuccessfulProposalUseCase
 import co.electriccoin.zcash.ui.screen.migration.battery.MigrationBatteryVM
+import co.electriccoin.zcash.ui.screen.migration.complete.MigrationCompleteArgs
 import co.electriccoin.zcash.ui.screen.migration.complete.MigrationCompleteVM
 import co.electriccoin.zcash.ui.screen.migration.customservertor.MigrationCustomServerTorArgs
 import co.electriccoin.zcash.ui.screen.migration.customservertor.MigrationCustomServerTorVM
@@ -169,6 +170,7 @@ class MigrationKoinGraphSmokeTest {
                 factory { MigrationPrivacyArgs(mode = MigrationMode.AUTOMATIC) }
                 factory { MigrationReviewArgs(mode = MigrationMode.AUTOMATIC) }
                 factory { MigrationSuccessArgs(txId = null) }
+                factory { MigrationCompleteArgs() }
             }
 
         koin =

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/model/migration/sim/FakeOrchardMigrationSdk.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/model/migration/sim/FakeOrchardMigrationSdk.kt
@@ -90,8 +90,8 @@ class FakeOrchardMigrationSdk : OrchardMigrationSdk {
     /** Seconds-per-block the harness reports; testnet-fast by default to match live tuning. */
     var secondsPerBlock: Long = 28L
 
-    /** Dust threshold — the fixed protocol constant (0.001 ZEC). */
-    var dustThresholdZatoshi: Long = 100_000L
+    /** Dust threshold — the fixed protocol constant (0.0001 ZEC). */
+    var dustThresholdZatoshi: Long = 10_000L
 
     /**
      * The Orchard balance the fake reports as *still migratable* — i.e. the residual left after

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/model/migration/sim/FakeOrchardMigrationSdk.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/model/migration/sim/FakeOrchardMigrationSdk.kt
@@ -443,6 +443,8 @@ class FakeOrchardMigrationSdk : OrchardMigrationSdk {
 
     override suspend fun migrationDustThresholdZatoshi(): Long = dustThresholdZatoshi
 
+    override suspend fun migratableOrchardTotal(): Long = migratableOrchardZatoshi
+
     override fun isSyncBlocked(): Flow<Boolean> = syncBlocked.asStateFlow()
 
     override fun privacySyncBufferDuration(): Duration = 30.seconds

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/model/migration/sim/MigrationKeystoneMultiRoundScenarioTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/model/migration/sim/MigrationKeystoneMultiRoundScenarioTest.kt
@@ -36,7 +36,7 @@ class MigrationKeystoneMultiRoundScenarioTest {
 
         // Per-run migratable ceiling the engine's note cap imposes.
         const val PER_RUN_CAP: Long = 1_000_000L // 0.01 ZEC per run
-        const val DUST: Long = 100_000L // 0.001 ZEC — the protocol dust threshold
+        const val DUST: Long = 10_000L // 0.0001 ZEC — the protocol dust threshold
 
         // Start with 2.5x a single run's reach: three rounds' worth (ceil(2_500_000/1_000_000) = 3).
         const val INITIAL_RESIDUAL: Long = 2_500_000L
@@ -94,7 +94,7 @@ class MigrationKeystoneMultiRoundScenarioTest {
             assertEquals(2, afterRound1, "1_500_000 / 1_000_000 = 2 runs still to go.")
             assertTrue(
                 anotherRoundNeeded(sdk),
-                "residual 1_500_000 > dust 100_000 and needs >0 further runs — round 2 expected.",
+                "residual 1_500_000 > dust 10_000 and needs >0 further runs — round 2 expected.",
             )
 
             // ── Round 2 completes: another run's worth clears. ──
@@ -104,7 +104,7 @@ class MigrationKeystoneMultiRoundScenarioTest {
             assertTrue(anotherRoundNeeded(sdk), "500_000 > dust — round 3 expected.")
 
             // ── Round 3 clears all but dust. ──
-            driver.setMigratableResidual(zatoshi = DUST - 1L) // 99_999 — below the dust threshold
+            driver.setMigratableResidual(zatoshi = DUST - 1L) // 9_999 — below the dust threshold
             assertEquals(
                 1,
                 sdk.estimateMigrationRunCount(),
@@ -112,7 +112,7 @@ class MigrationKeystoneMultiRoundScenarioTest {
             )
             assertFalse(
                 anotherRoundNeeded(sdk),
-                "…but the app gates on the dust threshold: 99_999 < 100_000 is negligible — campaign ends.",
+                "…but the app gates on the dust threshold: 9_999 < 10_000 is negligible — campaign ends.",
             )
 
             // Exactly-zero residual is unambiguously done.

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/CheckMigrationRecoveryUseCaseTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/CheckMigrationRecoveryUseCaseTest.kt
@@ -162,7 +162,7 @@ class CheckMigrationRecoveryUseCaseTest {
 
             coVerify(exactly = 0) { router.replaceAll(HomeArgs, MigrationTransferInvalidArgs) }
             coVerify(exactly = 0) { router.replaceAll(HomeArgs, MigrationProgressArgs) }
-            coVerify(exactly = 0) { router.replaceAll(HomeArgs, MigrationCompleteArgs) }
+            coVerify(exactly = 0) { router.replaceAll(HomeArgs, MigrationCompleteArgs()) }
         }
 
     @Test
@@ -265,7 +265,7 @@ class CheckMigrationRecoveryUseCaseTest {
                 pendingMigrationTorFailure = false,
             ).invoke()
 
-            coVerify(exactly = 0) { router.replaceAll(HomeArgs, MigrationCompleteArgs) }
+            coVerify(exactly = 0) { router.replaceAll(HomeArgs, MigrationCompleteArgs()) }
             coVerify(exactly = 0) { router.replaceAll(any()) }
         }
 

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCaseMigrationTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCaseMigrationTest.kt
@@ -102,7 +102,15 @@ class GetHomeMessageUseCaseMigrationTest {
                 hasSeenComplete = false,
                 orchardBalanceZatoshi = 500_000L,
             )
-        assertEquals(MigrationHomeMessageData(isRunActive = false, isComplete = true), result)
+        assertEquals(
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = 500_000L,
+            ),
+            result,
+        )
     }
 
     @Test
@@ -114,7 +122,15 @@ class GetHomeMessageUseCaseMigrationTest {
                 hasSeenComplete = false,
                 orchardBalanceZatoshi = MIGRATION_RESIDUAL_MIN_ZATOSHI - 1L,
             )
-        assertEquals(MigrationHomeMessageData(isRunActive = false, isComplete = true), result)
+        assertEquals(
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = MIGRATION_RESIDUAL_MIN_ZATOSHI - 1L,
+            ),
+            result,
+        )
     }
 
     @Test
@@ -126,7 +142,15 @@ class GetHomeMessageUseCaseMigrationTest {
                 hasSeenComplete = false,
                 orchardBalanceZatoshi = MIGRATION_DUST_THRESHOLD_ZATOSHI + 1L,
             )
-        assertEquals(MigrationHomeMessageData(isRunActive = false, isComplete = true), result)
+        assertEquals(
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = MIGRATION_DUST_THRESHOLD_ZATOSHI + 1L,
+            ),
+            result,
+        )
     }
 
     @Test

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/MigrationBannerStateTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/MigrationBannerStateTest.kt
@@ -140,7 +140,15 @@ class MigrationBannerStateTest {
                 hasSeenComplete = false,
                 orchardBalanceZatoshi = 500_000L, // in the (dust, min) gap — residue
             )
-        assertEquals(MigrationHomeMessageData(isRunActive = false, isComplete = true), result)
+        assertEquals(
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = 500_000L,
+            ),
+            result,
+        )
     }
 
     /**
@@ -273,7 +281,15 @@ class MigrationBannerStateTest {
                 hasSeenComplete = false,
                 orchardBalanceZatoshi = 500_000L, // in (dust, min) gap — residue, un-migratable
             )
-        assertEquals(MigrationHomeMessageData(isRunActive = false, isComplete = true), result)
+        assertEquals(
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = 500_000L,
+            ),
+            result,
+        )
     }
 
     // ─── §3 Cross-branch: SyncRequiredBeforeNext during InProgress ────────────

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/MigrationBannerStateTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/MigrationBannerStateTest.kt
@@ -391,4 +391,85 @@ class MigrationBannerStateTest {
         // ready-to-send branch must not have fired despite its other preconditions being met.
         assertEquals(MigrationHomeMessageData(isRunActive = false, completedCount = 1, totalCount = 2), result)
     }
+
+    // ─── §5 Per-note dust gate (Kris Nuttycombe's formula) ────────────────────
+
+    /**
+     * A raw Orchard balance above [MIGRATION_DUST_THRESHOLD_ZATOSHI] can still be true dust if it's
+     * made up of notes too small individually to be worth spending net of MARGINAL_FEE — e.g. many
+     * sub-MARGINAL_FEE notes, or few notes just barely above MARGINAL_FEE. In that case the SDK's
+     * migratableOrchardTotal() (per-note, net of MARGINAL_FEE) reports at or below the threshold
+     * even though the raw balance does not. [migrationMessageFor] must gate the residue banner on
+     * the per-note total, not the raw balance — otherwise it prompts to migrate/lock a balance that
+     * costs more to move than it's worth.
+     */
+    @Test
+    fun rawBalanceAboveDustButPerNoteTotalAtDustShowsNothing() {
+        val result =
+            migrationMessageFor(
+                sdkState = null,
+                snapshot = null,
+                hasSeenComplete = false,
+                orchardBalanceZatoshi = MIGRATION_DUST_THRESHOLD_ZATOSHI + 50_000L, // raw: well above dust
+                migratableOrchardTotalZatoshi = MIGRATION_DUST_THRESHOLD_ZATOSHI, // per-note: at the threshold
+            )
+        // No banner — the per-note total is not strictly above the threshold, even though the raw
+        // balance is. Falls through both the residue branch (gated on the per-note total) and the
+        // "Migrate now" branch (raw balance is still below MIGRATION_RESIDUAL_MIN_ZATOSHI).
+        assertNull(result)
+    }
+
+    /**
+     * Contrast case: when the per-note total genuinely exceeds the threshold, the residue banner
+     * fires exactly as before, and still displays the raw balance (not the net-of-fee total) as
+     * [MigrationHomeMessageData.residualBalanceZatoshi] — the user should see what they actually
+     * hold, not the fee-adjusted figure used only for the internal gate.
+     */
+    @Test
+    fun rawBalanceAndPerNoteTotalBothAboveDustShowsResidueWithRawBalanceDisplayed() {
+        val rawBalance = MIGRATION_DUST_THRESHOLD_ZATOSHI + 50_000L
+        val result =
+            migrationMessageFor(
+                sdkState = null,
+                snapshot = null,
+                hasSeenComplete = false,
+                orchardBalanceZatoshi = rawBalance,
+                migratableOrchardTotalZatoshi = MIGRATION_DUST_THRESHOLD_ZATOSHI + 1L,
+            )
+        assertEquals(
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = rawBalance,
+            ),
+            result,
+        )
+    }
+
+    /**
+     * Omitting [migrationMessageFor]'s migratableOrchardTotalZatoshi parameter defaults it to
+     * orchardBalanceZatoshi — i.e. legacy raw-balance behavior — so every pre-existing call site in
+     * this file and [GetHomeMessageUseCaseMigrationTest] that doesn't pass it keeps its original
+     * meaning unchanged.
+     */
+    @Test
+    fun migratableOrchardTotalZatoshiDefaultsToRawBalance() {
+        val result =
+            migrationMessageFor(
+                sdkState = null,
+                snapshot = null,
+                hasSeenComplete = false,
+                orchardBalanceZatoshi = 500_000L, // in (dust, min) gap — residue, per legacy behavior
+            )
+        assertEquals(
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = 500_000L,
+            ),
+            result,
+        )
+    }
 }

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVMTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVMTest.kt
@@ -208,7 +208,7 @@ class MigrationCompleteVMTest {
         runTest {
             // Regression guard for the threshold discrepancy this test used to reproduce: onDone()'s
             // `moreRoundsNeeded` check used to compare the residual only against
-            // MIGRATION_DUST_THRESHOLD_ZATOSHI (0.001 ZEC) instead of MIGRATION_RESIDUAL_MIN_ZATOSHI
+            // MIGRATION_DUST_THRESHOLD_ZATOSHI (0.0001 ZEC) instead of MIGRATION_RESIDUAL_MIN_ZATOSHI
             // (0.01 ZEC) -- the actual engine minimum below which proposeMigrationTransfers() returns
             // NothingToMigrate. For a balance in the gap between the two (e.g. the live-observed
             // 0.005 ZEC / 500_000L zatoshi used by GetHomeMessageUseCaseMigrationTest's own
@@ -385,6 +385,52 @@ class MigrationCompleteVMTest {
             collectJob.cancel()
         }
 
+    @Test
+    fun isResidueOnlyArgPropagatesThroughToState() =
+        runTest {
+            // MOB-1750: MigrationCompleteArgs.isResidueOnly must reach MigrationCompleteState
+            // unchanged — this is what MigrationCompleteScreen branches its copy/summary card on.
+            val vm =
+                vm(
+                    account = mockk<KeystoneAccount>(relaxed = true),
+                    orchardBalanceZatoshi = 500_000L,
+                    router = FakeNavigationRouter(),
+                    args = MigrationCompleteArgs(isResidueOnly = true),
+                )
+
+            val collectJob = launch { vm.state.collect {} }
+            advanceUntilIdle()
+
+            assertEquals(
+                true,
+                vm.state.value.content
+                    ?.isResidueOnly
+            )
+            collectJob.cancel()
+        }
+
+    @Test
+    fun isResidueOnlyDefaultsToFalseForTheOriginalCelebrationVariant() =
+        runTest {
+            val vm =
+                vm(
+                    account = mockk<KeystoneAccount>(relaxed = true),
+                    orchardBalanceZatoshi = 500_000L,
+                    router = FakeNavigationRouter(),
+                    args = MigrationCompleteArgs(isResidueOnly = false),
+                )
+
+            val collectJob = launch { vm.state.collect {} }
+            advanceUntilIdle()
+
+            assertEquals(
+                false,
+                vm.state.value.content
+                    ?.isResidueOnly
+            )
+            collectJob.cancel()
+        }
+
     private fun invokeOnDone(vm: MigrationCompleteVM) {
         val onDone = MigrationCompleteVM::class.java.getDeclaredMethod("onDone")
         onDone.isAccessible = true
@@ -403,6 +449,7 @@ class MigrationCompleteVMTest {
         account: WalletAccount,
         orchardBalanceZatoshi: Long,
         router: FakeNavigationRouter,
+        args: MigrationCompleteArgs = MigrationCompleteArgs(),
         getOrchardMigrationSdk: GetOrchardMigrationSdkUseCase =
             mockk {
                 coEvery { this@mockk() } returns mockk(relaxed = true)
@@ -414,6 +461,7 @@ class MigrationCompleteVMTest {
         migrationScheduler: MigrationScheduler = mockk(relaxed = true),
         migrationNotifier: MigrationNotifier = mockk(relaxed = true),
     ) = MigrationCompleteVM(
+        args = args,
         getOrchardBalance =
             mockk<GetOrchardBalanceUseCase> {
                 coEvery { this@mockk() } returns Zatoshi(orchardBalanceZatoshi)

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVMTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVMTest.kt
@@ -25,6 +25,7 @@ import co.electriccoin.zcash.ui.common.provider.MigrationNotifier
 import co.electriccoin.zcash.ui.common.repository.BiometricRepository
 import co.electriccoin.zcash.ui.common.repository.KeystoneProposalRepository
 import co.electriccoin.zcash.ui.common.usecase.ErrorMapperUseCase
+import co.electriccoin.zcash.ui.common.usecase.GetIronwoodBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardMigrationSdkUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetSelectedWalletAccountUseCase
@@ -345,6 +346,47 @@ class MigrationCompleteVMTest {
         }
 
     @Test
+    fun residueVariantReadsTotalTransferredFromLiveIronwoodBalanceNotEngineSummary() =
+        runTest {
+            // MOB-1750: for isResidueOnly, "In Ironwood" must be the live Ironwood pool balance
+            // (GetIronwoodBalanceUseCase) -- never the migration engine's campaign-scoped
+            // getMigrationSummary(), which can genuinely have no rows for this account (e.g.
+            // after a debug migration restart) even though the wallet's real Ironwood balance is
+            // nonzero. Pins that the engine summary is never even queried for this variant, and
+            // a mismatched summary value (999 ZEC) is ignored in favor of the real balance.
+            val sdk =
+                mockk<OrchardMigrationSdk> {
+                    coEvery { getMigrationSummary() } returns
+                        MigrationSummary(
+                            totalMigratedZatoshi = 99_900_000_000L,
+                            transferCount = 5,
+                            firstMinedEpochSeconds = 1_785_281_502L,
+                            lastMinedEpochSeconds = 1_785_283_542L,
+                        )
+                }
+            val vm =
+                vm(
+                    account = mockk<KeystoneAccount>(relaxed = true),
+                    orchardBalanceZatoshi = 500_000L,
+                    router = FakeNavigationRouter(),
+                    args = MigrationCompleteArgs(isResidueOnly = true),
+                    ironwoodBalanceZatoshi = 12_450_000L,
+                    getOrchardMigrationSdk = mockk { coEvery { this@mockk() } returns sdk },
+                )
+
+            val collectJob = launch { vm.state.collect {} }
+            advanceUntilIdle()
+
+            assertEquals(
+                stringRes(Zatoshi(12_450_000L)),
+                vm.state.value.content
+                    ?.totalTransferred
+            )
+            coVerify(exactly = 0) { sdk.getMigrationSummary() }
+            collectJob.cancel()
+        }
+
+    @Test
     fun durationDoesNotApplyThePrivacyFloorSinceBothTimestampsAreAlreadyMined() =
         runTest {
             // The displayed duration spans the campaign's first to last MINED transfer -- both
@@ -450,6 +492,7 @@ class MigrationCompleteVMTest {
         orchardBalanceZatoshi: Long,
         router: FakeNavigationRouter,
         args: MigrationCompleteArgs = MigrationCompleteArgs(),
+        ironwoodBalanceZatoshi: Long = 0L,
         getOrchardMigrationSdk: GetOrchardMigrationSdkUseCase =
             mockk {
                 coEvery { this@mockk() } returns mockk(relaxed = true)
@@ -465,6 +508,10 @@ class MigrationCompleteVMTest {
         getOrchardBalance =
             mockk<GetOrchardBalanceUseCase> {
                 coEvery { this@mockk() } returns Zatoshi(orchardBalanceZatoshi)
+            },
+        getIronwoodBalance =
+            mockk<GetIronwoodBalanceUseCase> {
+                coEvery { this@mockk() } returns Zatoshi(ironwoodBalanceZatoshi)
             },
         hasSeenMigrationCompleteStorageProvider = seen,
         hasLockedOrchardDustStorageProvider =

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=7093188d380d8152fa6780c2a7b039549540025c
+SDK_COMMIT_PIN=1bf61214d7ff460d9faaea30baf84729b07c826e
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=1bf61214d7ff460d9faaea30baf84729b07c826e
+SDK_COMMIT_PIN=e607703f56312d826accad5da0abcaa897bb0bd0
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=26dab43dbf6d8f2c8cbb5739686c71685f9e7981
+SDK_COMMIT_PIN=7093188d380d8152fa6780c2a7b039549540025c
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
@@ -1076,6 +1076,11 @@
     <string name="migrationComplete_migrateAnywayFailureRejected">La red rechazó esta transacción. Comunícate con el soporte.</string>
     <string name="migrationComplete_migrateAnywayFailureError">Ocurrió un error al enviar. Comunícate con el soporte.</string>
     <string name="migrationComplete_migrateAnywayFailurePartial">Se enviaron algunas partes de esta transacción, pero no todas. Comunícate con el soporte.</string>
+    <string name="migrationComplete_residueTitle">Te has movido a Ironwood</string>
+    <string name="migrationComplete_residueSubtitle">Un pequeño saldo todavía permanece en Orchard.</string>
+    <string name="migrationComplete_inIronwoodLabel">En Ironwood</string>
+    <string name="migrationComplete_leftInOrchardLabel">Restante en Orchard</string>
+    <string name="migrationComplete_residueRecommendationBody">%1$s todavía está en Orchard. Mover un monto tan específico podría vincular tus fondos de Ironwood con tu historial de Orchard. Te recomendamos bloquearlo en su lugar.</string>
 
     <string name="migrationNotifPermission_title">Permitir notificaciones</string>
     <string name="migrationNotifPermission_subtitle">Si se pierde una transferencia programada o falla un envío en segundo plano, podemos enviarte una notificación local para que abras Zodl. Recibe avisos sobre:</string>
@@ -1203,5 +1208,7 @@
     <string name="migrationHome_readyToSendTitle">Transferencia lista</string>
     <string name="migrationHome_attentionTitle">El plan de migración necesita actualización</string>
     <string name="migrationHome_defaultSubtitle">Mueve tus fondos a Ironwood.</string>
+    <string name="migrationHome_residueTitle">%1$s restante en Orchard</string>
+    <string name="migrationHome_residueSubtitle">Toca para decidir qué hacer con él</string>
 
 </resources>

--- a/ui-design-lib/src/main/res/ui/common/values/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values/strings.xml
@@ -1357,6 +1357,11 @@ Your vote can no longer be submitted.</string>
     <string name="migrationComplete_migrateAnywayFailureRejected">The network rejected this transaction. Please contact support.</string>
     <string name="migrationComplete_migrateAnywayFailureError">Something went wrong while sending. Please contact support.</string>
     <string name="migrationComplete_migrateAnywayFailurePartial">Some but not all of this transaction\'s parts were sent. Please contact support.</string>
+    <string name="migrationComplete_residueTitle">You’ve moved to Ironwood</string>
+    <string name="migrationComplete_residueSubtitle">A small balance is still sitting in Orchard.</string>
+    <string name="migrationComplete_inIronwoodLabel">In Ironwood</string>
+    <string name="migrationComplete_leftInOrchardLabel">Left in Orchard</string>
+    <string name="migrationComplete_residueRecommendationBody">%1$s is still in Orchard. Moving an amount this specific would link your Ironwood funds back to your Orchard history. We recommend locking it instead.</string>
 
     <string name="migrationNotifPermission_title">Allow Notifications</string>
     <string name="migrationNotifPermission_subtitle">If a scheduled transfer is missed or a background submission fails, we can send you a local notification and prompt you to open Zodl. Get notified about:</string>
@@ -1484,5 +1489,7 @@ Your vote can no longer be submitted.</string>
     <string name="migrationHome_readyToSendTitle">Transfer Ready</string>
     <string name="migrationHome_attentionTitle">Migration plan needs update</string>
     <string name="migrationHome_defaultSubtitle">Move your funds to Ironwood.</string>
+    <string name="migrationHome_residueTitle">%1$s left in Orchard</string>
+    <string name="migrationHome_residueSubtitle">Tap to decide what happens to it</string>
 
 </resources>

--- a/ui-lib/src/main/java/co/electriccoin/zcash/di/UseCaseModule.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/di/UseCaseModule.kt
@@ -38,6 +38,7 @@ import co.electriccoin.zcash.ui.common.usecase.GetExchangeRateUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetFilteredActivitiesUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetFlexaStatusUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetHomeMessageUseCase
+import co.electriccoin.zcash.ui.common.usecase.GetIronwoodBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetKeystoneStatusUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetPersistableWalletUseCase
@@ -170,6 +171,7 @@ val useCaseModule =
         factoryOf(::Zip321ParseUriValidationUseCase)
         factoryOf(::GetPersistableWalletUseCase)
         factoryOf(::GetOrchardBalanceUseCase)
+        factoryOf(::GetIronwoodBalanceUseCase)
         factoryOf(::GetSupportUseCase)
         factoryOf(::GetWalletSeedBytesUseCase)
         factoryOf(::ErrorMapperUseCase)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/migration/MigrationDustThreshold.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/migration/MigrationDustThreshold.kt
@@ -9,7 +9,7 @@ package co.electriccoin.zcash.ui.common.model.migration
 // Lives in ui-lib (not feature-migration) so ui-lib-level callers -- e.g.
 // WalletViewModel.shouldShowIronwoodAnnouncement -- can share the same gate feature-migration
 // uses, instead of each module inventing its own threshold.
-const val MIGRATION_DUST_THRESHOLD_ZATOSHI = 100_000L
+const val MIGRATION_DUST_THRESHOLD_ZATOSHI = 10_000L
 
 // The smallest Orchard balance the migration engine will actually migrate. Mirrors librustzcash's
 // `RESIDUAL_MIGRATION_MIN` in `zcash_pool_migration/src/denomination.rs` (0.01 ZEC): below this,

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetIronwoodBalanceUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetIronwoodBalanceUseCase.kt
@@ -1,0 +1,33 @@
+package co.electriccoin.zcash.ui.common.usecase
+
+import cash.z.ecc.android.sdk.model.Zatoshi
+import cash.z.ecc.sdk.extension.ZERO
+import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
+import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+
+/**
+ * The live Ironwood pool balance for the currently selected wallet account, read straight from
+ * the synchronizer (mirrors [GetOrchardBalanceUseCase]'s pattern) rather than reconstructed from
+ * the migration engine's own campaign-scoped bookkeeping
+ * ([cash.z.ecc.android.sdk.OrchardMigrationSdk.getMigrationSummary]).
+ *
+ * `total + locked`, matching [GetBalancePoolsUseCase]'s display semantics (see its kdoc for why
+ * `locked` must be added back in) — this is "what the user currently owns in Ironwood", not "how
+ * much this app's migration engine has moved there", which is a real but narrower fact that can
+ * read zero/stale when the engine's own tracking doesn't have a row for it (e.g. after a debug
+ * migration restart, or funds that arrived in Ironwood some other way).
+ */
+class GetIronwoodBalanceUseCase(
+    private val synchronizerProvider: SynchronizerProvider,
+    private val accountDataSource: AccountDataSource,
+) {
+    suspend operator fun invoke(): Zatoshi {
+        synchronizerProvider.getSynchronizer()
+        val account = accountDataSource.getSelectedAccount()
+        val balances = synchronizerProvider.walletBalances.filterNotNull().first()
+        val ironwood = balances[account.sdkAccount.accountUuid]?.ironwood ?: return Zatoshi.ZERO
+        return ironwood.total + ironwood.locked
+    }
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/migration/MigrationMessage.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/migration/MigrationMessage.kt
@@ -203,6 +203,25 @@ private fun PreviewComplete() =
 
 @PreviewScreens
 @Composable
+private fun PreviewCompleteResidue() =
+    ZcashTheme {
+        BlankSurface {
+            MigrationMessage(
+                contentPadding = PaddingValues(),
+                state =
+                    MigrationMessageState(
+                        phase = MigrationBannerPhase.COMPLETE,
+                        title = "0.008 ZEC left in Orchard",
+                        progressLabel = "Tap to decide what happens to it",
+                        onClick = {},
+                        onButtonClick = {},
+                    ),
+            )
+        }
+    }
+
+@PreviewScreens
+@Composable
 private fun PreviewReadyToSend() =
     ZcashTheme {
         BlankSurface {


### PR DESCRIPTION
## Summary
- New home-banner + Migration Complete screen variant ("You've moved to Ironwood") for a
  small unlocked Orchard residue (0.0001-0.01 ZEC) not tied to an unseen in-app migration
  celebration -- covers a fresh wallet restore and an already-acknowledged completion with
  leftover dust. The original "Migration complete" celebration screen is unchanged and keeps
  precedence whenever it hasn't been seen yet, per the ticket.
- `MigrationCompleteArgs` changed from `data object` to `data class(isResidueOnly)`, threaded
  through the VM into `MigrationCompleteState` so the screen renders the right header/summary
  card/recommendation copy without touching the celebration variant's own rendering path.
- Lowers the shared `MIGRATION_DUST_THRESHOLD_ZATOSHI` fallback to 0.0001 ZEC to match the
  companion SDK PR.
- 7 new EN + ES strings matching the ticket's copy verbatim (ES is my own draft translation,
  not vendor-reviewed -- flagging for a native-speaker pass before release).
- Companion SDK PR: zcash/zcash-android-wallet-sdk#2192 (bugfix/MOB-1750 -> maint/v3.1.x).

Linear: https://linear.app/zodl/issue/MOB-1750

<img width="480" height="956" alt="Screenshot 2026-08-21 at 13 59 15" src="https://github.com/user-attachments/assets/0882f2a6-560c-49dc-b1e6-4d709776c4fa" />
<img width="504" height="1004" alt="Screenshot 2026-08-21 at 13 12 42" src="https://github.com/user-attachments/assets/c127982f-47e1-4d5b-9a47-a345b1ccf488" />
<img width="482" height="960" alt="Screenshot 2026-08-21 at 13 12 36" src="https://github.com/user-attachments/assets/14f2f947-e8f5-4575-a388-763c160285e1" />


## Test plan
- [x] `./gradlew ktlint detektAll` clean (fixed one new `CyclomaticComplexMethod` finding by
      extracting `SummaryCard`, no baseline edits)
- [x] `feature-migration`/`ui-lib` unit test suites pass, including new
      `isResidueOnlyArgPropagatesThroughToState`/`isResidueOnlyDefaultsToFalseForTheOriginalCelebrationVariant`
      coverage for the VM->state wiring
- [x] Full debug APK (`assembleZcashtestnetInternalDebug`) built and installed on an emulator
      against a real testnet wallet with a genuine 0.00545 ZEC Orchard residue -- confirmed the
      new banner/screen render correctly with live data, and (via a temporary, fully-reverted
      local override) confirmed the original celebration screen still renders correctly too

🤖 Generated with [Claude Code](https://claude.com/claude-code)