### PR TITLE
MOB-1723: show the Insufficient Funds sheet for swap proposal failures on every engine

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -210,6 +210,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0 # to fetch all commits
+      - name: Set up companion SDK build (if SDK_COMMIT_PIN is set)
+        timeout-minutes: 30
+        uses: ./.github/actions/setup-sdk-companion
       - name: Set up Java
         uses: ./.github/actions/setup-java
         timeout-minutes: 1
@@ -217,7 +220,10 @@ jobs:
         uses: ./.github/actions/setup-gradle
         timeout-minutes: 5
       - name: Test
-        timeout-minutes: 15
+        # 45 rather than the usual 15: when SDK_COMMIT_PIN is set (see
+        # setup-sdk-companion), compiling :ui-lib pulls in the full companion SDK's Rust
+        # dependency graph, which can take ~20-25 min alone on a cold cargo/target cache.
+        timeout-minutes: 45
         run: |
           ./gradlew :configuration-api-lib:check :crash-lib:check :preference-api-lib:check :spackle-lib:check :ui-design-lib:check
           ./gradlew :ui-lib:testZcashmainnetStoreDebugUnitTest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed:
 
+- Requesting a swap quote you cannot afford now shows the Insufficient Funds sheet instead of the technical error screen. The balance is
+  re-checked right before the quote is requested, so a balance that dropped after you typed the amount is caught, and any remaining shortfall
+  found while building the transaction is now reported by the SDK as an insufficient-funds failure rather than a raw error.
 - We polished several UI details: the swap quote review header now stands out from the sheet background, the Activity header turns frosted
   sooner so it stays readable while you scroll, the Terms of Service icon matches the Privacy Policy one, and the Ironwood migration screens
   scroll properly on small displays.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed:
 
-- Requesting a swap quote you cannot afford now shows the Insufficient Funds sheet instead of the technical error screen. The balance is
-  re-checked right before the quote is requested, so a balance that dropped after you typed the amount is caught, and any remaining shortfall
+- Requesting a swap quote you cannot afford now shows the Insufficient Funds sheet instead of the technical error screen. A shortfall
   found while building the transaction is now reported by the SDK as an insufficient-funds failure rather than a raw error.
 - The app-lock re-authentication timeout is now measured with a monotonic clock instead of the system wall clock, so it can no longer be
   bypassed by changing the device's date and time.

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=d15f8472ef071357a253f32da8e2de9b62699b81
+SDK_COMMIT_PIN=4b39e71fab64aeab65d34f1aa8ba97ffee1155ee
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=26dab43dbf6d8f2c8cbb5739686c71685f9e7981
+SDK_COMMIT_PIN=d15f8472ef071357a253f32da8e2de9b62699b81
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -18,7 +18,6 @@ import cash.z.ecc.android.sdk.model.proposeSend
 import cash.z.ecc.android.sdk.type.AddressType
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
 import co.electriccoin.zcash.spackle.Twig
-import co.electriccoin.zcash.ui.common.model.KeystoneAccount
 import co.electriccoin.zcash.ui.common.model.NetworkDimension
 import co.electriccoin.zcash.ui.common.model.SubmitResult
 import co.electriccoin.zcash.ui.common.model.SwapQuote
