### PR TITLE
MOB-1750: gate the residue banner on full wallet sync

### DIFF
--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import cash.z.ecc.android.sdk.AttentionReason
 import cash.z.ecc.android.sdk.MigrationBlocker
 import cash.z.ecc.android.sdk.MigrationState
+import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.model.Zatoshi
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
+import co.electriccoin.zcash.ui.common.datasource.WalletSnapshotDataSource
 import co.electriccoin.zcash.ui.common.migration.MigrationHomeMessageSource
 import co.electriccoin.zcash.ui.common.model.migration.LiveMigrationSnapshot
 import co.electriccoin.zcash.ui.common.model.migration.MIGRATION_DUST_THRESHOLD_ZATOSHI
@@ -61,6 +63,7 @@ class MigrationHomeMessageSourceImpl(
     private val getOrchardMigrationSdk: GetOrchardMigrationSdkUseCase,
     private val observeMigrationLiveReadout: ObserveMigrationLiveReadoutUseCase,
     private val getOrchardBalance: GetOrchardBalanceUseCase,
+    private val walletSnapshotDataSource: WalletSnapshotDataSource,
     private val hasSeenMigrationCompleteStorageProvider: HasSeenMigrationCompleteStorageProvider,
     private val isBackgroundExecutionAvailableProvider: IsBackgroundExecutionAvailableProvider,
     private val navigationRouter: NavigationRouter,
@@ -84,7 +87,14 @@ class MigrationHomeMessageSourceImpl(
                 // never touches the engine) the balance is the only input that can hide the
                 // "Migrate required" banner once the Orchard funds are spent.
                 getOrchardBalance.observe(),
-            ) { hasSeenComplete, readout, orchardBalance ->
+                // Mirrors HomeVM's isSyncComplete (iOS: SmartBannerStore.isSyncComplete) — the
+                // RESIDUE branch below reads a live balance/migratable-total pair that can
+                // disagree with each other mid-sync (two different queries against the same,
+                // still-changing DB), so it must not fire until the wallet has caught up with
+                // the chain tip. See MOB-1750 mid-sync race investigation.
+                walletSnapshotDataSource.observe(),
+            ) { hasSeenComplete, readout, orchardBalance, walletSnapshot ->
+                val isFullySynced = walletSnapshot?.status == Synchronizer.Status.SYNCED
                 val sdkState = readout?.migrationState
                 val states = readout?.states
                 val snapshot =
@@ -137,6 +147,7 @@ class MigrationHomeMessageSourceImpl(
                     orchardBalanceZatoshi = orchardBalanceZatoshi,
                     migratableOrchardTotalZatoshi = migratableOrchardTotal,
                     dustThresholdZatoshi = dustThreshold,
+                    isFullySynced = isFullySynced,
                     isBackgroundExecutionAvailable = isBackgroundExecutionAvailableProvider.isAvailable(),
                     hasOverdueTransfers = readout?.hasOverdueTransfers ?: false,
                     attentionKind = attentionKind,
@@ -311,6 +322,14 @@ class MigrationHomeMessageSourceImpl(
  * worth spending. The displayed amount ([MigrationHomeMessageData.residualBalanceZatoshi]) still
  * uses the raw balance — the user's real, current Orchard balance — only the "is this worth
  * prompting about" gate uses the net-of-fee total.
+ *
+ * The residue branch is additionally gated on [isFullySynced]: [orchardBalanceZatoshi] and
+ * [migratableOrchardTotalZatoshi] are two independent reads of the same, still-changing DB while
+ * the wallet is mid-sync, and can disagree window-to-window — firing the residue prompt on that
+ * stale pair produced a bogus balance and a "Migrate anyway" that failed with "no Orchard input
+ * found" once the notes it referenced had moved on. Not applied to the other branches above: the
+ * celebration branch is explicitly out of scope for this fix, and the plain "Migrate now" branch
+ * only shows a CTA (no one-click transfer proposal) so the same race isn't user-visible there.
  */
 @Suppress("CyclomaticComplexMethod")
 internal fun migrationMessageFor(
@@ -320,6 +339,7 @@ internal fun migrationMessageFor(
     orchardBalanceZatoshi: Long,
     migratableOrchardTotalZatoshi: Long = orchardBalanceZatoshi,
     dustThresholdZatoshi: Long = MIGRATION_DUST_THRESHOLD_ZATOSHI,
+    isFullySynced: Boolean = true,
     isBackgroundExecutionAvailable: Boolean = true,
     hasOverdueTransfers: Boolean = false,
     now: Instant = Clock.System.now(),
@@ -407,8 +427,15 @@ internal fun migrationMessageFor(
         // the user LOCK it or MIGRATE it anyway. The reported balance is the *spendable* Orchard
         // balance (locked notes excluded), so locking makes this stop firing on its own.
         // Lower bound uses migratableOrchardTotalZatoshi (per-note, net of MARGINAL_FEE), not the
-        // raw balance — see the function doc.
+        // raw balance — see the function doc. Gated on isFullySynced: orchardBalanceZatoshi (live
+        // synchronizer balance) and migratableOrchardTotalZatoshi (one-shot SQLite query) can
+        // disagree with each other while the wallet is still catching up to the chain tip — both
+        // read the same DB but at different consistency points during active scanning. Firing this
+        // branch on stale/mid-sync data showed a bogus "X ZEC left in Orchard" popup and let
+        // "Migrate anyway" propose a transfer against notes that no longer existed by the time the
+        // proposal ran (Slack repro, 2026-08-24).
         !midRunAttention &&
+            isFullySynced &&
             migratableOrchardTotalZatoshi > dustThresholdZatoshi &&
             orchardBalanceZatoshi < MIGRATION_RESIDUAL_MIN_ZATOSHI -> {
             MigrationHomeMessageData(

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/MigrationBannerStateTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/MigrationBannerStateTest.kt
@@ -472,4 +472,73 @@ class MigrationBannerStateTest {
             result,
         )
     }
+
+    // ─── §6 RESIDUE gated on isFullySynced (mid-sync race) ────────────────────
+
+    /**
+     * Neal's repro (Slack, 2026-08-24): a wallet that was already fully swept elsewhere (0 ZEC)
+     * but hadn't finished syncing this instance showed a bogus "X ZEC left in Orchard" residue
+     * popup, and its "Migrate anyway" action failed with "no Orchard input found for TXID..." —
+     * orchardBalanceZatoshi and migratableOrchardTotalZatoshi are two independent reads of the
+     * same, still-changing DB mid-sync and can disagree window-to-window. The residue branch must
+     * not fire until the wallet has caught up with the chain tip.
+     */
+    @Test
+    fun residueBranchSuppressedWhileNotFullySynced() {
+        val result =
+            migrationMessageFor(
+                sdkState = null,
+                snapshot = null,
+                hasSeenComplete = false,
+                orchardBalanceZatoshi = 500_000L, // in (dust, min) gap — would be residue if synced
+                migratableOrchardTotalZatoshi = MIGRATION_DUST_THRESHOLD_ZATOSHI + 1L,
+                isFullySynced = false,
+            )
+        assertNull(result, "Residue banner must not fire while the wallet is still mid-sync")
+    }
+
+    /**
+     * Contrast case: identical inputs, but the wallet is fully synced — the residue banner fires
+     * exactly as before. Confirms the new gate doesn't change behavior once sync has caught up.
+     */
+    @Test
+    fun residueBranchFiresOnceFullySynced() {
+        val result =
+            migrationMessageFor(
+                sdkState = null,
+                snapshot = null,
+                hasSeenComplete = false,
+                orchardBalanceZatoshi = 500_000L,
+                migratableOrchardTotalZatoshi = MIGRATION_DUST_THRESHOLD_ZATOSHI + 1L,
+                isFullySynced = true,
+            )
+        assertEquals(
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = 500_000L,
+            ),
+            result,
+        )
+    }
+
+    /**
+     * The plain "Migrate now" branch (raw balance ≥ [MIGRATION_RESIDUAL_MIN_ZATOSHI], no run) is
+     * deliberately NOT gated on [isFullySynced] — unlike the residue branch it only surfaces a CTA
+     * (no one-click transfer proposal reading stale notes), so the same mid-sync race isn't
+     * user-visible there. This pins that it still fires while mid-sync.
+     */
+    @Test
+    fun migrateNowBranchStillFiresWhileNotFullySynced() {
+        val result =
+            migrationMessageFor(
+                sdkState = null,
+                snapshot = null,
+                hasSeenComplete = false,
+                orchardBalanceZatoshi = MIGRATION_RESIDUAL_MIN_ZATOSHI + 1_000_000L,
+                isFullySynced = false,
+            )
+        assertEquals(MigrationHomeMessageData(isRunActive = false), result)
+    }
 }


### PR DESCRIPTION
## Summary
Follow-up to #2458. Neal reported (Slack, 2026-08-24) opening an already fully-swept (0 ZEC) wallet mid-sync and immediately seeing a bogus "X ZEC left in Orchard" residue popup; tapping "Migrate anyway" failed with "no Orchard input found for TXID...".

Root cause: `orchardBalanceZatoshi` (live synchronizer balance) and `migratableOrchardTotalZatoshi` (one-shot SQLite query) are two independent reads of the same, still-changing DB during active scanning, and can disagree window-to-window. The nominal Syncing-banner gate one layer up (`GetHomeMessageUseCase`) has a hole: `SYNCING_BANNER_HIDE_BELOW_BLOCKS` suppresses the Syncing banner near tip, and that `null` falls through straight to the migration message — so the residue branch could fire on stale mid-sync data.

Fix: thread a new `isFullySynced` flag (mirrors `HomeVM.isSyncComplete`) from `WalletSnapshotDataSource` into `migrationMessageFor()`, gating **only** the RESIDUE branch. Left ungated: the plain "Migrate now" branch (CTA only, no one-click proposal, same race isn't user-visible) and the celebration branch (out of scope).

Linear: https://linear.app/zodl/issue/MOB-1750/update-migration-complete-flow-to-provide-handling-for-sub-001-zec
Slack repro: https://zodl.slack.com/archives/C0B4F0CUWMC/p1787602444149159

## Test plan
- [x] `:zodl-android:feature-migration:compileZcashmainnetStoreDebugKotlin` compiles
- [x] `:zodl-android:ktlint` clean
- [x] `:zodl-android:detektAll` clean
- [x] `MigrationBannerStateTest` (existing + 3 new: residue suppressed while unsynced, residue fires once synced, "Migrate now" intentionally ungated) pass
- [x] `GetHomeMessageUseCaseMigrationTest` — unaffected, still passes
- [ ] Manual repro of Neal's mid-sync scenario on device/emulator