### PR TITLE
fix(send): re-read the spendable balance before proposing and flag in-progress sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed:
 
+- Sending an amount the wallet can no longer cover now shows the Insufficient Funds sheet instead of the technical "Insufficient balance
+  (have 0, need N including fee)" error. The spendable balance is re-read from the SDK right before the transaction proposal is built, so a
+  balance that went stale while the wallet was still syncing (for example over Tor, or when far behind the chain tip) is caught first. The
+  Send screen also notes while sync is in progress that the spendable balance may still change.
 - Shielded coinholder polling works again after the voting infrastructure's v1.3.0 upgrade: the app now reads the PIR polynomial length from the
   voting configuration, verifies the new round-attestation signature format, and submits vote shares with the round binding the voting server
   requires. Rounds signed with the old attestation format are no longer shown.

--- a/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
@@ -648,6 +648,7 @@
     <string name="send_abbreviated_address_format" formatted="true"><xliff:g id="first_five" example="zs1g7">%1$s</xliff:g>…<xliff:g id="last_five" example="mvyzg">%2$s</xliff:g></string>
     <string name="send_info_memo">Las transacciones transparentes no pueden tener mensajes</string>
     <string name="send_addressNotInBook">Agrega un contacto tocando el ícono de la libreta de direcciones.</string>
+    <string name="send_syncingBalanceHint">Sincronización en curso. Tu saldo disponible puede cambiar hasta que termine.</string>
     <string name="send_address_book_content_description">Abrir libreta de direcciones.</string>
 
     <!-- ===== send_confirmation ===== -->

--- a/ui-design-lib/src/main/res/ui/common/values/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values/strings.xml
@@ -686,6 +686,7 @@
     <string name="send_abbreviated_address_format" formatted="true"><xliff:g id="first_five" example="zs1g7">%1$s</xliff:g>…<xliff:g id="last_five" example="mvyzg">%2$s</xliff:g></string>
     <string name="send_info_memo">Transparent transactions can\'t have memos</string>
     <string name="send_addressNotInBook">Add contact by tapping on Address Book icon.</string>
+    <string name="send_syncingBalanceHint">Sync in progress. Your spendable balance may change until it finishes.</string>
     <string name="send_address_book_content_description">Open address book</string>
 
     <!-- ===== send_confirmation ===== -->

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/send/SendViewTestSetup.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/send/SendViewTestSetup.kt
@@ -142,7 +142,8 @@ class SendViewTestSetup(
                             ) {
                                 onSettingsCount.incrementAndGet()
                             }
-                    )
+                    ),
+                isSyncing = false
             )
         }
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
@@ -1,8 +1,10 @@
 package co.electriccoin.zcash.ui.common.datasource
 
 import android.content.Context
+import cash.z.ecc.android.sdk.SdkSynchronizer
 import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.model.Account
+import cash.z.ecc.android.sdk.model.AccountBalance
 import cash.z.ecc.android.sdk.model.AccountImportSetup
 import cash.z.ecc.android.sdk.model.AccountPurpose
 import cash.z.ecc.android.sdk.model.AccountUuid
@@ -14,6 +16,7 @@ import cash.z.ecc.android.sdk.model.WalletBalance
 import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.model.Zip32AccountIndex
 import cash.z.ecc.sdk.extension.ZERO
+import co.electriccoin.zcash.spackle.Twig
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.model.KeystoneAccount
 import co.electriccoin.zcash.ui.common.model.SaplingInfo