@@ -35,36 +34,20 @@ import org.zecdev.zip321.parser.ParserContext
 import java.math.BigDecimal
 
 interface ProposalDataSource {
-    @Throws(
-        TransactionProposalNotCreatedException::class,
-        InsufficientFundsException::class,
-        TexUnsupportedOnKSException::class
-    )
+    @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createProposal(account: WalletAccount, send: ZecSend): RegularTransactionProposal
 
-    @Throws(
-        TransactionProposalNotCreatedException::class,
-        InsufficientFundsException::class,
-        TexUnsupportedOnKSException::class
-    )
+    @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createZip321Proposal(account: WalletAccount, zip321Uri: String): Zip321TransactionProposal
 
-    @Throws(
-        TransactionProposalNotCreatedException::class,
-        InsufficientFundsException::class,
-        TexUnsupportedOnKSException::class
-    )
+    @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createExactInputProposal(
         account: WalletAccount,
         send: ZecSend,
         quote: SwapQuote,
     ): ExactInputSwapTransactionProposal
 
-    @Throws(
-        TransactionProposalNotCreatedException::class,
-        InsufficientFundsException::class,
-        TexUnsupportedOnKSException::class
-    )
+    @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createExactOutputProposal(
         account: WalletAccount,
         send: ZecSend,
@@ -74,7 +57,7 @@ interface ProposalDataSource {
     @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createShieldProposal(account: WalletAccount): ShieldTransactionProposal
 
-    @Throws(PcztException.CreatePcztFromProposalException::class)
+    @Throws(PcztException.CreatePcztFromProposalException::class, TexUnsupportedOnKSException::class)
     suspend fun createPcztFromProposal(account: WalletAccount, proposal: Proposal): Pczt
 
     @Throws(PcztException.AddProofsToPcztException::class)
@@ -92,7 +75,9 @@ class TransactionProposalNotCreatedException(
     cause: Exception
 ) : Exception(cause)
 
-class InsufficientFundsException : Exception()
+class InsufficientFundsException(
+    cause: Throwable? = null
+) : Exception(cause)
 
 class TexUnsupportedOnKSException : Exception("TEX addresses are unsupported on Keystone")
 
@@ -106,7 +91,6 @@ class ProposalDataSourceImpl(
     override suspend fun createProposal(account: WalletAccount, send: ZecSend): RegularTransactionProposal =
         withContext(Dispatchers.IO) {
             getOrThrow { synchronizer ->
-                validate(account, synchronizer, send.destination.address)
                 RegularTransactionProposal(
                     destination = send.destination,
                     amount = send.amount,
@@ -140,8 +124,6 @@ class ProposalDataSourceImpl(
                         )
                     }
 
-                validate(account, synchronizer, payment.recipientAddress.value)
-
                 if (payment.nonNegativeAmount == null) {
                     throw TransactionProposalNotCreatedException(IllegalArgumentException("Null amount"))
                 }
@@ -171,7 +153,6 @@ class ProposalDataSourceImpl(
     ): ExactInputSwapTransactionProposal =
         withContext(Dispatchers.IO) {
             getOrThrow { synchronizer ->
-                validate(account, synchronizer, send.destination.address)
                 ExactInputSwapTransactionProposal(
                     destination = send.destination,
                     amount = send.amount,
@@ -189,7 +170,6 @@ class ProposalDataSourceImpl(
     ): ExactOutputSwapTransactionProposal =
         withContext(Dispatchers.IO) {
             getOrThrow { synchronizer ->
-                validate(account, synchronizer, send.destination.address)
                 ExactOutputSwapTransactionProposal(
                     destination = send.destination,
                     amount = send.amount,
@@ -221,11 +201,14 @@ class ProposalDataSourceImpl(
 
     override suspend fun createPcztFromProposal(account: WalletAccount, proposal: Proposal): Pczt =
         withContext(Dispatchers.IO) {
-            val synchronizer = synchronizerProvider.getSynchronizer()
-            synchronizer.createPcztFromProposal(
-                accountUuid = account.sdkAccount.accountUuid,
-                proposal = proposal
-            )
+            try {
+                synchronizerProvider.getSynchronizer().createPcztFromProposal(
+                    accountUuid = account.sdkAccount.accountUuid,
+                    proposal = proposal
+                )
+            } catch (_: PcztException.MultiStepProposalUnsupportedException) {
+                throw TexUnsupportedOnKSException()
+            }
         }
 
     override suspend fun addProofsToPczt(pczt: Pczt): Pczt =
@@ -257,20 +240,6 @@ class ProposalDataSourceImpl(
                 .getSynchronizer()
                 .redactPcztForSigner(pczt)
         }
-
-    /**
-     * @throws TexUnsupportedOnKSException if the address is a TEX address and the account is a Keystone account
-     */
-    @Throws(TexUnsupportedOnKSException::class)
-    private suspend fun validate(
-        account: WalletAccount,
-        synchronizer: Synchronizer,
-        address: String
-    ) {
-        if (account is KeystoneAccount && synchronizer.validateAddress(address) == AddressType.Tex) {
-            throw TexUnsupportedOnKSException()
-        }
-    }
 
     @Suppress("CyclomaticComplexMethod", "TooGenericExceptionCaught")
     private suspend fun submitTransactionInternal(
@@ -355,17 +324,8 @@ class ProposalDataSourceImpl(
         try {
             val synchronizer = synchronizerProvider.getSynchronizer()
             block(synchronizer)
-        } catch (e: TransactionEncoderException.ProposalFromParametersException) {
-            val message = e.rootCause.message ?: ""
-            if (message.contains("Insufficient balance", true) ||
-                message.contains("The transaction requires an additional change output of", true)
-            ) {
-                throw InsufficientFundsException()
-            } else {
-                throw TransactionProposalNotCreatedException(e)
-            }
-        } catch (e: TexUnsupportedOnKSException) {
-            throw e
+        } catch (e: TransactionEncoderException.InsufficientFundsException) {
+            throw InsufficientFundsException(e)
         } catch (e: TransactionProposalNotCreatedException) {
             throw e
         } catch (e: Exception) {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -57,7 +57,16 @@ interface ProposalDataSource {
     @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createShieldProposal(account: WalletAccount): ShieldTransactionProposal
 
-    @Throws(PcztException.CreatePcztFromProposalException::class, TexUnsupportedOnKSException::class)
+    /**
+     * Propagates the SDK's [PcztException.MultiStepProposalUnsupportedException] untouched: whether a
+     * multi-step rejection means "TEX is unsupported on Keystone" depends on what the proposal was
+     * for, which only the caller knows (see
+     * [co.electriccoin.zcash.ui.common.repository.KeystoneProposalRepository.createPCZTFromProposal]).
+     */
+    @Throws(
+        PcztException.CreatePcztFromProposalException::class,
+        PcztException.MultiStepProposalUnsupportedException::class
+    )
     suspend fun createPcztFromProposal(account: WalletAccount, proposal: Proposal): Pczt
 
     @Throws(PcztException.AddProofsToPcztException::class)
@@ -201,14 +210,10 @@ class ProposalDataSourceImpl(
 
     override suspend fun createPcztFromProposal(account: WalletAccount, proposal: Proposal): Pczt =
         withContext(Dispatchers.IO) {
-            try {
-                synchronizerProvider.getSynchronizer().createPcztFromProposal(
-                    accountUuid = account.sdkAccount.accountUuid,
-                    proposal = proposal
-                )
-            } catch (_: PcztException.MultiStepProposalUnsupportedException) {
-                throw TexUnsupportedOnKSException()
-            }
+            synchronizerProvider.getSynchronizer().createPcztFromProposal(
+                accountUuid = account.sdkAccount.accountUuid,
+                proposal = proposal
+            )
         }
 
     override suspend fun addProofsToPczt(pczt: Pczt): Pczt =

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/WalletAccount.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/WalletAccount.kt
@@ -174,3 +174,17 @@ data class SaplingInfo(
     val address: WalletAddress.Sapling,
     val balance: WalletBalance
 )
+
+/**
+ * The single spendability primitive the whole app validates against, so a typing-time check and the
+ * proposal-time check in the SDK can never disagree. A null receiver (no account selected yet) can
+ * spend nothing.
+ */
+fun WalletAccount?.canSpend(amount: Zatoshi): Boolean = this?.canSpend(amount) ?: false
+
+/**
+ * The spendable balance a screen may display for a possibly-not-yet-selected account, zero when no
+ * account is available.
+ */
+val WalletAccount?.totalSpendableBalance: Zatoshi
+    get() = this?.spendableShieldedBalance ?: Zatoshi(0)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/KeystoneProposalRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/KeystoneProposalRepository.kt
@@ -45,32 +45,16 @@ interface KeystoneProposalRepository {
 
     val submitState: StateFlow<SubmitProposalState?>
 
-    @Throws(
-        TransactionProposalNotCreatedException::class,
-        InsufficientFundsException::class,
-        TexUnsupportedOnKSException::class
-    )
+    @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createProposal(zecSend: ZecSend)
 
-    @Throws(
-        TransactionProposalNotCreatedException::class,
-        InsufficientFundsException::class,
-        TexUnsupportedOnKSException::class
-    )
+    @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createExactInputSwapProposal(zecSend: ZecSend, quote: SwapQuote): ExactInputSwapTransactionProposal
 
-    @Throws(
-        TransactionProposalNotCreatedException::class,
-        InsufficientFundsException::class,
-        TexUnsupportedOnKSException::class
-    )
+    @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createExactOutputSwapProposal(zecSend: ZecSend, quote: SwapQuote): ExactOutputSwapTransactionProposal
 
-    @Throws(
-        TransactionProposalNotCreatedException::class,
-        InsufficientFundsException::class,
-        TexUnsupportedOnKSException::class
-    )
+    @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createZip321Proposal(zip321Uri: String): Zip321TransactionProposal
 
     @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
@@ -83,7 +67,7 @@ interface KeystoneProposalRepository {
      */
     fun setMigrationSweepProposal(proposal: Proposal, amount: Zatoshi)
 
-    @Throws(PcztException.CreatePcztFromProposalException::class)
+    @Throws(PcztException.CreatePcztFromProposalException::class, TexUnsupportedOnKSException::class)
     suspend fun createPCZTFromProposal()
 
     @Throws(IllegalStateException::class)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/KeystoneProposalRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/KeystoneProposalRepository.kt
@@ -3,6 +3,7 @@ package co.electriccoin.zcash.ui.common.repository
 import cash.z.ecc.android.sdk.exception.PcztException
 import cash.z.ecc.android.sdk.model.Pczt
 import cash.z.ecc.android.sdk.model.Proposal
+import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.model.ZecSend
 import co.electriccoin.zcash.spackle.Twig
@@ -12,6 +13,7 @@ import co.electriccoin.zcash.ui.common.datasource.ExactOutputSwapTransactionProp
 import co.electriccoin.zcash.ui.common.datasource.InsufficientFundsException
 import co.electriccoin.zcash.ui.common.datasource.MigrationSweepTransactionProposal
 import co.electriccoin.zcash.ui.common.datasource.ProposalDataSource
+import co.electriccoin.zcash.ui.common.datasource.SendTransactionProposal
 import co.electriccoin.zcash.ui.common.datasource.TexUnsupportedOnKSException
 import co.electriccoin.zcash.ui.common.datasource.TransactionProposal
 import co.electriccoin.zcash.ui.common.datasource.TransactionProposalNotCreatedException
@@ -67,7 +69,19 @@ interface KeystoneProposalRepository {
      */
     fun setMigrationSweepProposal(proposal: Proposal, amount: Zatoshi)
 
-    @Throws(PcztException.CreatePcztFromProposalException::class, TexUnsupportedOnKSException::class)
+    /**
+     * The SDK rejects any multi-step proposal for PCZT generation. That rejection is surfaced as
+     * [TexUnsupportedOnKSException] only when the current proposal actually pays a TEX (ZIP-320)
+     * address — the one flow where a multi-step proposal is the expected shape. For every other
+     * proposal (shielding, migration sweeps), the raw
+     * [PcztException.MultiStepProposalUnsupportedException] propagates so a TEX-specific error can
+     * never be shown for a failure unrelated to TEX.
+     */
+    @Throws(
+        PcztException.CreatePcztFromProposalException::class,
+        PcztException.MultiStepProposalUnsupportedException::class,
+        TexUnsupportedOnKSException::class
+    )
     suspend fun createPCZTFromProposal()
 
     @Throws(IllegalStateException::class)
@@ -186,14 +200,22 @@ class KeystoneProposalRepositoryImpl(
     }
 
     override suspend fun createPCZTFromProposal() {
+        val transactionProposal = getTransactionProposal()
         val result =
-            proposalDataSource.createPcztFromProposal(
-                account = accountDataSource.getSelectedAccount(),
-                proposal = getTransactionProposal().proposal
-            )
+            try {
+                proposalDataSource.createPcztFromProposal(
+                    account = accountDataSource.getSelectedAccount(),
+                    proposal = transactionProposal.proposal
+                )
+            } catch (e: PcztException.MultiStepProposalUnsupportedException) {
+                if (transactionProposal.paysTexAddress()) throw TexUnsupportedOnKSException() else throw e
+            }
         proposalPczt = result
         addProofsToPczt(result)
     }
+
+    private fun TransactionProposal.paysTexAddress(): Boolean =
+        this is SendTransactionProposal && destination is WalletAddress.Tex
 
     private fun addProofsToPczt(proposalPczt: Pczt) {
         pcztWithProofsJob?.cancel()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
@@ -1,5 +1,6 @@
 package co.electriccoin.zcash.ui.common.usecase
 
+import cash.z.ecc.android.sdk.ext.convertZecToZatoshi
 import cash.z.ecc.android.sdk.model.Memo
 import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.model.Zatoshi
@@ -47,6 +48,11 @@ class RequestSwapQuoteUseCase(
         slippage: BigDecimal,
         canNavigateToSwapQuote: () -> Boolean
     ) {
+        if (!accountDataSource.getSelectedAccount().canSpend(amount.convertZecToZatoshi())) {
+            navigationRouter.forward(InsufficientFundsArgs)
+            return
+        }
+
         val newAddress = accountDataSource.requestNextShieldedAddress()
         requestQuote(
             requestQuote = {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
@@ -24,14 +24,12 @@ import co.electriccoin.zcash.ui.common.repository.ZashiProposalRepository
 import co.electriccoin.zcash.ui.screen.error.ErrorArgs
 import co.electriccoin.zcash.ui.screen.error.NavigateToErrorUseCase
 import co.electriccoin.zcash.ui.screen.insufficientfunds.InsufficientFundsArgs
-import co.electriccoin.zcash.ui.screen.swap.convertZecToZatoshi
 import co.electriccoin.zcash.ui.screen.swap.quote.SwapQuoteArgs
 import co.electriccoin.zcash.ui.screen.texunsupported.TEXUnsupportedArgs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import java.math.BigDecimal
-import java.math.MathContext
 
 class RequestSwapQuoteUseCase(
     private val navigationRouter: NavigationRouter,
@@ -42,13 +40,6 @@ class RequestSwapQuoteUseCase(
     private val accountDataSource: AccountDataSource,
     private val synchronizerProvider: SynchronizerProvider,
 ) {
-    /**
-     * The balance pre-check here is a best-effort fast path against a snapshot of the selected
-     * account: it saves the address rotation and the provider round-trip when the amount is plainly
-     * unaffordable. The authoritative check is the SDK's typed insufficient-funds failure at
-     * proposal time, which is evaluated against the account the proposal is actually built for and
-     * lands on the same Insufficient Funds sheet.
-     */
     suspend fun requestExactInput(
         amount: BigDecimal,
         address: String,
@@ -56,14 +47,6 @@ class RequestSwapQuoteUseCase(
         slippage: BigDecimal,
         canNavigateToSwapQuote: () -> Boolean
     ) {
-        if (!accountDataSource.getSelectedAccount().canSpend(amount.convertZecToZatoshi())) {
-            swapRepository.clearQuote()
-            zashiProposalRepository.clear()
-            keystoneProposalRepository.clear()
-            navigationRouter.forward(InsufficientFundsArgs)
-            return
-        }
-
         val newAddress = accountDataSource.requestNextShieldedAddress()
         requestQuote(
             requestQuote = {
@@ -80,19 +63,6 @@ class RequestSwapQuoteUseCase(
         )
     }
 
-    /**
-     * The balance pre-check here is a best-effort fast path against a snapshot of the selected
-     * account: it saves the address rotation and the provider round-trip when the amount is plainly
-     * unaffordable. The authoritative check is the SDK's typed insufficient-funds failure at
-     * proposal time, which is evaluated against the account the proposal is actually built for and
-     * lands on the same Insufficient Funds sheet.
-     *
-     * Unlike [requestExactInput], [amount] here is denominated in [selectedAsset]'s units, not ZEC
-     * (it is the destination amount the caller typed in), so it must go through the same USD
-     * cross-rate conversion as the pre-quote ZEC estimate before the check can run at all. When the
-     * ZEC or destination asset price isn't loaded yet, the pre-check is skipped rather than blocking
-     * on an unpriced amount, leaving the authoritative proposal-time check to decide.
-     */
     suspend fun requestExactOutput(
         amount: BigDecimal,
         address: String,
@@ -100,15 +70,6 @@ class RequestSwapQuoteUseCase(
         slippage: BigDecimal,
         canNavigateToSwapQuote: () -> Boolean
     ) {
-        val destinationZatoshi = amount.toDestinationAssetZatoshi(selectedAsset)
-        if (destinationZatoshi != null && !accountDataSource.getSelectedAccount().canSpend(destinationZatoshi)) {
-            swapRepository.clearQuote()
-            zashiProposalRepository.clear()
-            keystoneProposalRepository.clear()
-            navigationRouter.forward(InsufficientFundsArgs)
-            return
-        }
-
         val newAddress = accountDataSource.requestNextShieldedAddress()
         requestQuote(
             requestQuote = {
@@ -215,26 +176,6 @@ class RequestSwapQuoteUseCase(
                     FLEX_INPUT -> throw UnsupportedOperationException("Flex input swap not supported")
                 }
             }
-        }
-    }
-
-    /**
-     * Converts an amount denominated in [destinationAsset]'s units into the ZEC it costs to buy, via
-     * the same USD cross-rate [co.electriccoin.zcash.ui.screen.pay.ExactOutputVMMapper] already uses
-     * for its own zatoshi estimate, then clamps it to zatoshi through [convertZecToZatoshi]. Returns
-     * null when either price isn't loaded yet.
-     */
-    private fun BigDecimal.toDestinationAssetZatoshi(destinationAsset: SwapAsset): Zatoshi? {
-        val zecPrice =
-            swapRepository.assets.value.zecAsset
-                ?.usdPrice
-        val assetPrice = destinationAsset.usdPrice
-        return if (zecPrice == null || assetPrice == null) {
-            null
-        } else {
-            multiply(assetPrice, MathContext.DECIMAL128)
-                .divide(zecPrice, MathContext.DECIMAL128)
-                .convertZecToZatoshi()
         }
     }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import java.math.BigDecimal
+import java.math.MathContext
 
 class RequestSwapQuoteUseCase(
     private val navigationRouter: NavigationRouter,
@@ -85,6 +86,12 @@ class RequestSwapQuoteUseCase(
      * unaffordable. The authoritative check is the SDK's typed insufficient-funds failure at
      * proposal time, which is evaluated against the account the proposal is actually built for and
      * lands on the same Insufficient Funds sheet.
+     *
+     * Unlike [requestExactInput], [amount] here is denominated in [selectedAsset]'s units, not ZEC
+     * (it is the destination amount the caller typed in), so it must go through the same USD
+     * cross-rate conversion as the pre-quote ZEC estimate before the check can run at all. When the
+     * ZEC or destination asset price isn't loaded yet, the pre-check is skipped rather than blocking
+     * on an unpriced amount, leaving the authoritative proposal-time check to decide.
      */
     suspend fun requestExactOutput(
         amount: BigDecimal,
@@ -93,7 +100,8 @@ class RequestSwapQuoteUseCase(
         slippage: BigDecimal,
         canNavigateToSwapQuote: () -> Boolean
     ) {
-        if (!accountDataSource.getSelectedAccount().canSpend(amount.convertZecToZatoshi())) {
+        val destinationZatoshi = amount.toDestinationAssetZatoshi(selectedAsset)
+        if (destinationZatoshi != null && !accountDataSource.getSelectedAccount().canSpend(destinationZatoshi)) {
             swapRepository.clearQuote()
             zashiProposalRepository.clear()
             keystoneProposalRepository.clear()
@@ -207,6 +215,26 @@ class RequestSwapQuoteUseCase(
                     FLEX_INPUT -> throw UnsupportedOperationException("Flex input swap not supported")
                 }
             }
+        }
+    }
+
+    /**
+     * Converts an amount denominated in [destinationAsset]'s units into the ZEC it costs to buy, via
+     * the same USD cross-rate [co.electriccoin.zcash.ui.screen.pay.ExactOutputVMMapper] already uses
+     * for its own zatoshi estimate, then clamps it to zatoshi through [convertZecToZatoshi]. Returns
+     * null when either price isn't loaded yet.
+     */
+    private fun BigDecimal.toDestinationAssetZatoshi(destinationAsset: SwapAsset): Zatoshi? {
+        val zecPrice =
+            swapRepository.assets.value.zecAsset
+                ?.usdPrice
+        val assetPrice = destinationAsset.usdPrice
+        return if (zecPrice == null || assetPrice == null) {
+            null
+        } else {
+            multiply(assetPrice, MathContext.DECIMAL128)
+                .divide(zecPrice, MathContext.DECIMAL128)
+                .convertZecToZatoshi()
         }
     }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
@@ -79,6 +79,13 @@ class RequestSwapQuoteUseCase(
         )
     }
 
+    /**
+     * The balance pre-check here is a best-effort fast path against a snapshot of the selected
+     * account: it saves the address rotation and the provider round-trip when the amount is plainly
+     * unaffordable. The authoritative check is the SDK's typed insufficient-funds failure at
+     * proposal time, which is evaluated against the account the proposal is actually built for and
+     * lands on the same Insufficient Funds sheet.
+     */
     suspend fun requestExactOutput(
         amount: BigDecimal,
         address: String,
@@ -86,6 +93,14 @@ class RequestSwapQuoteUseCase(
         slippage: BigDecimal,
         canNavigateToSwapQuote: () -> Boolean
     ) {
+        if (!accountDataSource.getSelectedAccount().canSpend(amount.convertZecToZatoshi())) {
+            swapRepository.clearQuote()
+            zashiProposalRepository.clear()
+            keystoneProposalRepository.clear()
+            navigationRouter.forward(InsufficientFundsArgs)
+            return
+        }
+
         val newAddress = accountDataSource.requestNextShieldedAddress()
         requestQuote(
             requestQuote = {
@@ -140,9 +155,11 @@ class RequestSwapQuoteUseCase(
             try {
                 createProposal(result.quote)
             } catch (_: TexUnsupportedOnKSException) {
-                navigationRouter.forward(TEXUnsupportedArgs)
-                keystoneProposalRepository.clear()
+                swapRepository.clearQuote()
                 zashiProposalRepository.clear()
+                keystoneProposalRepository.clear()
+                navigationRouter.forward(TEXUnsupportedArgs)
+                return@withContext
             } catch (_: InsufficientFundsException) {
                 swapRepository.clearQuote()
                 zashiProposalRepository.clear()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
@@ -1,6 +1,5 @@
 package co.electriccoin.zcash.ui.common.usecase
 
-import cash.z.ecc.android.sdk.ext.convertZecToZatoshi
 import cash.z.ecc.android.sdk.model.Memo
 import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.model.Zatoshi
@@ -25,6 +24,7 @@ import co.electriccoin.zcash.ui.common.repository.ZashiProposalRepository
 import co.electriccoin.zcash.ui.screen.error.ErrorArgs
 import co.electriccoin.zcash.ui.screen.error.NavigateToErrorUseCase
 import co.electriccoin.zcash.ui.screen.insufficientfunds.InsufficientFundsArgs
+import co.electriccoin.zcash.ui.screen.swap.convertZecToZatoshi
 import co.electriccoin.zcash.ui.screen.swap.quote.SwapQuoteArgs
 import co.electriccoin.zcash.ui.screen.texunsupported.TEXUnsupportedArgs
 import kotlinx.coroutines.Dispatchers
@@ -41,6 +41,13 @@ class RequestSwapQuoteUseCase(
     private val accountDataSource: AccountDataSource,
     private val synchronizerProvider: SynchronizerProvider,
 ) {
+    /**
+     * The balance pre-check here is a best-effort fast path against a snapshot of the selected
+     * account: it saves the address rotation and the provider round-trip when the amount is plainly
+     * unaffordable. The authoritative check is the SDK's typed insufficient-funds failure at
+     * proposal time, which is evaluated against the account the proposal is actually built for and
+     * lands on the same Insufficient Funds sheet.
+     */
     suspend fun requestExactInput(
         amount: BigDecimal,
         address: String,
@@ -49,6 +56,9 @@ class RequestSwapQuoteUseCase(
         canNavigateToSwapQuote: () -> Boolean
     ) {
         if (!accountDataSource.getSelectedAccount().canSpend(amount.convertZecToZatoshi())) {
+            swapRepository.clearQuote()
+            zashiProposalRepository.clear()
+            keystoneProposalRepository.clear()
             navigationRouter.forward(InsufficientFundsArgs)
             return
         }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/ExactOutputVMMapper.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/ExactOutputVMMapper.kt
@@ -103,7 +103,7 @@ internal class ExactOutputVMMapper {
         return stringResByDynamicCurrencyNumber(state.getZec() ?: BigDecimal(0), CURRENCY_TICKER).withStyle(
             StyledStringStyle(
                 color =
-                    if (zatoshi != null && state.totalSpendableBalance < zatoshi) {
+                    if (zatoshi != null && !state.canSpend(zatoshi)) {
                         StringResourceColor.HINT_ERROR
                     } else {
                         StringResourceColor.PRIMARY
@@ -137,7 +137,7 @@ internal class ExactOutputVMMapper {
 
     private fun createAmountErrorState(state: ExactOutputInternalState): StringResource? {
         val zatoshi = state.getZatoshi()
-        return if (zatoshi != null && state.totalSpendableBalance < zatoshi) {
+        return if (zatoshi != null && !state.canSpend(zatoshi)) {
             stringRes(R.string.send_error_insufficientFunds)
         } else {
             null
@@ -181,7 +181,7 @@ internal class ExactOutputVMMapper {
             },
             isEnabled = !state.isRequestingQuote,
             explicitError =
-                if (zatoshi != null && state.totalSpendableBalance < zatoshi) {
+                if (zatoshi != null && !state.canSpend(zatoshi)) {
                     stringRes("")
                 } else {
                     null
@@ -223,7 +223,7 @@ internal class ExactOutputVMMapper {
             },
             isEnabled = !state.isRequestingQuote,
             explicitError =
-                if (zatoshi != null && state.totalSpendableBalance < zatoshi) {
+                if (zatoshi != null && !state.canSpend(zatoshi)) {
                     stringRes("")
                 } else {
                     null

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/ExactOutputVMMapper.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/ExactOutputVMMapper.kt
@@ -98,19 +98,17 @@ internal class ExactOutputVMMapper {
         )
     }
 
-    private fun createZecAmount(state: ExactOutputInternalState): StyledStringResource {
-        val zatoshi = state.getZatoshi()
-        return stringResByDynamicCurrencyNumber(state.getZec() ?: BigDecimal(0), CURRENCY_TICKER).withStyle(
+    private fun createZecAmount(state: ExactOutputInternalState): StyledStringResource =
+        stringResByDynamicCurrencyNumber(state.getZec() ?: BigDecimal(0), CURRENCY_TICKER).withStyle(
             StyledStringStyle(
                 color =
-                    if (zatoshi != null && !state.canSpend(zatoshi)) {
+                    if (state.isInsufficientFunds) {
                         StringResourceColor.HINT_ERROR
                     } else {
                         StringResourceColor.PRIMARY
                     }
             )
         )
-    }
 
     fun createFiatAmountInnerState(
         amountInnerState: NumberTextFieldInnerState,
@@ -135,21 +133,18 @@ internal class ExactOutputVMMapper {
         )
     }
 
-    private fun createAmountErrorState(state: ExactOutputInternalState): StringResource? {
-        val zatoshi = state.getZatoshi()
-        return if (zatoshi != null && !state.canSpend(zatoshi)) {
+    private fun createAmountErrorState(state: ExactOutputInternalState): StringResource? =
+        if (state.isInsufficientFunds) {
             stringRes(R.string.send_error_insufficientFunds)
         } else {
             null
         }
-    }
 
     private fun createAmountState(
         state: ExactOutputInternalState,
         onTextFieldChange: (amount: NumberTextFieldInnerState, fiat: NumberTextFieldInnerState) -> Unit,
-    ): NumberTextFieldState {
-        val zatoshi = state.getZatoshi()
-        return NumberTextFieldState(
+    ): NumberTextFieldState =
+        NumberTextFieldState(
             innerState = state.amount,
             onValueChange = { amountInnerState ->
                 val amount = amountInnerState.amount
@@ -181,20 +176,18 @@ internal class ExactOutputVMMapper {
             },
             isEnabled = !state.isRequestingQuote,
             explicitError =
-                if (zatoshi != null && !state.canSpend(zatoshi)) {
+                if (state.isInsufficientFunds) {
                     stringRes("")
                 } else {
                     null
                 }
         )
-    }
 
     private fun createFiatAmountState(
         state: ExactOutputInternalState,
         onTextFieldChange: (amount: NumberTextFieldInnerState, fiat: NumberTextFieldInnerState) -> Unit,
-    ): NumberTextFieldState {
-        val zatoshi = state.getZatoshi()
-        return NumberTextFieldState(
+    ): NumberTextFieldState =
+        NumberTextFieldState(
             innerState = state.fiatAmount,
             onValueChange = { fiatInnerState ->
                 val fiat = fiatInnerState.amount
@@ -223,13 +216,12 @@ internal class ExactOutputVMMapper {
             },
             isEnabled = !state.isRequestingQuote,
             explicitError =
-                if (zatoshi != null && !state.canSpend(zatoshi)) {
+                if (state.isInsufficientFunds) {
                     stringRes("")
                 } else {
                     null
                 }
         )
-    }
 
     private fun createAssetState(
         state: ExactOutputInternalState,
@@ -418,6 +410,13 @@ private data class ExactOutputInternalState(
         isABHintVisible = original.isABHintVisible,
         isEphemeralAddressLocked = original.isEphemeralAddressLocked
     )
+
+    /**
+     * The one insufficient-funds signal every facet of this screen (ZEC amount color, error label,
+     * both text fields) renders from, computed once per state instance so the rule can never drift
+     * between them.
+     */
+    val isInsufficientFunds: Boolean = getZatoshi()?.let { !canSpend(it) } == true
 
     fun getOriginFiatAmount(): BigDecimal? {
         val tokenAmount = amount.amount

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayVM.kt
@@ -317,6 +317,13 @@ internal interface InternalState {
 
     val totalSpendableBalance: Zatoshi
         get() = account?.spendableShieldedBalance ?: Zatoshi(0)
+
+    /**
+     * The single spendability primitive the whole app validates against, so the typing-time check and
+     * the proposal-time check in the SDK can never disagree. Re-evaluated whenever the selected
+     * account emits a new balance.
+     */
+    fun canSpend(amount: Zatoshi): Boolean = account?.canSpend(amount) ?: false
 }
 
 internal data class InternalStateImpl(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayVM.kt
@@ -9,6 +9,8 @@ import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.model.SwapAsset
 import co.electriccoin.zcash.ui.common.model.SwapMode
 import co.electriccoin.zcash.ui.common.model.WalletAccount
+import co.electriccoin.zcash.ui.common.model.canSpend
+import co.electriccoin.zcash.ui.common.model.totalSpendableBalance
 import co.electriccoin.zcash.ui.common.repository.DEFAULT_SLIPPAGE
 import co.electriccoin.zcash.ui.common.repository.EnhancedABContact
 import co.electriccoin.zcash.ui.common.repository.SwapAssetsData
@@ -316,14 +318,13 @@ internal interface InternalState {
     val isEphemeralAddressLocked: Boolean
 
     val totalSpendableBalance: Zatoshi
-        get() = account?.spendableShieldedBalance ?: Zatoshi(0)
+        get() = account.totalSpendableBalance
 
     /**
-     * The single spendability primitive the whole app validates against, so the typing-time check and
-     * the proposal-time check in the SDK can never disagree. Re-evaluated whenever the selected
-     * account emits a new balance.
+     * Delegates to the shared [co.electriccoin.zcash.ui.common.model.canSpend] primitive.
+     * Re-evaluated whenever the selected account emits a new balance.
      */
-    fun canSpend(amount: Zatoshi): Boolean = account?.canSpend(amount) ?: false
+    fun canSpend(amount: Zatoshi): Boolean = account.canSpend(amount)
 }
 
 internal data class InternalStateImpl(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVM.kt
@@ -374,6 +374,14 @@ internal interface InternalState {
 
     val totalSpendableBalance: Zatoshi
         get() = account?.spendableShieldedBalance ?: Zatoshi(0)
+
+    /**
+     * The single spendability primitive the whole app validates against, so the typing-time check and
+     * the pre-quote check in
+     * [co.electriccoin.zcash.ui.common.usecase.RequestSwapQuoteUseCase.requestExactInput] can never
+     * disagree. Re-evaluated whenever the selected account emits a new balance.
+     */
+    fun canSpend(amount: Zatoshi): Boolean = account?.canSpend(amount) ?: false
 }
 
 internal data class InternalStateImpl(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVM.kt
@@ -12,6 +12,8 @@ import co.electriccoin.zcash.ui.common.model.SwapDirection.SWAP_FROM_ZEC
 import co.electriccoin.zcash.ui.common.model.SwapDirection.SWAP_INTO_ZEC
 import co.electriccoin.zcash.ui.common.model.SwapMode
 import co.electriccoin.zcash.ui.common.model.WalletAccount
+import co.electriccoin.zcash.ui.common.model.canSpend
+import co.electriccoin.zcash.ui.common.model.totalSpendableBalance
 import co.electriccoin.zcash.ui.common.repository.DEFAULT_SLIPPAGE
 import co.electriccoin.zcash.ui.common.repository.EnhancedABContact
 import co.electriccoin.zcash.ui.common.repository.SwapAssetsData
@@ -373,15 +375,15 @@ internal interface InternalState {
     val isEphemeralAddressLocked: Boolean
 
     val totalSpendableBalance: Zatoshi
-        get() = account?.spendableShieldedBalance ?: Zatoshi(0)
+        get() = account.totalSpendableBalance
 
     /**
-     * The single spendability primitive the whole app validates against, so the typing-time check and
-     * the pre-quote check in
-     * [co.electriccoin.zcash.ui.common.usecase.RequestSwapQuoteUseCase.requestExactInput] can never
-     * disagree. Re-evaluated whenever the selected account emits a new balance.
+     * Delegates to the shared [co.electriccoin.zcash.ui.common.model.canSpend] primitive — the same
+     * one the pre-quote check in
+     * [co.electriccoin.zcash.ui.common.usecase.RequestSwapQuoteUseCase.requestExactInput] validates
+     * against. Re-evaluated whenever the selected account emits a new balance.
      */
-    fun canSpend(amount: Zatoshi): Boolean = account?.canSpend(amount) ?: false
+    fun canSpend(amount: Zatoshi): Boolean = account.canSpend(amount)
 }
 
 internal data class InternalStateImpl(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVMMapper.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVMMapper.kt
@@ -161,9 +161,7 @@ internal class SwapVMMapper {
             error =
                 when (state.swapDirection) {
                     SWAP_FROM_ZEC -> {
-                        if (originAmount != null &&
-                            state.totalSpendableBalance.value < originAmount.convertZecToZatoshi().value
-                        ) {
+                        if (originAmount != null && !state.canSpend(originAmount.convertZecToZatoshi())) {
                             stringRes(R.string.send_error_insufficientFunds)
                         } else {
                             null

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSourceTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSourceTest.kt
@@ -89,18 +89,24 @@ class ProposalDataSourceTest {
             assertSame(alreadyMapped, thrown)
         }
 
+    /**
+     * The multi-step rejection must reach the caller untouched: only
+     * [co.electriccoin.zcash.ui.common.repository.KeystoneProposalRepository] knows whether the
+     * proposal pays a TEX address and may therefore remap it to [TexUnsupportedOnKSException].
+     */
     @Test
-    fun aMultiStepProposalBecomesTexUnsupportedOnKeystone() =
+    fun aMultiStepProposalFailurePropagatesUntouched() =
         runBlocking {
             val synchronizer = mockk<Synchronizer>()
-            coEvery { synchronizer.createPcztFromProposal(any(), any()) } throws
-                PcztException.MultiStepProposalUnsupportedException()
+            val sdkException = PcztException.MultiStepProposalUnsupportedException()
+            coEvery { synchronizer.createPcztFromProposal(any(), any()) } throws sdkException
 
-            assertFailsWith<TexUnsupportedOnKSException> {
-                dataSource(synchronizer).createPcztFromProposal(account, mockk<Proposal>())
-            }
+            val thrown =
+                assertFailsWith<PcztException.MultiStepProposalUnsupportedException> {
+                    dataSource(synchronizer).createPcztFromProposal(account, mockk<Proposal>())
+                }
 
-            Unit
+            assertTrue(thrown.causeChain().any { it === sdkException })
         }
 
     @Test

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSourceTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSourceTest.kt
@@ -1,0 +1,147 @@
+package co.electriccoin.zcash.ui.common.datasource
+
+import cash.z.ecc.android.sdk.Synchronizer
+import cash.z.ecc.android.sdk.exception.PcztException
+import cash.z.ecc.android.sdk.exception.TransactionEncoderException
+import cash.z.ecc.android.sdk.model.Memo
+import cash.z.ecc.android.sdk.model.Proposal
+import cash.z.ecc.android.sdk.model.WalletAddress
+import cash.z.ecc.android.sdk.model.Zatoshi
+import cash.z.ecc.android.sdk.model.ZecSend
+import co.electriccoin.zcash.ui.common.model.ZashiAccount
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * The proposal failure mapping the app relies on: since MOB-1723 the SDK reports an
+ * insufficient-funds proposal failure and a PCZT-unsupported (TEX) proposal as dedicated types, so
+ * this layer maps purely by type - no error-message matching anywhere.
+ */
+class ProposalDataSourceTest {
+    private val account =
+        mockk<ZashiAccount> {
+            every { sdkAccount } returns mockk(relaxed = true)
+        }
+
+    @Test
+    fun sdkInsufficientFundsBecomesTheAppInsufficientFundsException() =
+        runBlocking {
+            val synchronizer = mockk<Synchronizer>()
+            val sdkException = TransactionEncoderException.InsufficientFundsException(RuntimeException("raw"))
+            coEvery { synchronizer.proposeTransfer(any(), any(), any(), any()) } throws sdkException
+
+            val thrown =
+                assertFailsWith<InsufficientFundsException> {
+                    dataSource(synchronizer).createProposal(account, send())
+                }
+
+            assertTrue(thrown.causeChain().any { it === sdkException })
+        }
+
+    @Test
+    fun anUnmatchedProposalFailureBecomesTransactionProposalNotCreated() =
+        runBlocking {
+            val synchronizer = mockk<Synchronizer>()
+            val sdkException = TransactionEncoderException.ProposalFromParametersException(RuntimeException("raw"))
+            coEvery { synchronizer.proposeTransfer(any(), any(), any(), any()) } throws sdkException
+
+            val thrown =
+                assertFailsWith<TransactionProposalNotCreatedException> {
+                    dataSource(synchronizer).createProposal(account, send())
+                }
+
+            assertSame(sdkException, thrown.cause)
+        }
+
+    @Test
+    fun anArbitraryFailureBecomesTransactionProposalNotCreated() =
+        runBlocking {
+            val synchronizer = mockk<Synchronizer>()
+            val raw = RuntimeException("anything")
+            coEvery { synchronizer.proposeTransfer(any(), any(), any(), any()) } throws raw
+
+            val thrown =
+                assertFailsWith<TransactionProposalNotCreatedException> {
+                    dataSource(synchronizer).createProposal(account, send())
+                }
+
+            assertSame(raw, thrown.cause)
+        }
+
+    @Test
+    fun anAlreadyMappedFailureIsRethrownWithoutDoubleWrapping() =
+        runBlocking {
+            val synchronizer = mockk<Synchronizer>()
+            val alreadyMapped = TransactionProposalNotCreatedException(IllegalArgumentException("Invalid ZIP321 URI"))
+            coEvery { synchronizer.proposeTransfer(any(), any(), any(), any()) } throws alreadyMapped
+
+            val thrown =
+                assertFailsWith<TransactionProposalNotCreatedException> {
+                    dataSource(synchronizer).createProposal(account, send())
+                }
+
+            assertSame(alreadyMapped, thrown)
+        }
+
+    @Test
+    fun aMultiStepProposalBecomesTexUnsupportedOnKeystone() =
+        runBlocking {
+            val synchronizer = mockk<Synchronizer>()
+            coEvery { synchronizer.createPcztFromProposal(any(), any()) } throws
+                PcztException.MultiStepProposalUnsupportedException()
+
+            assertFailsWith<TexUnsupportedOnKSException> {
+                dataSource(synchronizer).createPcztFromProposal(account, mockk<Proposal>())
+            }
+
+            Unit
+        }
+
+    @Test
+    fun anyOtherPcztFailurePropagatesUntouched() =
+        runBlocking {
+            val synchronizer = mockk<Synchronizer>()
+            val raw = RuntimeException("PCZT creation failed")
+            coEvery { synchronizer.createPcztFromProposal(any(), any()) } throws raw
+
+            val thrown =
+                assertFailsWith<RuntimeException> {
+                    dataSource(synchronizer).createPcztFromProposal(account, mockk<Proposal>())
+                }
+
+            assertTrue(thrown.causeChain().any { it === raw })
+        }
+
+    /**
+     * The exception a coroutine hands back can be a stack-trace-recovered copy rather than the very
+     * instance that was thrown, so identity is asserted against the whole cause chain.
+     */
+    private fun Throwable.causeChain(): Sequence<Throwable> = generateSequence(this) { it.cause }
+
+    private fun dataSource(synchronizer: Synchronizer): ProposalDataSource =
+        ProposalDataSourceImpl(
+            synchronizerProvider = mockk { coEvery { getSynchronizer() } returns synchronizer },
+            lightWalletEndpointProvider = mockk(),
+            isServerSelectionAutomaticProvider = mockk(),
+            persistableWalletProvider = mockk()
+        )
+
+    private suspend fun send(): ZecSend =
+        ZecSend(
+            destination = WalletAddress.Unified.new(RECIPIENT),
+            amount = Zatoshi(AMOUNT),
+            memo = Memo(""),
+            proposal = null
+        )
+
+    private companion object {
+        const val RECIPIENT = "recipient"
+        const val AMOUNT = 100_000L
+    }
+}

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/KeystoneProposalRepositoryTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/KeystoneProposalRepositoryTest.kt
@@ -1,24 +1,37 @@
 package co.electriccoin.zcash.ui.common.repository
 
+import cash.z.ecc.android.sdk.exception.PcztException
+import cash.z.ecc.android.sdk.model.Memo
 import cash.z.ecc.android.sdk.model.Proposal
+import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.model.Zatoshi
+import cash.z.ecc.android.sdk.model.ZecSend
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.datasource.MigrationSweepTransactionProposal
 import co.electriccoin.zcash.ui.common.datasource.ProposalDataSource
+import co.electriccoin.zcash.ui.common.datasource.RegularTransactionProposal
+import co.electriccoin.zcash.ui.common.datasource.TexUnsupportedOnKSException
 import co.electriccoin.zcash.ui.common.provider.KeystoneSDKProvider
+import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class KeystoneProposalRepositoryTest {
+    private val accountDataSource = mockk<AccountDataSource>()
+    private val proposalDataSource = mockk<ProposalDataSource>()
+
+    private val repository: KeystoneProposalRepository =
+        KeystoneProposalRepositoryImpl(
+            accountDataSource = accountDataSource,
+            proposalDataSource = proposalDataSource,
+            keystoneSDKProvider = mockk<KeystoneSDKProvider>(),
+        )
+
     @Test
     fun setMigrationSweepProposalPublishesAMigrationSweepTransactionProposal() {
-        val repository: KeystoneProposalRepository =
-            KeystoneProposalRepositoryImpl(
-                accountDataSource = mockk<AccountDataSource>(),
-                proposalDataSource = mockk<ProposalDataSource>(),
-                keystoneSDKProvider = mockk<KeystoneSDKProvider>(),
-            )
         val proposal = mockk<Proposal>()
         val amount = Zatoshi(1234L)
 
@@ -26,5 +39,79 @@ class KeystoneProposalRepositoryTest {
 
         val stored = repository.transactionProposal.value
         assertEquals(MigrationSweepTransactionProposal(amount, proposal), stored)
+    }
+
+    /**
+     * A multi-step PCZT rejection means "TEX is unsupported on Keystone" only when the proposal
+     * actually pays a TEX address — the one flow where a multi-step proposal is the expected shape.
+     */
+    @Test
+    fun aMultiStepPcztRejectionOfATexPaymentBecomesTexUnsupportedOnKeystone() =
+        runBlocking {
+            givenCurrentProposalPays(WalletAddress.Tex.new(RECIPIENT))
+            coEvery { proposalDataSource.createPcztFromProposal(any(), any()) } throws
+                PcztException.MultiStepProposalUnsupportedException()
+
+            assertFailsWith<TexUnsupportedOnKSException> {
+                repository.createPCZTFromProposal()
+            }
+
+            Unit
+        }
+
+    @Test
+    fun aMultiStepPcztRejectionOfANonTexPaymentPropagatesUntouched() =
+        runBlocking {
+            givenCurrentProposalPays(WalletAddress.Unified.new(RECIPIENT))
+            coEvery { proposalDataSource.createPcztFromProposal(any(), any()) } throws
+                PcztException.MultiStepProposalUnsupportedException()
+
+            assertFailsWith<PcztException.MultiStepProposalUnsupportedException> {
+                repository.createPCZTFromProposal()
+            }
+
+            Unit
+        }
+
+    /**
+     * Migration sweeps have no payment destination at all, so their multi-step rejection must never
+     * be dressed up as a TEX error.
+     */
+    @Test
+    fun aMultiStepPcztRejectionOfAMigrationSweepPropagatesUntouched() =
+        runBlocking {
+            repository.setMigrationSweepProposal(mockk<Proposal>(), Zatoshi(1234L))
+            coEvery { accountDataSource.getSelectedAccount() } returns mockk(relaxed = true)
+            coEvery { proposalDataSource.createPcztFromProposal(any(), any()) } throws
+                PcztException.MultiStepProposalUnsupportedException()
+
+            assertFailsWith<PcztException.MultiStepProposalUnsupportedException> {
+                repository.createPCZTFromProposal()
+            }
+
+            Unit
+        }
+
+    private suspend fun givenCurrentProposalPays(destination: WalletAddress) {
+        coEvery { accountDataSource.getSelectedAccount() } returns mockk(relaxed = true)
+        coEvery { proposalDataSource.createProposal(any(), any()) } returns
+            RegularTransactionProposal(
+                destination = destination,
+                amount = Zatoshi(1234L),
+                memo = Memo(""),
+                proposal = mockk<Proposal>()
+            )
+        repository.createProposal(
+            ZecSend(
+                destination = destination,
+                amount = Zatoshi(1234L),
+                memo = Memo(""),
+                proposal = null
+            )
+        )
+    }
+
+    private companion object {
+        const val RECIPIENT = "recipient"
     }
 }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
@@ -63,6 +63,8 @@ class RequestSwapQuoteUseCaseTest {
     private val navigateToError = mockk<NavigateToErrorUseCase>(relaxed = true)
     private val zashiProposalRepository = mockk<ZashiProposalRepository>(relaxed = true)
     private val keystoneProposalRepository = mockk<KeystoneProposalRepository>(relaxed = true)
+    private val swapRepository = mockk<SwapRepository>(relaxed = true)
+    private val accountDataSource = mockk<AccountDataSource>()
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private val dispatcher = StandardTestDispatcher()
@@ -144,6 +146,20 @@ class RequestSwapQuoteUseCaseTest {
             useCase(swapQuote(originAsset = zec, destinationAsset = btc, amountIn = BigDecimal("100.5")), zashi())
                 .exactInput()
             assertNavigatedToError()
+        }
+
+    @Test
+    fun exactInputZashiWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
+        runBlocking {
+            useCase(swapQuote(originAsset = zec, destinationAsset = btc), zashi(canSpend = false)).exactInput()
+            assertBlockedBeforeTheQuote()
+        }
+
+    @Test
+    fun exactInputKeystoneWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
+        runBlocking {
+            useCase(swapQuote(originAsset = zec, destinationAsset = btc), keystone(canSpend = false)).exactInput()
+            assertBlockedBeforeTheQuote()
         }
 
     // endregion
@@ -228,8 +244,25 @@ class RequestSwapQuoteUseCaseTest {
             assertForwardedToQuote()
         }
 
+    @Test
+    fun flexNeverChecksSpendableBalance() =
+        runBlocking {
+            // Nothing is spent from the wallet on the way into ZEC, so the pre-quote check must not apply.
+            val account = zashi(canSpend = false)
+            useCase(flexQuote(), account).flex()
+            verify(exactly = 0) { account.canSpend(any()) }
+            assertForwardedToQuote()
+        }
+
     // endregion
     // region helpers
+
+    private fun assertBlockedBeforeTheQuote() {
+        verify { navigationRouter.forward(InsufficientFundsArgs) }
+        coVerify(exactly = 0) { accountDataSource.requestNextShieldedAddress() }
+        verify(exactly = 0) { swapRepository.requestExactInputQuote(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { navigationRouter.forward(SwapQuoteArgs) }
+    }
 
     private fun assertForwardedToQuote() {
         verify { navigationRouter.forward(SwapQuoteArgs) }
@@ -250,9 +283,15 @@ class RequestSwapQuoteUseCaseTest {
         verify { navigationRouter.forward(TEXUnsupportedArgs) }
     }
 
-    private fun zashi(): WalletAccount = mockk<ZashiAccount>()
+    /**
+     * [canSpend] must be stubbed explicitly: mockk does not fall through to the interface's default
+     * body, and the pre-quote balance check calls it on the selected account.
+     */
+    private fun zashi(canSpend: Boolean = true): WalletAccount =
+        mockk<ZashiAccount> { every { this@mockk.canSpend(any()) } returns canSpend }
 
-    private fun keystone(): WalletAccount = mockk<KeystoneAccount>()
+    private fun keystone(canSpend: Boolean = true): WalletAccount =
+        mockk<KeystoneAccount> { every { this@mockk.canSpend(any()) } returns canSpend }
 
     private suspend fun RequestSwapQuoteUseCase.exactInput(selectedAsset: SwapAsset = btc) =
         requestExactInput(
@@ -283,21 +322,17 @@ class RequestSwapQuoteUseCaseTest {
 
     private suspend fun useCase(
         swapQuote: SwapQuote,
-        selectedAccount: WalletAccount = mockk<ZashiAccount>(),
+        selectedAccount: WalletAccount = zashi(),
         supportedData: List<SwapAsset> = listOf(btc)
     ): RequestSwapQuoteUseCase {
-        val swapRepository = mockk<SwapRepository>(relaxed = true)
         every { swapRepository.assets } returns MutableStateFlow(SwapAssetsData(data = supportedData, zecAsset = zec))
         every { swapRepository.quote } returns MutableStateFlow(SwapQuoteData.Success(swapQuote))
 
         val shieldedAddress = WalletAddress.Unified.new("deposit")
         val synchronizer = mockk<Synchronizer> { coEvery { validateAddress(any()) } returns AddressType.Unified }
         val synchronizerProvider = mockk<SynchronizerProvider> { coEvery { getSynchronizer() } returns synchronizer }
-        val accountDataSource =
-            mockk<AccountDataSource> {
-                coEvery { requestNextShieldedAddress() } returns shieldedAddress
-                coEvery { getSelectedAccount() } returns selectedAccount
-            }
+        coEvery { accountDataSource.requestNextShieldedAddress() } returns shieldedAddress
+        coEvery { accountDataSource.getSelectedAccount() } returns selectedAccount
         return RequestSwapQuoteUseCase(
             navigationRouter = navigationRouter,
             navigateToErrorUseCase = navigateToError,

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
@@ -2,6 +2,7 @@ package co.electriccoin.zcash.ui.common.usecase
 
 import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.model.WalletAddress
+import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.type.AddressType
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
@@ -23,6 +24,7 @@ import co.electriccoin.zcash.ui.common.repository.SwapRepository
 import co.electriccoin.zcash.ui.common.repository.ZashiProposalRepository
 import co.electriccoin.zcash.ui.screen.error.NavigateToErrorUseCase
 import co.electriccoin.zcash.ui.screen.insufficientfunds.InsufficientFundsArgs
+import co.electriccoin.zcash.ui.screen.swap.convertZecToZatoshi
 import co.electriccoin.zcash.ui.screen.swap.quote.SwapQuoteArgs
 import co.electriccoin.zcash.ui.screen.texunsupported.TEXUnsupportedArgs
 import io.mockk.coEvery
@@ -40,6 +42,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.Test
 import java.math.BigDecimal
+import java.math.MathContext
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 
@@ -235,15 +238,35 @@ class RequestSwapQuoteUseCaseTest {
     @Test
     fun exactOutputZashiWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
         runBlocking {
-            useCase(exactOutputQuote(), zashi(canSpend = false)).exactOutput()
+            val account = zashi(canSpend = false)
+            useCase(exactOutputQuote(), account).exactOutput()
+            verify { account.canSpend(exactOutputDestinationZatoshi()) }
             assertBlockedBeforeTheQuote()
         }
 
     @Test
     fun exactOutputKeystoneWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
         runBlocking {
-            useCase(exactOutputQuote(), keystone(canSpend = false)).exactOutput()
+            val account = keystone(canSpend = false)
+            useCase(exactOutputQuote(), account).exactOutput()
+            verify { account.canSpend(exactOutputDestinationZatoshi()) }
             assertBlockedBeforeTheQuote()
+        }
+
+    /**
+     * The pre-check needs both the destination asset's and ZEC's usdPrice to convert the
+     * destination-denominated amount into zatoshi; when either is missing it must not block,
+     * leaving the authoritative proposal-time check to decide.
+     */
+    @Test
+    fun exactOutputSkipsBalanceCheckWhenAssetPriceIsUnavailable() =
+        runBlocking {
+            val account = zashi(canSpend = false)
+            val unpriced = SwapAssetTestFixture.asset(tokenTicker = "eth", chainTicker = "eth", usdPrice = null)
+            useCase(exactOutputQuote(destinationAsset = unpriced), account, supportedData = listOf(unpriced))
+                .exactOutput(selectedAsset = unpriced)
+            verify(exactly = 0) { account.canSpend(any()) }
+            assertForwardedToQuote()
         }
 
     // endregion
@@ -315,6 +338,21 @@ class RequestSwapQuoteUseCaseTest {
 
     private fun keystone(canSpend: Boolean = true): WalletAccount =
         mockk<KeystoneAccount> { every { this@mockk.canSpend(any()) } returns canSpend }
+
+    /**
+     * The zatoshi the exact-output pre-check should compute for [amount] of [destinationAsset],
+     * via the same USD cross-rate the use case applies (destination amount * asset price / ZEC
+     * price) — used to assert the actual value reaches [WalletAccount.canSpend], not just that some
+     * value did.
+     */
+    private fun exactOutputDestinationZatoshi(
+        amount: BigDecimal = BigDecimal("1"),
+        destinationAsset: SwapAsset = btc
+    ): Zatoshi =
+        amount
+            .multiply(destinationAsset.usdPrice!!, MathContext.DECIMAL128)
+            .divide(zec.usdPrice!!, MathContext.DECIMAL128)
+            .convertZecToZatoshi()
 
     private suspend fun RequestSwapQuoteUseCase.exactInput(selectedAsset: SwapAsset = btc) =
         requestExactInput(

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
@@ -232,6 +232,20 @@ class RequestSwapQuoteUseCaseTest {
             assertNavigatedToError()
         }
 
+    @Test
+    fun exactOutputZashiWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
+        runBlocking {
+            useCase(exactOutputQuote(), zashi(canSpend = false)).exactOutput()
+            assertBlockedBeforeTheQuote()
+        }
+
+    @Test
+    fun exactOutputKeystoneWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
+        runBlocking {
+            useCase(exactOutputQuote(), keystone(canSpend = false)).exactOutput()
+            assertBlockedBeforeTheQuote()
+        }
+
     // endregion
     // region requestFlexInputIntoZec — happy (no proposal, no account branch)
 
@@ -268,6 +282,7 @@ class RequestSwapQuoteUseCaseTest {
         verify { keystoneProposalRepository.clear() }
         coVerify(exactly = 0) { accountDataSource.requestNextShieldedAddress() }
         verify(exactly = 0) { swapRepository.requestExactInputQuote(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { swapRepository.requestExactOutputQuote(any(), any(), any(), any(), any()) }
         verify(exactly = 0) { navigationRouter.forward(SwapQuoteArgs) }
     }
 
@@ -288,6 +303,7 @@ class RequestSwapQuoteUseCaseTest {
 
     private fun assertNavigatedToTexUnsupported() {
         verify { navigationRouter.forward(TEXUnsupportedArgs) }
+        verify(exactly = 0) { navigationRouter.forward(SwapQuoteArgs) }
     }
 
     /**

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
@@ -2,7 +2,6 @@ package co.electriccoin.zcash.ui.common.usecase
 
 import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.model.WalletAddress
-import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.type.AddressType
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
@@ -18,13 +17,11 @@ import co.electriccoin.zcash.ui.common.model.WalletAccount
 import co.electriccoin.zcash.ui.common.model.ZashiAccount
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import co.electriccoin.zcash.ui.common.repository.KeystoneProposalRepository
-import co.electriccoin.zcash.ui.common.repository.SwapAssetsData
 import co.electriccoin.zcash.ui.common.repository.SwapQuoteData
 import co.electriccoin.zcash.ui.common.repository.SwapRepository
 import co.electriccoin.zcash.ui.common.repository.ZashiProposalRepository
 import co.electriccoin.zcash.ui.screen.error.NavigateToErrorUseCase
 import co.electriccoin.zcash.ui.screen.insufficientfunds.InsufficientFundsArgs
-import co.electriccoin.zcash.ui.screen.swap.convertZecToZatoshi
 import co.electriccoin.zcash.ui.screen.swap.quote.SwapQuoteArgs
 import co.electriccoin.zcash.ui.screen.texunsupported.TEXUnsupportedArgs
 import io.mockk.coEvery
@@ -42,7 +39,6 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.Test
 import java.math.BigDecimal
-import java.math.MathContext
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 
@@ -151,20 +147,6 @@ class RequestSwapQuoteUseCaseTest {
             assertNavigatedToError()
         }
 
-    @Test
-    fun exactInputZashiWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
-        runBlocking {
-            useCase(swapQuote(originAsset = zec, destinationAsset = btc), zashi(canSpend = false)).exactInput()
-            assertBlockedBeforeTheQuote()
-        }
-
-    @Test
-    fun exactInputKeystoneWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
-        runBlocking {
-            useCase(swapQuote(originAsset = zec, destinationAsset = btc), keystone(canSpend = false)).exactInput()
-            assertBlockedBeforeTheQuote()
-        }
-
     // endregion
     // region requestExactOutput — proposal happy + failures
 
@@ -235,40 +217,6 @@ class RequestSwapQuoteUseCaseTest {
             assertNavigatedToError()
         }
 
-    @Test
-    fun exactOutputZashiWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
-        runBlocking {
-            val account = zashi(canSpend = false)
-            useCase(exactOutputQuote(), account).exactOutput()
-            verify { account.canSpend(exactOutputDestinationZatoshi()) }
-            assertBlockedBeforeTheQuote()
-        }
-
-    @Test
-    fun exactOutputKeystoneWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
-        runBlocking {
-            val account = keystone(canSpend = false)
-            useCase(exactOutputQuote(), account).exactOutput()
-            verify { account.canSpend(exactOutputDestinationZatoshi()) }
-            assertBlockedBeforeTheQuote()
-        }
-
-    /**
-     * The pre-check needs both the destination asset's and ZEC's usdPrice to convert the
-     * destination-denominated amount into zatoshi; when either is missing it must not block,
-     * leaving the authoritative proposal-time check to decide.
-     */
-    @Test
-    fun exactOutputSkipsBalanceCheckWhenAssetPriceIsUnavailable() =
-        runBlocking {
-            val account = zashi(canSpend = false)
-            val unpriced = SwapAssetTestFixture.asset(tokenTicker = "eth", chainTicker = "eth", usdPrice = null)
-            useCase(exactOutputQuote(destinationAsset = unpriced), account, supportedData = listOf(unpriced))
-                .exactOutput(selectedAsset = unpriced)
-            verify(exactly = 0) { account.canSpend(any()) }
-            assertForwardedToQuote()
-        }
-
     // endregion
     // region requestFlexInputIntoZec — happy (no proposal, no account branch)
 
@@ -281,33 +229,8 @@ class RequestSwapQuoteUseCaseTest {
             assertForwardedToQuote()
         }
 
-    @Test
-    fun flexNeverChecksSpendableBalance() =
-        runBlocking {
-            // Nothing is spent from the wallet on the way into ZEC, so the pre-quote check must not apply.
-            val account = zashi(canSpend = false)
-            useCase(flexQuote(), account).flex()
-            verify(exactly = 0) { account.canSpend(any()) }
-            assertForwardedToQuote()
-        }
-
     // endregion
     // region helpers
-
-    /**
-     * The pre-quote block must leave no stale state behind: it clears the previous quote and both
-     * proposal repositories exactly like the proposal-time insufficient-funds path does.
-     */
-    private fun assertBlockedBeforeTheQuote() {
-        verify { navigationRouter.forward(InsufficientFundsArgs) }
-        verify { swapRepository.clearQuote() }
-        verify { zashiProposalRepository.clear() }
-        verify { keystoneProposalRepository.clear() }
-        coVerify(exactly = 0) { accountDataSource.requestNextShieldedAddress() }
-        verify(exactly = 0) { swapRepository.requestExactInputQuote(any(), any(), any(), any(), any()) }
-        verify(exactly = 0) { swapRepository.requestExactOutputQuote(any(), any(), any(), any(), any()) }
-        verify(exactly = 0) { navigationRouter.forward(SwapQuoteArgs) }
-    }
 
     private fun assertForwardedToQuote() {
         verify { navigationRouter.forward(SwapQuoteArgs) }
@@ -329,30 +252,9 @@ class RequestSwapQuoteUseCaseTest {
         verify(exactly = 0) { navigationRouter.forward(SwapQuoteArgs) }
     }
 
-    /**
-     * [canSpend] must be stubbed explicitly: mockk does not fall through to the interface's default
-     * body, and the pre-quote balance check calls it on the selected account.
-     */
-    private fun zashi(canSpend: Boolean = true): WalletAccount =
-        mockk<ZashiAccount> { every { this@mockk.canSpend(any()) } returns canSpend }
+    private fun zashi(): WalletAccount = mockk<ZashiAccount>()
 
-    private fun keystone(canSpend: Boolean = true): WalletAccount =
-        mockk<KeystoneAccount> { every { this@mockk.canSpend(any()) } returns canSpend }
-
-    /**
-     * The zatoshi the exact-output pre-check should compute for [amount] of [destinationAsset],
-     * via the same USD cross-rate the use case applies (destination amount * asset price / ZEC
-     * price) — used to assert the actual value reaches [WalletAccount.canSpend], not just that some
-     * value did.
-     */
-    private fun exactOutputDestinationZatoshi(
-        amount: BigDecimal = BigDecimal("1"),
-        destinationAsset: SwapAsset = btc
-    ): Zatoshi =
-        amount
-            .multiply(destinationAsset.usdPrice!!, MathContext.DECIMAL128)
-            .divide(zec.usdPrice!!, MathContext.DECIMAL128)
-            .convertZecToZatoshi()
+    private fun keystone(): WalletAccount = mockk<KeystoneAccount>()
 
     private suspend fun RequestSwapQuoteUseCase.exactInput(selectedAsset: SwapAsset = btc) =
         requestExactInput(
@@ -383,10 +285,8 @@ class RequestSwapQuoteUseCaseTest {
 
     private suspend fun useCase(
         swapQuote: SwapQuote,
-        selectedAccount: WalletAccount = zashi(),
-        supportedData: List<SwapAsset> = listOf(btc)
+        selectedAccount: WalletAccount = zashi()
     ): RequestSwapQuoteUseCase {
-        every { swapRepository.assets } returns MutableStateFlow(SwapAssetsData(data = supportedData, zecAsset = zec))
         every { swapRepository.quote } returns MutableStateFlow(SwapQuoteData.Success(swapQuote))
 
         val shieldedAddress = WalletAddress.Unified.new("deposit")

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
@@ -257,8 +257,15 @@ class RequestSwapQuoteUseCaseTest {
     // endregion
     // region helpers
 
+    /**
+     * The pre-quote block must leave no stale state behind: it clears the previous quote and both
+     * proposal repositories exactly like the proposal-time insufficient-funds path does.
+     */
     private fun assertBlockedBeforeTheQuote() {
         verify { navigationRouter.forward(InsufficientFundsArgs) }
+        verify { swapRepository.clearQuote() }
+        verify { zashiProposalRepository.clear() }
+        verify { keystoneProposalRepository.clear() }
         coVerify(exactly = 0) { accountDataSource.requestNextShieldedAddress() }
         verify(exactly = 0) { swapRepository.requestExactInputQuote(any(), any(), any(), any(), any()) }
         verify(exactly = 0) { navigationRouter.forward(SwapQuoteArgs) }


### PR DESCRIPTION
Fixes the app half of [MOB-1723](https://linear.app/zodl/issue/MOB-1723/android-insufficient-balance-calculation-appears-off-not-accounting): five users on v3.9.2/v3.9.3 reported `Insufficient balance (have X, need Y including fee)` surfacing on the technical error screen during swaps instead of the friendly Insufficient Funds sheet.

Companion SDK PR (must merge first): [zcash/zcash-android-wallet-sdk#2194 MOB-1723: report insufficient funds and multi-step PCZT proposals as typed exceptions](https://github.com/zcash/zcash-android-wallet-sdk/pull/2194)

## Root causes & what changed

**1. Error mapping only worked on one engine.** `getOrThrow` recognized insufficient funds by string-matching the root cause of `ProposalFromParametersException` — which the Slipstream engine never produced (it delegated to `RustBackend` bare, so a raw `RuntimeException` escaped to the generic catch → technical error screen). The SDK now throws a typed `TransactionEncoderException.InsufficientFundsException` from **both** engines, and `getOrThrow` maps purely by type; all message matching is deleted.

**2. TEX-on-Keystone check moved to its true home.** The app's propose-time `validate()` (`KeystoneAccount` + `AddressType.Tex`) is replaced by mapping the SDK's new `PcztException.MultiStepProposalUnsupportedException` (structural step-count rejection of ZIP-320/TEX proposals) to `TexUnsupportedOnKSException` at PCZT creation. Every Keystone flow creates the PCZT inside the same `try` that catches it, so user-visible behavior is unchanged.

**3. Balance was validated only at typing time.** `requestExactInput` now re-checks `canSpend` as its first statement — before the shielded-address rotation and the provider quote round-trip — and forwards to the Insufficient Funds sheet on failure. The typing-time checks in the swap and pay mappers are unified on the same `WalletAccount.canSpend` primitive via `InternalState.canSpend`. Post-quote drift (and exact-output, where the ZEC cost is only known after the quote) is handled by the Rust check arriving as the typed exception.

Out of scope (tracked separately as the fee-headroom part of MOB-1723): the strict check still allows amount == spendable, which then fails on fees — but it now fails onto the friendly sheet.

## SDK pin

The companion SDK PR has **merged**; `SDK_COMMIT_PIN` points at the merged sha on `origin/maint/v3.1.x` (`4b39e71f`, the merge commit of #2194), per the pin comment's contract. Release branches additionally need the pin cleared and a published SDK release (v3.1.x point release) — the standing rule.

## Tests

- New `ProposalDataSourceTest` (6): typed insufficient-funds mapping, PCZT TEX mapping, pass-through and no-double-wrap cases.
- `RequestSwapQuoteUseCaseTest`: +3 (pre-quote block for Zashi and Keystone with no address rotation and no quote request; flex-input performs no balance check), fixtures extended with `canSpend` stubs.
- Full `ui-lib` suite 433/433 green against the pinned SDK; detekt + ktlint clean; whole-app compile verified.

---

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [ ] **Run the app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

