### PR TITLE
MOB-1754: show submission explainer note during Authorizing too

### DIFF
--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/confirmsubmission/VoteConfirmSubmissionComponents.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/confirmsubmission/VoteConfirmSubmissionComponents.kt
@@ -114,7 +114,7 @@ internal fun VoteSubmissionBottomSection(state: VoteConfirmSubmissionState) {
                 }
             }
         val progressNote: StringResource? =
-            if (state.status is VoteSubmissionStatus.Submitting) {
+            if (progressTitle != null) {
                 stringRes(R.string.coinVote_confirmSubmission_submittingExplainerNote)
             } else {
                 null


### PR DESCRIPTION
## Summary
Follow-up to #2464. Team testing found the Authorizing phase can take longer than Submitting (up to 80% of total time in one report) — the explainer note ("This can take a few minutes. Wallets with more voting weight take longer to process.") should be visible for the whole progress panel, not just the Submitting phase.

Changes the `progressNote` condition in `VoteSubmissionBottomSection` from `state.status is VoteSubmissionStatus.Submitting` to `progressTitle != null`, tying it to the same condition that shows the progress card itself (Authorizing + Submitting), so the two can't drift apart again.

Linear: https://linear.app/zodl/issue/MOB-1754/add-an-explainer-note-to-the-submitting-progress-screen
Slack decision: https://zodl.slack.com/archives/C0B4F0CUWMC/p1787586182292649

## Test plan
- [x] `:zodl-android:feature-voting:compileZcashmainnetStoreDebugKotlin` compiles (against local SDK included build, same known Maven-SDK gap as #2464)
- [x] `:zodl-android:ktlint` clean
- [x] `:zodl-android:detektAll` clean
- [ ] Manual visual check on device/emulator