### PR TITLE
MOB-1754: add explainer note to the Submitting progress screen

### DIFF
--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/confirmsubmission/VoteConfirmSubmissionComponents.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/confirmsubmission/VoteConfirmSubmissionComponents.kt
@@ -113,10 +113,17 @@ internal fun VoteSubmissionBottomSection(state: VoteConfirmSubmissionState) {
                     null
                 }
             }
+        val progressNote: StringResource? =
+            if (state.status is VoteSubmissionStatus.Submitting) {
+                stringRes(R.string.coinVote_confirmSubmission_submittingExplainerNote)
+            } else {
+                null
+            }
 
         if (progressTitle != null) {
             VoteSubmissionProgressCard(
                 title = progressTitle,
+                note = progressNote,
                 progress = submissionProgress,
                 ctaButton = state.ctaButton
             )
@@ -158,6 +165,7 @@ private fun VoteSubmissionProgressCard(
     title: StringResource,
     progress: Float,
     ctaButton: ButtonState,
+    note: StringResource? = null,
 ) {
     val animatedProgress by animateFloatAsState(
         targetValue = progress,
@@ -185,6 +193,14 @@ private fun VoteSubmissionProgressCard(
                 )
                 VerticalSpacer(12.dp)
                 ZashiLinearProgressIndicator(progress = animatedProgress)
+                if (note != null) {
+                    VerticalSpacer(12.dp)
+                    Text(
+                        text = note.getValue(),
+                        style = ZashiTypography.textXs,
+                        color = ZashiColors.Text.textTertiary,
+                    )
+                }
             }
             HorizontalDivider(color = ZashiColors.Surfaces.strokeSecondary)
             ZashiButton(

--- a/ui-design-lib/src/main/res/ui/common/values/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values/strings.xml
@@ -1134,6 +1134,7 @@ Your vote can no longer be submitted.</string>
     <string name="vote_confirm_cta_submitting" tools:ignore="MissingTranslation">Submitting vote %1$d of %2$d</string>
     <string name="coinVote_store_submissionAuthorizingVote" tools:ignore="MissingTranslation">Authorizing vote...</string>
     <string name="coinVote_confirmSubmission_progressSubmittingVoteCount" tools:ignore="MissingTranslation">Submitting vote %1$d of %2$d...</string>
+    <string name="coinVote_confirmSubmission_submittingExplainerNote" tools:ignore="MissingTranslation">This can take a few minutes. Wallets with more voting weight take longer to process.</string>
     <string name="coinVote_results_percentValue" tools:ignore="MissingTranslation">%1$d%%</string>
     <string name="coinVote_common_submission" tools:ignore="MissingTranslation">Submission</string>
     <string name="coinVote_confirmSubmission_headerTitleIdle" tools:ignore="MissingTranslation">Confirm &amp; Submit</string>


### PR DESCRIPTION
## Summary
- Adds a secondary explainer note below the progress bar on the voting Submitting progress screen: "This can take a few minutes. Wallets with more voting weight take longer to process."
- Shown only while `VoteSubmissionStatus.Submitting` is active (not during `Authorizing`), per the Figma reference (node 1319-11260).
- New string resource `coinVote_confirmSubmission_submittingExplainerNote`; `VoteSubmissionProgressCard` gets an optional `note: StringResource?` parameter.

Linear: https://linear.app/zodl/issue/MOB-1754/add-an-explainer-note-to-the-submitting-progress-screen

## Test plan
- [x] `:zodl-android:ktlint` clean
- [x] `:zodl-android:detektAll` clean
- [x] `:zodl-android:feature-voting:compileZcashmainnetStoreDebugKotlin` compiles (verified against local SDK included build, since this module doesn't compile against the currently published Maven SDK — pre-existing, unrelated to this change)
- [ ] Manual visual check against Figma (not yet run on device/emulator)