### PR TITLE
MOB-1674: Surface the real addProofsToPczt failure instead of a generic error

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/KeystoneProposalRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/KeystoneProposalRepository.kt
@@ -219,8 +219,9 @@ class KeystoneProposalRepositoryImpl(
                 try {
                     val result = proposalDataSource.addProofsToPczt(proposalPczt.clonePczt())
                     pcztWithProofs.update { PcztState(isLoading = false, pczt = result) }
-                } catch (_: PcztException.AddProofsToPcztException) {
-                    pcztWithProofs.update { PcztState(isLoading = false, pczt = null) }
+                } catch (e: PcztException.AddProofsToPcztException) {
+                    Twig.error(e) { "Failed to add proofs to PCZT" }
+                    pcztWithProofs.update { PcztState(isLoading = false, pczt = null, error = e) }
                 }
             }
     }
@@ -276,9 +277,12 @@ class KeystoneProposalRepositoryImpl(
                     throw cause
                 } else {
                     submitState.update { SubmitProposalState.Submitting }
-                    val pcztWithProofs = pcztWithProofs.filter { !it.isLoading }.first().pczt
+                    val pcztWithProofsState = pcztWithProofs.filter { !it.isLoading }.first()
+                    val pcztWithProofs = pcztWithProofsState.pczt
                     if (pcztWithProofs == null) {
-                        val cause = IllegalStateException("PCZT with proofs is null")
+                        val cause =
+                            pcztWithProofsState.error
+                                ?: IllegalStateException("PCZT with proofs is null")
                         submitState.update { SubmitProposalState.Result(SubmitResult.Error(cause)) }
                         throw cause
                     } else {
@@ -334,5 +338,6 @@ class KeystoneProposalRepositoryImpl(
 
 private data class PcztState(
     val isLoading: Boolean,
-    val pczt: Pczt?
+    val pczt: Pczt?,
+    val error: Exception? = null
 )


### PR DESCRIPTION
## Summary
- `KeystoneProposalRepository.addProofsToPczt` caught `PcztException.AddProofsToPcztException` and discarded it entirely, so `submit()` always reported a contentless `IllegalStateException("PCZT with proofs is null")` regardless of the actual cause.
- Root cause of the underlying failure (per [MOB-1674](https://linear.app/zodl/issue/MOB-1674/error-submitting-transaction-pczt-with-proofs-is-null)): the SDK's Sapling param download can fail (network) or race (see [PRO-97/MOB-1763](https://linear.app/zodl/issue/MOB-1763/parameter-file-size-is-not-correct-please-clean-your-zcash-parameters), zcash/zcash-android-wallet-sdk#2011 and zcash/zcash-android-wallet-sdk#2201), which then fails proving — but the app swallowed that signal completely.
- Fix: keep the caught exception on `PcztState` and use it as the `submit()` failure cause when present, falling back to the old generic message only if there's genuinely no captured cause.

No SDK API change required — `PcztException.AddProofsToPcztException` already existed and already carries the underlying description/cause; this PR only stops the app from throwing that information away.

## Test plan
- [x] `:ui-lib:compileZcashmainnetFossDebugKotlin` and `:zodl-android:ktlint` pass
- [ ] Manual: trigger a Keystone send with proofs failing (e.g. by blocking network to the param server before signing) and confirm the surfaced error now reflects the real cause instead of "PCZT with proofs is null"