### PR TITLE
fix: reduce isServerCustom() to two returns to satisfy detekt ReturnCount

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
@@ -87,8 +87,9 @@ class AutomaticServerRepositoryImpl(
     // one of our own bundled servers — see resolveIsEndpointCustom.
     override suspend fun isServerCustom(): Boolean {
         if (isServerAutomatic()) return false
-        val endpoint = persistableWalletProvider.getPersistableWallet()?.endpoint ?: return false
-        return resolveIsEndpointCustom(endpoint, lightWalletEndpointProvider.getEndpoints())
+        return persistableWalletProvider.getPersistableWallet()?.endpoint?.let { endpoint ->
+            resolveIsEndpointCustom(endpoint, lightWalletEndpointProvider.getEndpoints())
+        } ?: false
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
## Summary

`detektAll` is currently red on `main` for every branch: `AutomaticServerRepositoryImpl.isServerCustom()` (added in #2448) has 3 `return` statements, exceeding the `ReturnCount` limit of 2. This blocks the `static_analysis_detekt` CI job on all open PRs (observed on at least three branches).

This collapses the nullable-endpoint check and the final computation into a single `?.let { ... } ?: false` expression, preserving the original short-circuit order (automatic-mode check first, wallet lookup only when not automatic). Behavior-preserving: a null wallet or null endpoint still yields `false`.

Cherry-pick of 674194924 from #2461, where CI's `static_analysis_detekt` already went green with this change.

## Test plan

- `./gradlew ktlint detektAll` on this branch (main + this commit): green.
- `static_analysis_detekt` on #2461's branch carrying the same commit: [green](https://github.com/zodl-inc/zodl-android/actions/runs/32814155766).
- `:ui-lib:testZcashmainnetStoreDebugUnitTest` (includes `AutomaticServerRepositoryTest`) was run green with this change on the #2461 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)