### PR TITLE
[#MOB-1690] Use monotonic clock for app-lock timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed:
 
+- The app-lock re-authentication timeout is now measured with a monotonic clock instead of the system wall clock, so it can no longer be
+  bypassed by changing the device's date and time.
 - We polished several UI details: the swap quote review header now stands out from the sheet background, the Activity header turns frosted
   sooner so it stays readable while you scroll, the Terms of Service icon matches the Privacy Policy one, and the Ironwood migration screens
   scroll properly on small displays.

--- a/ui-lib/src/main/java/co/electriccoin/zcash/di/ProviderModule.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/di/ProviderModule.kt
@@ -10,6 +10,7 @@ import co.electriccoin.zcash.ui.common.provider.CrashReportingStorageProvider
 import co.electriccoin.zcash.ui.common.provider.CrashReportingStorageProviderImpl
 import co.electriccoin.zcash.ui.common.provider.EphemeralAddressStorageProvider
 import co.electriccoin.zcash.ui.common.provider.EphemeralAddressStorageProviderImpl
+import co.electriccoin.zcash.ui.common.provider.GetMonotonicTimeProvider
 import co.electriccoin.zcash.ui.common.provider.GetVersionInfoProvider
 import co.electriccoin.zcash.ui.common.provider.GetZcashCurrencyProvider
 import co.electriccoin.zcash.ui.common.provider.HasSeenHowToVoteKeystoneStorageProvider
@@ -72,6 +73,7 @@ import org.koin.dsl.module
 val providerModule =
     module {
         factoryOf(::LightWalletEndpointProvider)
+        singleOf(::GetMonotonicTimeProvider)
         singleOf(::GetVersionInfoProvider)
         singleOf(::GetZcashCurrencyProvider)
         singleOf(::SelectedAccountUUIDProviderImpl) bind SelectedAccountUUIDProvider::class

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/MainActivity.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/MainActivity.kt
@@ -125,7 +125,7 @@ class MainActivity : FragmentActivity() {
 
     override fun onStop() {
         Twig.debug { "Activity state: Stop" }
-        authenticationViewModel.persistGoToBackgroundTime(System.currentTimeMillis())
+        authenticationViewModel.onEnteredBackground()
         super.onStop()
     }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/GetMonotonicTimeProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/GetMonotonicTimeProvider.kt
@@ -1,0 +1,13 @@
+package co.electriccoin.zcash.ui.common.provider
+
+import android.os.SystemClock
+
+/**
+ * Provides a monotonic timestamp, i.e. milliseconds elapsed since boot (including deep sleep),
+ * via [SystemClock.elapsedRealtime]. Unlike [System.currentTimeMillis], this clock cannot be
+ * changed by the user, which makes it the only safe source of truth for security-relevant
+ * elapsed-time checks such as the app-lock re-authentication timeout.
+ */
+class GetMonotonicTimeProvider {
+    operator fun invoke() = SystemClock.elapsedRealtime()
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/AuthenticationViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/AuthenticationViewModel.kt
@@ -15,6 +15,7 @@ import co.electriccoin.zcash.preference.model.entry.BooleanPreferenceDefault
 import co.electriccoin.zcash.spackle.AndroidApiVersion
 import co.electriccoin.zcash.spackle.Twig
 import co.electriccoin.zcash.ui.R
+import co.electriccoin.zcash.ui.common.provider.GetMonotonicTimeProvider
 import co.electriccoin.zcash.ui.common.provider.GetVersionInfoProvider
 import co.electriccoin.zcash.ui.preference.StandardPreferenceKeys
 import co.electriccoin.zcash.ui.screen.authentication.AuthenticationUseCase
@@ -40,6 +41,7 @@ private val AUTHENTICATE_TIMEOUT = 15.minutes.inWholeMilliseconds
 class AuthenticationViewModel(
     application: Application,
     private val biometricManager: BiometricManager,
+    private val getMonotonicTime: GetMonotonicTimeProvider,
     private val getVersionInfo: GetVersionInfoProvider,
     private val standardPreferenceProvider: StandardPreferenceProvider,
     private val walletViewModel: WalletViewModel,
@@ -143,20 +145,19 @@ class AuthenticationViewModel(
         showWelcomeAnimation.value = true
     }
 
-    fun runAuthenticationRequiredCheck() =
-        viewModelScope.launch {
-            val latestAppBackgroundedTimeMillis =
-                StandardPreferenceKeys.LATEST_APP_BACKGROUND_TIME_MILLIS.getValue(standardPreferenceProvider())
+    private var latestAppBackgroundedElapsedRealtimeMillis: Long? = null
 
-            if ((System.currentTimeMillis() - latestAppBackgroundedTimeMillis) > AUTHENTICATE_TIMEOUT) {
-                resetEntireAuthenticationState()
-            }
-        }
+    fun runAuthenticationRequiredCheck() {
+        val latestAppBackgroundedElapsedRealtimeMillis = latestAppBackgroundedElapsedRealtimeMillis ?: return
 
-    fun persistGoToBackgroundTime(millis: Long) =
-        viewModelScope.launch {
-            StandardPreferenceKeys.LATEST_APP_BACKGROUND_TIME_MILLIS.putValue(standardPreferenceProvider(), millis)
+        if ((getMonotonicTime() - latestAppBackgroundedElapsedRealtimeMillis) > AUTHENTICATE_TIMEOUT) {
+            resetEntireAuthenticationState()
         }
+    }
+
+    fun onEnteredBackground() {
+        latestAppBackgroundedElapsedRealtimeMillis = getMonotonicTime()
+    }
 
     /**
      * Authentication framework result

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/preference/StandardPreferenceKeys.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/preference/StandardPreferenceKeys.kt
@@ -2,7 +2,6 @@ package co.electriccoin.zcash.ui.preference
 
 import co.electriccoin.zcash.preference.model.entry.BooleanPreferenceDefault
 import co.electriccoin.zcash.preference.model.entry.IntegerPreferenceDefault
-import co.electriccoin.zcash.preference.model.entry.LongPreferenceDefault
 import co.electriccoin.zcash.preference.model.entry.PreferenceKey
 import co.electriccoin.zcash.ui.common.model.OnboardingState
 
@@ -31,10 +30,5 @@ object StandardPreferenceKeys {
         BooleanPreferenceDefault(
             PreferenceKey("IS_HIDE_BALANCES"),
             false
-        )
-    val LATEST_APP_BACKGROUND_TIME_MILLIS =
-        LongPreferenceDefault(
-            PreferenceKey("LATEST_APP_BACKGROUND_TIME_MILLIS"),
-            Long.MAX_VALUE
         )
 }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/viewmodel/AuthenticationViewModelTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/viewmodel/AuthenticationViewModelTest.kt
@@ -6,6 +6,7 @@ import co.electriccoin.zcash.preference.StandardPreferenceProvider
 import co.electriccoin.zcash.preference.api.PreferenceProvider
 import co.electriccoin.zcash.preference.model.entry.PreferenceKey
 import co.electriccoin.zcash.spackle.AndroidApiVersion
+import co.electriccoin.zcash.ui.common.provider.GetMonotonicTimeProvider
 import co.electriccoin.zcash.ui.common.provider.GetVersionInfoProvider
 import co.electriccoin.zcash.ui.fixture.VersionInfoFixture
 import io.mockk.coEvery
@@ -28,6 +29,9 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
 
 /**
  * Regression coverage for MOB-1447: opening the app before any wallet has been created or
@@ -140,11 +144,56 @@ class AuthenticationViewModelTest {
             assertEquals(AuthenticationUIState.NotRequired, viewModel.appAccessAuthenticationResultState.value)
         }
 
+    @Test
+    fun recentBackgroundDoesNotResetAuthenticationState() =
+        runTest {
+            val (viewModel, _, setMonotonicTimeMillis) = newViewModel(secretState = SecretState.READY)
+            viewModel.appAccessAuthentication.value = AuthenticationUIState.Successful
+            viewModel.setWelcomeAnimationDisplayed()
+
+            setMonotonicTimeMillis(0L)
+            viewModel.onEnteredBackground()
+
+            setMonotonicTimeMillis(5.minutes.inWholeMilliseconds)
+            viewModel.runAuthenticationRequiredCheck()
+
+            assertEquals(AuthenticationUIState.Successful, viewModel.appAccessAuthentication.value)
+            assertFalse(viewModel.showWelcomeAnimation.value)
+        }
+
+    @Test
+    fun backgroundTimeoutResetsAuthenticationState() =
+        runTest {
+            val (viewModel, _, setMonotonicTimeMillis) = newViewModel(secretState = SecretState.READY)
+            viewModel.appAccessAuthentication.value = AuthenticationUIState.Successful
+            viewModel.setWelcomeAnimationDisplayed()
+
+            setMonotonicTimeMillis(0L)
+            viewModel.onEnteredBackground()
+
+            setMonotonicTimeMillis(16.minutes.inWholeMilliseconds)
+            viewModel.runAuthenticationRequiredCheck()
+
+            assertEquals(AuthenticationUIState.Initial, viewModel.appAccessAuthentication.value)
+            assertTrue(viewModel.showWelcomeAnimation.value)
+        }
+
+    @Test
+    fun authenticationCheckWithoutRecordedBackgroundTimeIsNoOp() =
+        runTest {
+            val (viewModel, _, _) = newViewModel(secretState = SecretState.READY)
+            viewModel.appAccessAuthentication.value = AuthenticationUIState.Successful
+
+            viewModel.runAuthenticationRequiredCheck()
+
+            assertEquals(AuthenticationUIState.Successful, viewModel.appAccessAuthentication.value)
+        }
+
     private fun newViewModel(
         secretState: SecretState,
         isAppAccessAuthenticationPreference: String? = null,
         isRunningUnderTestService: Boolean = false
-    ): Pair<AuthenticationViewModel, MutableStateFlow<SecretState>> {
+    ): Triple<AuthenticationViewModel, MutableStateFlow<SecretState>, (Long) -> Unit> {
         val secretStateFlow = MutableStateFlow(secretState)
         val walletViewModel = mockk<WalletViewModel>()
         every { walletViewModel.secretState } returns secretStateFlow
@@ -156,16 +205,21 @@ class AuthenticationViewModelTest {
         every { getVersionInfo() } returns
             VersionInfoFixture.new(isRunningUnderTestService = isRunningUnderTestService)
 
+        var monotonicTimeMillis = 0L
+        val getMonotonicTime = mockk<GetMonotonicTimeProvider>()
+        every { getMonotonicTime() } answers { monotonicTimeMillis }
+
         val viewModel =
             AuthenticationViewModel(
                 application = application,
                 biometricManager = biometricManager,
+                getMonotonicTime = getMonotonicTime,
                 getVersionInfo = getVersionInfo,
                 standardPreferenceProvider = standardPreferenceProvider,
                 walletViewModel = walletViewModel
             )
 
-        return viewModel to secretStateFlow
+        return Triple(viewModel, secretStateFlow) { monotonicTimeMillis = it }
     }
 }
 


### PR DESCRIPTION
Fixes Least Authority finding C ([MOB-1690](https://linear.app/zodl/issue/MOB-1690/c-application-lock-screen-can-be-bypassed-by-changing-system-clock)): the app-lock re-authentication timeout compared wall-clock timestamps (`System.currentTimeMillis`), and the check only ever clears the in-memory auth state — so setting the device clock backwards while the app was backgrounded made the delta negative and the lock screen never reappeared.

## Changes

- The backgrounded-at timestamp is now sampled from a new injectable `GetMonotonicTimeProvider` backed by `SystemClock.elapsedRealtime()` (monotonic, cannot be changed by the user) and held in-memory in `AuthenticationViewModel`; both the record and the check are plain synchronous calls (no coroutine/DataStore round-trip, which also closes a brief flash-of-content window on foregrounding).
- Removed the persisted `LATEST_APP_BACKGROUND_TIME_MILLIS` preference: all authentication state is in-memory in the activity-scoped ViewModel, so process death always re-locks regardless — the persisted value never provided protection, and dropping it avoids the elapsedRealtime-resets-at-boot ambiguity.
- Unit tests for the timeout path (previously uncovered): recent background keeps the unlocked state, >15 min background resets it, check without a recorded background time is a no-op.

## Testing

- `AuthenticationViewModelTest`: 9/9 green (6 existing + 3 new).
- `detektAll` and `ktlintFormat` clean.
- Manual: background the app, set the device clock back several hours, reopen — the lock still appears after 15 minutes of real elapsed time; a forward clock change no longer force-locks within the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)