@@ -65,6 +68,21 @@ interface AccountDataSource {
     suspend fun getAllAccounts(): List<WalletAccount>
 
     suspend fun getSelectedAccount(): WalletAccount
+
+    /**
+     * Forces the SDK to re-read the wallet summary from the wallet database and returns the selected
+     * account with its balances taken from that fresh read.
+     *
+     * [selectedAccount] is only as fresh as [cash.z.ecc.android.sdk.Synchronizer.walletBalances], which
+     * the SDK refreshes at processor start and after each scanned batch. Between a chain-tip update and
+     * the scan of the queued range (minutes over Tor, or when far behind the tip) the Rust wallet treats
+     * every non-stabilized note in the tip shard as unspendable, so the displayed spendable balance can be
+     * stale in either direction. Call this right before an operation that must agree with the Rust
+     * wallet's current view (proposal creation) instead of trusting the cached account.
+     *
+     * A failed refresh never blocks the caller: it is logged and the last known account is returned.
+     */
+    suspend fun refreshSelectedAccount(): WalletAccount
 
     suspend fun getZashiAccount(): ZashiAccount
 
@@ -163,6 +181,29 @@ class AccountDataSourceImpl(
     override suspend fun getSelectedAccount() = withContext(Dispatchers.IO) { selectedAccount.filterNotNull().first() }
 
     override suspend fun getZashiAccount() = withContext(Dispatchers.IO) { zashiAccount.filterNotNull().first() }
+
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun refreshSelectedAccount(): WalletAccount =
+        withContext(Dispatchers.IO) {
+            val account = getSelectedAccount()
+            val synchronizer = synchronizerProvider.getSynchronizer()
+            if (synchronizer !is SdkSynchronizer) {
+                return@withContext account
+            }
+            try {
+                synchronizer.refreshAllBalances()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Twig.warn(e) { "Balance refresh failed; falling back to the last known balance" }
+                return@withContext account
+            }
+            // Read the SDK's StateFlow directly rather than waiting on [selectedAccount]: the refresh
+            // has already published the new summary synchronously, whereas the account pipeline above
+            // propagates it asynchronously (and never re-emits if nothing changed).
+            val balance = synchronizer.walletBalances.value?.get(account.sdkAccount.accountUuid)
+            if (balance == null) account else account.withBalances(balance)
+        }
 
     override suspend fun selectAccount(account: Account) =
         withContext(Dispatchers.IO) {
@@ -312,12 +353,7 @@ class AccountDataSourceImpl(
 
         val balanceFlow =
             synchronizerProvider.walletBalances
-                .map {
-                    it
-                        ?.get(sdkAccount.accountUuid)
-                        ?.let { balance -> balance.orchard + balance.ironwood }
-                        ?: createEmptyWalletBalance()
-                }
+                .map { it?.get(sdkAccount.accountUuid).unifiedBalance() }
 
         return combine(addressFlow, balanceFlow) { address, balance ->
             UnifiedInfo(address = address, balance = balance)
@@ -333,8 +369,7 @@ class AccountDataSourceImpl(
                 true
             }
         return combine(transparentAddress, synchronizerProvider.walletBalances) { address, balances ->
-            val balance = balances?.get(sdkAccount.accountUuid)
-            TransparentInfo(address = address, balance = balance?.unshielded ?: Zatoshi.ZERO)
+            TransparentInfo(address = address, balance = balances?.get(sdkAccount.accountUuid).transparentBalance())
         }
     }
 
@@ -350,8 +385,7 @@ class AccountDataSourceImpl(
                     true
                 }
             combine(saplingAddress, synchronizerProvider.walletBalances) { address, balances ->
-                val balance = balances?.get(sdkAccount.accountUuid)
-                SaplingInfo(address = address, balance = balance?.sapling ?: createEmptyWalletBalance())
+                SaplingInfo(address = address, balance = balances?.get(sdkAccount.accountUuid).saplingBalance())
             }
         }
 
@@ -359,18 +393,53 @@ class AccountDataSourceImpl(
     // just its balance.
     private fun observeIronwoodBalance(sdkAccount: Account): Flow<WalletBalance> =
         synchronizerProvider.walletBalances.map { balances ->
-            balances?.get(sdkAccount.accountUuid)?.ironwood ?: createEmptyWalletBalance()
+            balances?.get(sdkAccount.accountUuid).ironwoodBalance()
+        }
+}
+
+/**
+ * Returns a copy of this account carrying the balances of [balance]. This is the single place that maps
+ * an SDK [AccountBalance] onto [WalletAccount]'s pool fields, shared by the account observers and by
+ * [AccountDataSource.refreshSelectedAccount], so a refreshed account and an observed one always agree.
+ */
+internal fun WalletAccount.withBalances(balance: AccountBalance): WalletAccount =
+    when (this) {
+        is ZashiAccount -> {
+            copy(
+                unified = unified.copy(balance = balance.unifiedBalance()),
+                sapling = sapling.copy(balance = balance.saplingBalance()),
+                ironwoodBalance = balance.ironwoodBalance(),
+                transparent = transparent.copy(balance = balance.transparentBalance()),
+            )
         }
 
-    private fun createEmptyWalletBalance() = WalletBalance(Zatoshi.ZERO, Zatoshi.ZERO, Zatoshi.ZERO)
+        is KeystoneAccount -> {
+            copy(
+                unified = unified.copy(balance = balance.unifiedBalance()),
+                ironwoodBalance = balance.ironwoodBalance(),
+                transparent = transparent.copy(balance = balance.transparentBalance()),
+            )
+        }
+    }
 
-    private operator fun WalletBalance.plus(other: WalletBalance) =
-        WalletBalance(
-            available = available + other.available,
-            changePending = changePending + other.changePending,
-            valuePending = valuePending + other.valuePending
-        )
-}
+// The unified pool folds Orchard + Ironwood together (see WalletAccount.unified's kdoc).
+private fun AccountBalance?.unifiedBalance(): WalletBalance =
+    this?.let { it.orchard + it.ironwood } ?: createEmptyWalletBalance()
+
+private fun AccountBalance?.saplingBalance(): WalletBalance = this?.sapling ?: createEmptyWalletBalance()
+
+private fun AccountBalance?.ironwoodBalance(): WalletBalance = this?.ironwood ?: createEmptyWalletBalance()
+
+private fun AccountBalance?.transparentBalance(): Zatoshi = this?.unshielded ?: Zatoshi.ZERO
+
+private fun createEmptyWalletBalance() = WalletBalance(Zatoshi.ZERO, Zatoshi.ZERO, Zatoshi.ZERO)
+
+private operator fun WalletBalance.plus(other: WalletBalance) =
+    WalletBalance(
+        available = available + other.available,
+        changePending = changePending + other.changePending,
+        valuePending = valuePending + other.valuePending
+    )
 
 private data class AddressRequest(
     val accountUuid: AccountUuid,

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/CreateProposalUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/CreateProposalUseCase.kt
@@ -24,7 +24,18 @@ class CreateProposalUseCase(
     suspend operator fun invoke(zecSend: ZecSend, floor: Boolean) {
         val normalized = if (floor) zecSend.copy(amount = zecSend.amount.floor()) else zecSend
         try {
-            when (accountDataSource.getSelectedAccount()) {
+            // The Send form gates its button on the cached spendable balance, which can be stale while
+            // the SDK is between a chain-tip update and the scan of the queued range. Re-read it from
+            // the SDK first so an amount the wallet can no longer cover lands on the Insufficient Funds
+            // sheet instead of surfacing the SDK's "Insufficient balance (have 0, ...)" as a raw error.
+            val account = accountDataSource.refreshSelectedAccount()
+            if (!account.canSpend(normalized.amount)) {
+                keystoneProposalRepository.clear()
+                zashiProposalRepository.clear()
+                navigationRouter.forward(InsufficientFundsArgs)
+                return
+            }
+            when (account) {
                 is KeystoneAccount -> {
                     keystoneProposalRepository.createProposal(normalized)
                     keystoneProposalRepository.createPCZTFromProposal()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/AndroidSend.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/AndroidSend.kt
@@ -123,6 +123,8 @@ internal fun WrapSend(
 
     val sendAddressBookState by viewModel.sendAddressBookState.collectAsStateWithLifecycle()
 
+    val isSyncing by viewModel.isSyncing.collectAsStateWithLifecycle()
+
     val topAppBarViewModel = koinActivityViewModel<ZashiTopAppBarVM>()
 
     val zashiMainTopAppBarState by topAppBarViewModel.state.collectAsStateWithLifecycle()
@@ -323,7 +325,8 @@ internal fun WrapSend(
             selectedAccount = selectedAccount,
             exchangeRateState = exchangeRateState,
             sendAddressBookState = sendAddressBookState,
-            zashiMainTopAppBarState = zashiMainTopAppBarState
+            zashiMainTopAppBarState = zashiMainTopAppBarState,
+            isSyncing = isSyncing,
         )
     }
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/SendViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/SendViewModel.kt
@@ -2,10 +2,13 @@ package co.electriccoin.zcash.ui.screen.send
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.model.ZecSend
 import cash.z.ecc.sdk.ANDROID_STATE_FLOW_TIMEOUT
 import co.electriccoin.zcash.spackle.Twig
 import co.electriccoin.zcash.ui.NavigationRouter
+import co.electriccoin.zcash.ui.common.datasource.WalletSnapshotDataSource
+import co.electriccoin.zcash.ui.common.model.WalletSnapshot
 import co.electriccoin.zcash.ui.common.repository.ExchangeRateRepository
 import co.electriccoin.zcash.ui.common.usecase.CreateProposalUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetWalletAccountsUseCase
@@ -23,10 +26,12 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -40,8 +45,24 @@ class SendViewModel(
     private val observeWalletAccounts: GetWalletAccountsUseCase,
     private val navigateToSelectRecipient: NavigateToSelectRecipientUseCase,
     private val navigationRouter: NavigationRouter,
+    walletSnapshotDataSource: WalletSnapshotDataSource,
 ) : ViewModel() {
     val recipientAddressState = MutableStateFlow(RecipientAddressState.new("", null))
+
+    /**
+     * True while the synchronizer is anything other than [Synchronizer.Status.SYNCED]. The spendable
+     * balance shown on the form is only refreshed by the SDK per scanned batch, so until sync settles it
+     * may still move; the form surfaces this next to the balance.
+     */
+    val isSyncing: StateFlow<Boolean> =
+        walletSnapshotDataSource
+            .observe()
+            .map { it.isSyncing() }
+            .stateIn(
+                viewModelScope,
+                SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
+                walletSnapshotDataSource.observe().value.isSyncing()
+            )
 
     private var onCreateZecSendClickJob: Job? = null
 
@@ -149,3 +170,9 @@ class SendViewModel(
             }
     }
 }
+
+/**
+ * A snapshot that has not yet reached [Synchronizer.Status.SYNCED]. An absent snapshot (no synchronizer
+ * yet) counts as not syncing so the hint never flashes before the wallet is even loaded.
+ */
+internal fun WalletSnapshot?.isSyncing(): Boolean = this != null && status != Synchronizer.Status.SYNCED

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/view/SendSyncingHint.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/view/SendSyncingHint.kt
@@ -1,0 +1,42 @@
+package co.electriccoin.zcash.ui.screen.send.view
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import co.electriccoin.zcash.ui.R
+import co.electriccoin.zcash.ui.design.newcomponent.PreviewScreens
+import co.electriccoin.zcash.ui.design.theme.ZcashTheme
+import co.electriccoin.zcash.ui.design.theme.colors.ZashiColors
+import co.electriccoin.zcash.ui.design.theme.typography.ZashiTypography
+
+/**
+ * Shown under the balance widget while the synchronizer is not yet SYNCED: the spendable balance the
+ * form validates against is only refreshed per scanned batch, so it may still move.
+ */
+@Composable
+fun SendSyncingHint(modifier: Modifier = Modifier) {
+    Text(
+        modifier = modifier,
+        text = stringResource(id = R.string.send_syncingBalanceHint),
+        style = ZashiTypography.textXs,
+        color = ZashiColors.Text.textTertiary,
+        textAlign = TextAlign.Center
+    )
+}
+
+@PreviewScreens
+@Composable
+private fun SendSyncingHintPreview() =
+    ZcashTheme {
+        Box(
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
+        ) {
+            SendSyncingHint(Modifier.fillMaxWidth())
+        }
+    }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/view/SendView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/view/SendView.kt
@@ -116,6 +116,7 @@ fun Send(
     exchangeRateState: ExchangeRateState,
     sendAddressBookState: SendAddressBookState,
     zashiMainTopAppBarState: ZashiMainTopAppBarState?,
+    isSyncing: Boolean,
 ) {
     if (selectedAccount == null) {
         return
@@ -163,6 +164,7 @@ fun Send(
                 memoState = memoState,
                 setMemoState = setMemoState,
                 sendState = sendAddressBookState,
+                isSyncing = isSyncing,
                 modifier = Modifier.scaffoldPadding(paddingValues)
             )
         }
@@ -187,6 +189,7 @@ private fun SendMainContent(
     memoState: MemoState,
     setMemoState: (MemoState) -> Unit,
     sendState: SendAddressBookState,
+    isSyncing: Boolean,
     modifier: Modifier = Modifier,
 ) {
     // For now, we merge [SendStage.Form] and [SendStage.Proposing] into one stage. We could eventually display a
@@ -206,6 +209,7 @@ private fun SendMainContent(
         onQrScannerOpen = onQrScannerOpen,
         hasCameraFeature = hasCameraFeature,
         sendState = sendState,
+        isSyncing = isSyncing,
         modifier = modifier
     )
 
@@ -239,6 +243,7 @@ private fun SendForm(
     onQrScannerOpen: () -> Unit,
     hasCameraFeature: Boolean,
     sendState: SendAddressBookState,
+    isSyncing: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -254,6 +259,13 @@ private fun SendForm(
         BalanceWidget(
             state = balanceWidgetState
         )
+
+        AnimatedVisibility(visible = isSyncing) {
+            Column {
+                Spacer(12.dp)
+                SendSyncingHint(Modifier.fillMaxWidth())
+            }
+        }
 
         Spacer(24.dp)
 

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/WalletAccountWithBalancesTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/WalletAccountWithBalancesTest.kt
@@ -1,0 +1,107 @@
+package co.electriccoin.zcash.ui.common.datasource
+
+import cash.z.ecc.android.sdk.model.Account
+import cash.z.ecc.android.sdk.model.AccountBalance
+import cash.z.ecc.android.sdk.model.WalletAddress
+import cash.z.ecc.android.sdk.model.WalletBalance
+import cash.z.ecc.android.sdk.model.Zatoshi
+import co.electriccoin.zcash.ui.common.model.KeystoneAccount
+import co.electriccoin.zcash.ui.common.model.SaplingInfo
+import co.electriccoin.zcash.ui.common.model.TransparentInfo
+import co.electriccoin.zcash.ui.common.model.UnifiedInfo
+import co.electriccoin.zcash.ui.common.model.ZashiAccount
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+/**
+ * [withBalances] is the mapping [AccountDataSource.refreshSelectedAccount] applies to a freshly read SDK
+ * balance. It must fold the pools exactly like the account observers do (unified = Orchard + Ironwood)
+ * while leaving addresses, selection and identity untouched.
+ */
+class WalletAccountWithBalancesTest {
+    private val fresh =
+        AccountBalance(
+            sapling = balance(available = 100L, changePending = 10L, valuePending = 1L),
+            orchard = balance(available = 200L, changePending = 20L, valuePending = 2L),
+            ironwood = balance(available = 300L, changePending = 30L, valuePending = 3L),
+            unshielded = Zatoshi(400L),
+        )
+
+    @Test
+    fun zashiAccountFoldsOrchardAndIronwoodIntoUnifiedAndKeepsIdentity() =
+        runBlocking {
+            val account = zashiAccount()
+
+            val refreshed = account.withBalances(fresh) as ZashiAccount
+
+            assertEquals(balance(500L, 50L, 5L), refreshed.unified.balance)
+            assertEquals(fresh.sapling, refreshed.sapling.balance)
+            assertEquals(fresh.ironwood, refreshed.ironwoodBalance)
+            assertEquals(Zatoshi(400L), refreshed.transparent.balance)
+            assertEquals(Zatoshi(600L), refreshed.spendableShieldedBalance)
+            assertSame(account.sdkAccount, refreshed.sdkAccount)
+            assertEquals(account.unified.address, refreshed.unified.address)
+            assertEquals(account.sapling.address, refreshed.sapling.address)
+            assertEquals(account.transparent.address, refreshed.transparent.address)
+            assertEquals(account.isSelected, refreshed.isSelected)
+        }
+
+    @Test
+    fun zashiAccountCanSpendReflectsTheFreshBalanceNotTheStaleOne() =
+        runBlocking {
+            val stale = zashiAccount()
+            assertEquals(true, stale.canSpend(Zatoshi(1_000L)))
+
+            val drained = stale.withBalances(fresh.copy(sapling = zero(), orchard = zero(), ironwood = zero()))
+
+            assertEquals(false, drained.canSpend(Zatoshi(1L)))
+            assertEquals(true, drained.canSpend(Zatoshi(0L)))
+        }
+
+    @Test
+    fun keystoneAccountIgnoresSaplingAndFoldsUnified() =
+        runBlocking {
+            val account = keystoneAccount()
+
+            val refreshed = account.withBalances(fresh) as KeystoneAccount
+
+            assertEquals(balance(500L, 50L, 5L), refreshed.unified.balance)
+            assertEquals(fresh.ironwood, refreshed.ironwoodBalance)
+            assertEquals(Zatoshi(400L), refreshed.transparent.balance)
+            assertEquals(Zatoshi(500L), refreshed.spendableShieldedBalance)
+            assertNull(refreshed.sapling)
+            assertSame(account.sdkAccount, refreshed.sdkAccount)
+        }
+
+    private suspend fun zashiAccount() =
+        ZashiAccount(
+            sdkAccount = mockk<Account>(),
+            unified = UnifiedInfo(WalletAddress.Unified.new("ua"), balance(1_000L, 0L, 0L)),
+            sapling = SaplingInfo(WalletAddress.Sapling.new("zs"), balance(1_000L, 0L, 0L)),
+            ironwoodBalance = balance(500L, 0L, 0L),
+            transparent = TransparentInfo(WalletAddress.Transparent.new("t1"), Zatoshi(7L)),
+            isSelected = true,
+        )
+
+    private suspend fun keystoneAccount() =
+        KeystoneAccount(
+            sdkAccount = mockk<Account>(),
+            unified = UnifiedInfo(WalletAddress.Unified.new("ua"), balance(1_000L, 0L, 0L)),
+            ironwoodBalance = balance(500L, 0L, 0L),
+            transparent = TransparentInfo(WalletAddress.Transparent.new("t1"), Zatoshi(7L)),
+            isSelected = true,
+        )
+
+    private fun balance(available: Long, changePending: Long, valuePending: Long) =
+        WalletBalance(
+            available = Zatoshi(available),
+            changePending = Zatoshi(changePending),
+            valuePending = Zatoshi(valuePending)
+        )
+
+    private fun zero() = balance(0L, 0L, 0L)
+}

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/CreateProposalUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/CreateProposalUseCaseTest.kt
@@ -1,0 +1,157 @@
+package co.electriccoin.zcash.ui.common.usecase
+
+import cash.z.ecc.android.sdk.model.Memo
+import cash.z.ecc.android.sdk.model.WalletAddress
+import cash.z.ecc.android.sdk.model.Zatoshi
+import cash.z.ecc.android.sdk.model.ZecSend
+import co.electriccoin.zcash.ui.NavigationRouter
+import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
+import co.electriccoin.zcash.ui.common.datasource.InsufficientFundsException
+import co.electriccoin.zcash.ui.common.datasource.TexUnsupportedOnKSException
+import co.electriccoin.zcash.ui.common.model.KeystoneAccount
+import co.electriccoin.zcash.ui.common.model.WalletAccount
+import co.electriccoin.zcash.ui.common.model.ZashiAccount
+import co.electriccoin.zcash.ui.common.repository.KeystoneProposalRepository
+import co.electriccoin.zcash.ui.common.repository.ZashiProposalRepository
+import co.electriccoin.zcash.ui.screen.insufficientfunds.InsufficientFundsArgs
+import co.electriccoin.zcash.ui.screen.reviewtransaction.ReviewTransactionArgs
+import co.electriccoin.zcash.ui.screen.texunsupported.TEXUnsupportedArgs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+/**
+ * [CreateProposalUseCase] must consult a freshly refreshed balance (not the cached account) before
+ * asking the SDK for a proposal, and route a shortfall to the Insufficient Funds sheet exactly like
+ * the SDK-reported [InsufficientFundsException] path does.
+ */
+class CreateProposalUseCaseTest {
+    private val navigationRouter = mockk<NavigationRouter>(relaxed = true)
+    private val zashiProposalRepository = mockk<ZashiProposalRepository>(relaxed = true)
+    private val keystoneProposalRepository = mockk<KeystoneProposalRepository>(relaxed = true)
+    private val accountDataSource = mockk<AccountDataSource>()
+
+    @Test
+    fun refreshedBalanceTooLowRoutesToInsufficientFundsWithoutProposing() =
+        runBlocking {
+            val account = zashi(canSpend = false)
+            useCase(account).invoke(zecSend(), floor = false)
+
+            coVerify(exactly = 1) { accountDataSource.refreshSelectedAccount() }
+            coVerify(exactly = 0) { accountDataSource.getSelectedAccount() }
+            coVerify(exactly = 0) { zashiProposalRepository.createProposal(any()) }
+            coVerify(exactly = 0) { keystoneProposalRepository.createProposal(any()) }
+            verify { zashiProposalRepository.clear() }
+            verify { keystoneProposalRepository.clear() }
+            verify(exactly = 1) { navigationRouter.forward(InsufficientFundsArgs) }
+            verify(exactly = 0) { navigationRouter.forward(ReviewTransactionArgs) }
+        }
+
+    @Test
+    fun refreshedBalanceSufficientCreatesZashiProposalAndForwards() =
+        runBlocking {
+            val send = zecSend()
+            useCase(zashi(canSpend = true)).invoke(send, floor = false)
+
+            coVerify(exactly = 1) { zashiProposalRepository.createProposal(send) }
+            coVerify(exactly = 0) { keystoneProposalRepository.createProposal(any()) }
+            verify(exactly = 1) { navigationRouter.forward(ReviewTransactionArgs) }
+            verify(exactly = 0) { navigationRouter.forward(InsufficientFundsArgs) }
+        }
+
+    @Test
+    fun refreshedBalanceSufficientCreatesKeystoneProposalAndPczt() =
+        runBlocking {
+            val send = zecSend()
+            useCase(keystone(canSpend = true)).invoke(send, floor = false)
+
+            coVerify(exactly = 1) { keystoneProposalRepository.createProposal(send) }
+            coVerify(exactly = 1) { keystoneProposalRepository.createPCZTFromProposal() }
+            coVerify(exactly = 0) { zashiProposalRepository.createProposal(any()) }
+            verify(exactly = 1) { navigationRouter.forward(ReviewTransactionArgs) }
+        }
+
+    @Test
+    fun keystoneShortfallAlsoRoutesToInsufficientFunds() =
+        runBlocking {
+            useCase(keystone(canSpend = false)).invoke(zecSend(), floor = false)
+
+            coVerify(exactly = 0) { keystoneProposalRepository.createProposal(any()) }
+            verify(exactly = 1) { navigationRouter.forward(InsufficientFundsArgs) }
+        }
+
+    @Test
+    fun preCheckUsesTheFlooredAmountWhenFlooring() =
+        runBlocking {
+            val account = zashi(canSpend = true)
+            useCase(account).invoke(zecSend(amount = Zatoshi(7_000L)), floor = true)
+
+            // 7 000 zatoshi floors to the nearest 5 000; the SDK receives the same floored amount.
+            verify(exactly = 1) { account.canSpend(Zatoshi(5_000L)) }
+            coVerify(exactly = 1) { zashiProposalRepository.createProposal(match { it.amount == Zatoshi(5_000L) }) }
+        }
+
+    @Test
+    fun sdkInsufficientFundsStillRoutesToInsufficientFunds() =
+        runBlocking {
+            coEvery { zashiProposalRepository.createProposal(any()) } throws InsufficientFundsException()
+            useCase(zashi(canSpend = true)).invoke(zecSend(), floor = false)
+
+            verify { zashiProposalRepository.clear() }
+            verify { keystoneProposalRepository.clear() }
+            verify(exactly = 1) { navigationRouter.forward(InsufficientFundsArgs) }
+        }
+
+    @Test
+    fun texUnsupportedStillRoutesToTexSheet() =
+        runBlocking {
+            coEvery { keystoneProposalRepository.createProposal(any()) } throws TexUnsupportedOnKSException()
+            useCase(keystone(canSpend = true)).invoke(zecSend(), floor = false)
+
+            verify(exactly = 1) { navigationRouter.forward(TEXUnsupportedArgs) }
+            verify { zashiProposalRepository.clear() }
+            verify { keystoneProposalRepository.clear() }
+        }
+
+    @Test
+    fun genericFailureClearsAndRethrows() {
+        coEvery { zashiProposalRepository.createProposal(any()) } throws IllegalStateException("boom")
+        assertFailsWith<IllegalStateException> {
+            runBlocking { useCase(zashi(canSpend = true)).invoke(zecSend(), floor = false) }
+        }
+        verify { zashiProposalRepository.clear() }
+        verify { keystoneProposalRepository.clear() }
+        verify(exactly = 0) { navigationRouter.forward(InsufficientFundsArgs) }
+        verify(exactly = 0) { navigationRouter.forward(ReviewTransactionArgs) }
+    }
+
+    private fun useCase(account: WalletAccount): CreateProposalUseCase {
+        coEvery { accountDataSource.refreshSelectedAccount() } returns account
+        coEvery { accountDataSource.getSelectedAccount() } returns account
+        return CreateProposalUseCase(
+            keystoneProposalRepository = keystoneProposalRepository,
+            zashiProposalRepository = zashiProposalRepository,
+            accountDataSource = accountDataSource,
+            navigationRouter = navigationRouter,
+        )
+    }
+
+    private fun zashi(canSpend: Boolean): ZashiAccount =
+        mockk { every { canSpend(any()) } returns canSpend }
+
+    private fun keystone(canSpend: Boolean): KeystoneAccount =
+        mockk { every { canSpend(any()) } returns canSpend }
+
+    private suspend fun zecSend(amount: Zatoshi = Zatoshi(10_000L)) =
+        ZecSend(
+            destination = WalletAddress.Unified.new("destination"),
+            amount = amount,
+            memo = Memo(""),
+            proposal = null
+        )
+}

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/screen/send/SendViewModelIsSyncingTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/screen/send/SendViewModelIsSyncingTest.kt
@@ -1,0 +1,33 @@
+package co.electriccoin.zcash.ui.screen.send
+
+import cash.z.ecc.android.sdk.Synchronizer
+import cash.z.ecc.android.sdk.model.PercentDecimal
+import co.electriccoin.zcash.ui.common.model.WalletRestoringState
+import co.electriccoin.zcash.ui.common.model.WalletSnapshot
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SendViewModelIsSyncingTest {
+    private fun snapshot(status: Synchronizer.Status) =
+        WalletSnapshot(
+            status = status,
+            progress = PercentDecimal(0.5f),
+            synchronizerError = null,
+            isSpendable = true,
+            restoringState = WalletRestoringState.SYNCING,
+        )
+
+    @Test
+    fun syncedIsNotSyncing() = assertFalse(snapshot(Synchronizer.Status.SYNCED).isSyncing())
+
+    @Test
+    fun missingSnapshotIsNotSyncing() = assertFalse((null as WalletSnapshot?).isSyncing())
+
+    @Test
+    fun everyOtherStatusIsSyncing() {
+        Synchronizer.Status.entries
+            .filter { it != Synchronizer.Status.SYNCED }
+            .forEach { assertTrue(snapshot(it).isSyncing(), "expected $it to count as syncing") }
+    }
+}


### PR DESCRIPTION
Users saw "Error creating transaction proposal: Insufficient balance (have 0, need N including fee)" right after the Send form showed a sufficient spendable balance. The form gates its button on WalletAccount.spendableShieldedBalance, which comes from Synchronizer.walletBalances; the SDK only refreshes that at processor start and after each scanned batch. After updateChainTip the Rust wallet treats every non-stabilized note in the tip shard as unspendable until the queued range is scanned, so during that window (minutes over Tor, or when far behind the tip) the cached balance is stale and proposeSend fails.

- AccountDataSource.refreshSelectedAccount() forces SdkSynchronizer .refreshAllBalances() (which publishes the new summary synchronously) and rebuilds the selected account from the fresh walletBalances value instead of waiting on the async account pipeline. A failed refresh is logged and falls back to the last known account so it never blocks sending. The AccountBalance -> WalletAccount pool mapping is extracted into one shared helper (WalletAccount.withBalances) used by both the observers and the refresh path.
- CreateProposalUseCase runs that refresh and re-checks canSpend() before proposing for both Zashi and Keystone accounts; a shortfall clears the proposal repositories and routes to the Insufficient Funds sheet exactly like the SDK-reported InsufficientFundsException path.
- The Send form shows a small hint under the balance widget while the synchronizer is not SYNCED, noting the spendable balance may still change (new send_syncingBalanceHint string, en + es).

The underlying race is being addressed separately in librustzcash and the Android SDK; this keeps the app-side failure honest in the meantime.


Claude-Session: https://claude.ai/code/session_01QFC3F7xL54sfad9qfNYnUv