### PR TITLE
Release 3.10.1

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -210,6 +210,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0 # to fetch all commits
+      - name: Set up companion SDK build (if SDK_COMMIT_PIN is set)
+        timeout-minutes: 30
+        uses: ./.github/actions/setup-sdk-companion
       - name: Set up Java
         uses: ./.github/actions/setup-java
         timeout-minutes: 1
@@ -217,7 +220,10 @@ jobs:
         uses: ./.github/actions/setup-gradle
         timeout-minutes: 5
       - name: Test
-        timeout-minutes: 15
+        # 45 rather than the usual 15: when SDK_COMMIT_PIN is set (see
+        # setup-sdk-companion), compiling :ui-lib pulls in the full companion SDK's Rust
+        # dependency graph, which can take ~20-25 min alone on a cold cargo/target cache.
+        timeout-minutes: 45
         run: |
           ./gradlew :configuration-api-lib:check :crash-lib:check :preference-api-lib:check :spackle-lib:check :ui-design-lib:check
           ./gradlew :ui-lib:testZcashmainnetStoreDebugUnitTest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [3.10.1 (2512)] - 2026-08-25
+
+### Added:
+
+- We added a home screen banner and follow-up screen for a small amount of ZEC that can be left in Orchard after migrating to Ironwood, so you can choose whether to lock it or move it.
+
+### Fixed:
+
+- We fixed migrating with a Keystone wallet, so migrations are now split into signing rounds correctly.
+
 ### Fixed:
 
 - A temporary Android Keystore failure at startup is no longer mistaken for corrupted encrypted storage: the encrypted secret store is now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed:
 
+- The app-lock re-authentication timeout is now measured with a monotonic clock instead of the system wall clock, so it can no longer be
+  bypassed by changing the device's date and time.
 - We polished several UI details: the swap quote review header now stands out from the sheet background, the Activity header turns frosted
   sooner so it stays readable while you scroll, the Terms of Service icon matches the Privacy Policy one, and the Ironwood migration screens
   scroll properly on small displays.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed:
 
+- Requesting a swap quote you cannot afford now shows the Insufficient Funds sheet instead of the technical error screen. The balance is
+  re-checked right before the quote is requested, so a balance that dropped after you typed the amount is caught, and any remaining shortfall
+  found while building the transaction is now reported by the SDK as an insufficient-funds failure rather than a raw error.
 - We polished several UI details: the swap quote review header now stands out from the sheet background, the Activity header turns frosted
   sooner so it stays readable while you scroll, the Terms of Service icon matches the Privacy Policy one, and the Ironwood migration screens
   scroll properly on small displays.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed:
+
+- A temporary Android Keystore failure at startup is no longer mistaken for corrupted encrypted storage: the encrypted secret store is now
+  recreated only when its data is provably undecryptable (for example after a device-to-device transfer, which cannot move hardware-bound
+  keys), and any other failure keeps the stored data intact.
+
 ## [3.10.0 (2475)] - 2026-08-20
 
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Fixed:
 
-- Requesting a swap quote you cannot afford now shows the Insufficient Funds sheet instead of the technical error screen. The balance is
-  re-checked right before the quote is requested, so a balance that dropped after you typed the amount is caught, and any remaining shortfall
+- Requesting a swap quote you cannot afford now shows the Insufficient Funds sheet instead of the technical error screen. A shortfall
   found while building the transaction is now reported by the SDK as an insufficient-funds failure rather than a raw error.
 - The app-lock re-authentication timeout is now measured with a monotonic clock instead of the system wall clock, so it can no longer be
   bypassed by changing the device's date and time.

--- a/docs/whatsNew/WHATS_NEW_EN.md
+++ b/docs/whatsNew/WHATS_NEW_EN.md
@@ -14,6 +14,16 @@ directly impact users rather than highlighting other key architectural updates.*
 
 ## [Unreleased]
 
+## [3.10.1 (2512)] - 2026-08-25
+
+### Added:
+
+- We added a home screen banner and follow-up screen for a small amount of ZEC that can be left in Orchard after migrating to Ironwood, so you can choose whether to lock it or move it.
+
+### Fixed:
+
+- We fixed migrating with a Keystone wallet, so migrations are now split into signing rounds correctly.
+
 ## [3.10.0 (2475)] - 2026-08-20
 
 ### Added:

--- a/docs/whatsNew/WHATS_NEW_ES.md
+++ b/docs/whatsNew/WHATS_NEW_ES.md
@@ -14,6 +14,16 @@ directly impact users rather than highlighting other key architectural updates.*
 
 ## [Unreleased]
 
+## [3.10.1 (2512)] - 2026-08-25
+
+### Añadido:
+
+- Añadimos un banner en la pantalla de inicio y una pantalla de seguimiento para un pequeño monto de ZEC que puede quedar en Orchard después de migrar a Ironwood, para que decidas si bloquearlo o moverlo.
+
+### Corregido:
+
+- Corregimos la migración con una billetera Keystone: ahora las migraciones se dividen correctamente en rondas de firma.
+
 ## [3.10.0 (2475)] - 2026-08-20
 
 ### Añadido:

--- a/fastlane/metadata/android/en-US/changelogs/2512.txt
+++ b/fastlane/metadata/android/en-US/changelogs/2512.txt
@@ -1,0 +1,5 @@
+Added:
+- We added a home screen banner and follow-up screen for a small amount of ZEC that can be left in Orchard after migrating to Ironwood, so you can choose whether to lock it or move it.
+
+Fixed:
+- We fixed migrating with a Keystone wallet, so migrations are now split into signing rounds correctly.

--- a/fastlane/metadata/android/es/changelogs/2512.txt
+++ b/fastlane/metadata/android/es/changelogs/2512.txt
@@ -1,0 +1,5 @@
+Añadido:
+- Añadimos un banner en la pantalla de inicio y una pantalla de seguimiento para un pequeño monto de ZEC que puede quedar en Orchard después de migrar a Ironwood, para que decidas si bloquearlo o moverlo.
+
+Corregido:
+- Corregimos la migración con una billetera Keystone: ahora las migraciones se dividen correctamente en rondas de firma.

--- a/feature-migration/src/main/java/co/electriccoin/zcash/migration/FeatureMigrationImpls.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/migration/FeatureMigrationImpls.kt
@@ -249,7 +249,7 @@ class MigrationNavContributorImpl : MigrationNavContributor {
             composable<MigrationSendingArgs> { MigrationSendingScreen() }
             composable<MigrationSuccessArgs> { MigrationSuccessScreen(it.toRoute()) }
             composable<MigrationScheduledArgs> { MigrationScheduledScreen() }
-            composable<MigrationCompleteArgs> { MigrationCompleteScreen() }
+            composable<MigrationCompleteArgs> { MigrationCompleteScreen(it.toRoute()) }
             composable<MigrationProgressArgs> { MigrationProgressScreen() }
             composable<MigrationTransferInvalidArgs> { MigrationTransferInvalidScreen() }
             composable<MigrationRestartArgs> { MigrationRestartScreen() }

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/repository/MigrationHomeMessageData.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/repository/MigrationHomeMessageData.kt
@@ -25,4 +25,12 @@ data class MigrationHomeMessageData(
     // generic message again. attentionRangeText is only meaningful for TRANSFER_EXPIRED.
     val attentionKind: MigrationAttentionKind? = null,
     val attentionRangeText: String? = null,
+    // MOB-1750: true when this Complete banner comes from the RESIDUE branch (a small leftover
+    // Orchard balance not tied to an unseen in-app migration celebration) rather than the one-time
+    // post-migration celebration — drives both the home banner's "X ZEC left in Orchard" copy and
+    // MigrationCompleteScreen's reduced summary card (no Transfers/Duration rows).
+    val isResidueOnly: Boolean = false,
+    // The live Orchard balance at decision time. Only meaningful when [isResidueOnly] is true — the
+    // home banner needs the amount for its title; the celebration branch's copy is static.
+    val residualBalanceZatoshi: Long = 0L,
 ) : MigrationHomeMessage()

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
@@ -41,6 +41,14 @@ import co.electriccoin.zcash.ui.design.R as DesignR
 
 private const val PERCENT_MULTIPLIER = 100
 
+/** The banner phase + title/subtitle override for one [MigrationMessageState] — replaces an
+ * anonymous [Triple] so each field is named at the call site instead of positional. */
+private data class BannerCopy(
+    val phase: MigrationBannerPhase,
+    val title: String?,
+    val subtitle: String?,
+)
+
 /**
  * The home-banner source, fully LIVE off the engine — no plan cache anywhere (see
  * `spec/2026-07-30-plan-cache-elimination-proposal.md`): counts come from the engine's transfer
@@ -137,18 +145,18 @@ class MigrationHomeMessageSourceImpl(
             }
         // Spec §6.2/§6.3 — takes priority over the ordinary phases below: a plan needing
         // re-confirmation is more actionable than its last-known progress/completion state.
-        val (phase, title, subtitle) =
+        val bannerCopy =
             when (data.attentionKind) {
                 MigrationAttentionKind.PLAN_UPDATE -> {
-                    Triple(MigrationBannerPhase.ATTENTION, "Update migration plan", "Tap to review the details")
+                    BannerCopy(MigrationBannerPhase.ATTENTION, "Update migration plan", "Tap to review the details")
                 }
 
                 MigrationAttentionKind.TRANSFER_EXPIRED -> {
                     val range = data.attentionRangeText
-                    Triple(
-                        MigrationBannerPhase.ATTENTION,
-                        if (range != null) "Transfer $range expired" else "A transfer expired",
-                        "Tap to review the details",
+                    BannerCopy(
+                        phase = MigrationBannerPhase.ATTENTION,
+                        title = if (range != null) "Transfer $range expired" else "A transfer expired",
+                        subtitle = "Tap to review the details",
                     )
                 }
 
@@ -159,29 +167,29 @@ class MigrationHomeMessageSourceImpl(
                         // the "Migration complete" celebration title.
                         data.isComplete && data.isResidueOnly -> {
                             val amount = stringRes(Zatoshi(data.residualBalanceZatoshi)).getString(context)
-                            Triple(
-                                MigrationBannerPhase.COMPLETE,
-                                stringRes(DesignR.string.migrationHome_residueTitle, amount).getString(context),
-                                stringRes(DesignR.string.migrationHome_residueSubtitle).getString(context),
+                            BannerCopy(
+                                phase = MigrationBannerPhase.COMPLETE,
+                                title = stringRes(DesignR.string.migrationHome_residueTitle, amount).getString(context),
+                                subtitle = stringRes(DesignR.string.migrationHome_residueSubtitle).getString(context),
                             )
                         }
 
                         data.isComplete -> {
-                            Triple(MigrationBannerPhase.COMPLETE, null, "Tap to review the details")
+                            BannerCopy(MigrationBannerPhase.COMPLETE, null, "Tap to review the details")
                         }
 
                         // Spec §6.4: numbered per the due transfer, matching the convention used
                         // elsewhere (e.g. Progress's "Transfer ${completedCount + 1}").
                         data.isReadyToSend -> {
-                            Triple(
-                                MigrationBannerPhase.READY_TO_SEND,
-                                null,
-                                "Transfer ${data.completedCount + 1} is ready to send",
+                            BannerCopy(
+                                phase = MigrationBannerPhase.READY_TO_SEND,
+                                title = null,
+                                subtitle = "Transfer ${data.completedCount + 1} is ready to send",
                             )
                         }
 
                         !data.isRunActive -> {
-                            Triple(MigrationBannerPhase.REQUIRED, null, null)
+                            BannerCopy(MigrationBannerPhase.REQUIRED, null, null)
                         }
 
                         // MOB-1620: always the numeric count, including the 0-of-N case right
@@ -189,20 +197,21 @@ class MigrationHomeMessageSourceImpl(
                         // sending…" copy read as vaguer/stuck to Harry, and 0-based counts render
                         // fine ("0 of 5 transfers done ~0% complete").
                         else -> {
-                            Triple(
-                                MigrationBannerPhase.IN_PROGRESS,
-                                null,
-                                "${data.completedCount} of ${data.totalCount} transfers done" +
-                                    " ~ $percent% complete",
+                            BannerCopy(
+                                phase = MigrationBannerPhase.IN_PROGRESS,
+                                title = null,
+                                subtitle =
+                                    "${data.completedCount} of ${data.totalCount} transfers done" +
+                                        " ~ $percent% complete",
                             )
                         }
                     }
                 }
             }
         return MigrationMessageState(
-            phase = phase,
-            title = title,
-            progressLabel = subtitle,
+            phase = bannerCopy.phase,
+            title = bannerCopy.title,
+            progressLabel = bannerCopy.subtitle,
             progressPercent = percent.toFloat(),
             onClick = {
                 onMigrationMessageClick(

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
@@ -121,11 +121,21 @@ class MigrationHomeMessageSourceImpl(
                 val dustThreshold =
                     runCatching { getOrchardMigrationSdk().migrationDustThresholdZatoshi() }
                         .getOrDefault(MIGRATION_DUST_THRESHOLD_ZATOSHI)
+                // Kris Nuttycombe's per-note dust total (Slack, MOB-1750 follow-up): sum of each
+                // spendable Orchard note's value net of MARGINAL_FEE, not the raw aggregate
+                // balance — a wallet can hold a raw balance above dustThreshold made up entirely
+                // of notes too small individually to be worth spending. Falls back to the raw
+                // balance (old behavior) if the SDK call fails, same guard shape as dustThreshold.
+                val orchardBalanceZatoshi = orchardBalance?.value ?: 0L
+                val migratableOrchardTotal =
+                    runCatching { getOrchardMigrationSdk().migratableOrchardTotal() }
+                        .getOrDefault(orchardBalanceZatoshi)
                 migrationMessageFor(
                     sdkState = sdkState,
                     snapshot = snapshot,
                     hasSeenComplete = hasSeenComplete,
-                    orchardBalanceZatoshi = orchardBalance?.value ?: 0L,
+                    orchardBalanceZatoshi = orchardBalanceZatoshi,
+                    migratableOrchardTotalZatoshi = migratableOrchardTotal,
                     dustThresholdZatoshi = dustThreshold,
                     isBackgroundExecutionAvailable = isBackgroundExecutionAvailableProvider.isAvailable(),
                     hasOverdueTransfers = readout?.hasOverdueTransfers ?: false,
@@ -286,12 +296,21 @@ class MigrationHomeMessageSourceImpl(
  *
  * - round running                → engine InProgress (counts from [snapshot])
  * - celebration (campaign done)  → engine Complete && balance < RESIDUAL_MIN && !hasSeenComplete
- * - residue (lock/migrate-anyway)→ dust < balance < RESIDUAL_MIN && not running
+ * - residue (lock/migrate-anyway)→ migratable total > dust threshold && balance < RESIDUAL_MIN &&
+ *                                   not running
  * - next round / never migrated  → balance ≥ RESIDUAL_MIN && not running → "Migrate now"
  *
  * The "Complete && balance ≥ min ⇒ Migrate now" mapping is deliberately identical whether the
  * balance is a next Keystone round's residual or newly received funds — both need a migration, so
  * the ambiguity the old cleared-plan marker guarded against does not exist.
+ *
+ * The residue branch's lower bound is gated on [migratableOrchardTotalZatoshi] — Kris
+ * Nuttycombe's per-note total (sum of each spendable note's value net of MARGINAL_FEE, over notes
+ * whose value exceeds MARGINAL_FEE), not the raw [orchardBalanceZatoshi] — a raw balance can sit
+ * above [dustThresholdZatoshi] while being made up entirely of notes too small individually to be
+ * worth spending. The displayed amount ([MigrationHomeMessageData.residualBalanceZatoshi]) still
+ * uses the raw balance — the user's real, current Orchard balance — only the "is this worth
+ * prompting about" gate uses the net-of-fee total.
  */
 @Suppress("CyclomaticComplexMethod")
 internal fun migrationMessageFor(
@@ -299,6 +318,7 @@ internal fun migrationMessageFor(
     snapshot: LiveMigrationSnapshot?,
     hasSeenComplete: Boolean,
     orchardBalanceZatoshi: Long,
+    migratableOrchardTotalZatoshi: Long = orchardBalanceZatoshi,
     dustThresholdZatoshi: Long = MIGRATION_DUST_THRESHOLD_ZATOSHI,
     isBackgroundExecutionAvailable: Boolean = true,
     hasOverdueTransfers: Boolean = false,
@@ -386,8 +406,10 @@ internal fun migrationMessageFor(
         // as "migration completed" and route to MigrationCompleteScreen, whose residue flow lets
         // the user LOCK it or MIGRATE it anyway. The reported balance is the *spendable* Orchard
         // balance (locked notes excluded), so locking makes this stop firing on its own.
+        // Lower bound uses migratableOrchardTotalZatoshi (per-note, net of MARGINAL_FEE), not the
+        // raw balance — see the function doc.
         !midRunAttention &&
-            orchardBalanceZatoshi > dustThresholdZatoshi &&
+            migratableOrchardTotalZatoshi > dustThresholdZatoshi &&
             orchardBalanceZatoshi < MIGRATION_RESIDUAL_MIN_ZATOSHI -> {
             MigrationHomeMessageData(
                 isRunActive = false,

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
@@ -1,8 +1,10 @@
 package co.electriccoin.zcash.ui.common.usecase
 
+import android.content.Context
 import cash.z.ecc.android.sdk.AttentionReason
 import cash.z.ecc.android.sdk.MigrationBlocker
 import cash.z.ecc.android.sdk.MigrationState
+import cash.z.ecc.android.sdk.model.Zatoshi
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.migration.MigrationHomeMessageSource
@@ -19,6 +21,8 @@ import co.electriccoin.zcash.ui.common.provider.HasSeenMigrationCompleteStorageP
 import co.electriccoin.zcash.ui.common.provider.IsBackgroundExecutionAvailableProvider
 import co.electriccoin.zcash.ui.common.repository.MigrationHomeMessage
 import co.electriccoin.zcash.ui.common.repository.MigrationHomeMessageData
+import co.electriccoin.zcash.ui.design.util.getString
+import co.electriccoin.zcash.ui.design.util.stringRes
 import co.electriccoin.zcash.ui.screen.home.HomeMessageState
 import co.electriccoin.zcash.ui.screen.home.migration.MigrationBannerPhase
 import co.electriccoin.zcash.ui.screen.home.migration.MigrationMessageState
@@ -33,6 +37,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlin.time.Clock
 import kotlin.time.Instant
+import co.electriccoin.zcash.ui.design.R as DesignR
 
 private const val PERCENT_MULTIPLIER = 100
 
@@ -43,6 +48,7 @@ private const val PERCENT_MULTIPLIER = 100
  * live Orchard balance. The only persisted inputs are genuine UX flags (hasSeenComplete).
  */
 class MigrationHomeMessageSourceImpl(
+    private val context: Context,
     private val accountDataSource: AccountDataSource,
     private val getOrchardMigrationSdk: GetOrchardMigrationSdkUseCase,
     private val observeMigrationLiveReadout: ObserveMigrationLiveReadoutUseCase,
@@ -148,6 +154,18 @@ class MigrationHomeMessageSourceImpl(
 
                 null -> {
                     when {
+                        // MOB-1750: a small leftover Orchard balance not tied to an unseen in-app
+                        // migration celebration gets its own "X ZEC left in Orchard" copy instead of
+                        // the "Migration complete" celebration title.
+                        data.isComplete && data.isResidueOnly -> {
+                            val amount = stringRes(Zatoshi(data.residualBalanceZatoshi)).getString(context)
+                            Triple(
+                                MigrationBannerPhase.COMPLETE,
+                                stringRes(DesignR.string.migrationHome_residueTitle, amount).getString(context),
+                                stringRes(DesignR.string.migrationHome_residueSubtitle).getString(context),
+                            )
+                        }
+
                         data.isComplete -> {
                             Triple(MigrationBannerPhase.COMPLETE, null, "Tap to review the details")
                         }
@@ -192,6 +210,7 @@ class MigrationHomeMessageSourceImpl(
                     isComplete = data.isComplete,
                     isReadyToSend = data.isReadyToSend,
                     hasAttention = data.attentionKind != null,
+                    isResidueOnly = data.isResidueOnly,
                 )
             },
             onButtonClick = {
@@ -200,6 +219,7 @@ class MigrationHomeMessageSourceImpl(
                     isComplete = data.isComplete,
                     isReadyToSend = data.isReadyToSend,
                     hasAttention = data.attentionKind != null,
+                    isResidueOnly = data.isResidueOnly,
                 )
             },
         )
@@ -210,6 +230,7 @@ class MigrationHomeMessageSourceImpl(
         isComplete: Boolean,
         isReadyToSend: Boolean = false,
         hasAttention: Boolean = false,
+        isResidueOnly: Boolean = false,
     ) {
         when {
             // A plan needing re-confirmation (spec §6.2/§6.3) always routes to the Transfer Invalid
@@ -217,8 +238,9 @@ class MigrationHomeMessageSourceImpl(
             hasAttention -> navigationRouter.forward(MigrationTransferInvalidArgs)
 
             // Tapping the widget just opens the celebration screen — MigrationCompleteVM.onDone()
-            // owns the seen-flag decision.
-            isComplete -> navigationRouter.forward(MigrationCompleteArgs)
+            // owns the seen-flag decision. MOB-1750: isResidueOnly threads which copy/summary
+            // variant MigrationCompleteScreen should render.
+            isComplete -> navigationRouter.forward(MigrationCompleteArgs(isResidueOnly = isResidueOnly))
 
             // Ready-to-send routes to Progress too — everything is pre-signed, there is nothing
             // to review; Progress's foreground broadcast loop executes the step silently while
@@ -358,7 +380,12 @@ internal fun migrationMessageFor(
         !midRunAttention &&
             orchardBalanceZatoshi > dustThresholdZatoshi &&
             orchardBalanceZatoshi < MIGRATION_RESIDUAL_MIN_ZATOSHI -> {
-            MigrationHomeMessageData(isRunActive = false, isComplete = true)
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = orchardBalanceZatoshi,
+            )
         }
 
         // Migratable balance with no run in progress — covers "never migrated", "a Keystone round

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import cash.z.ecc.android.sdk.AttentionReason
 import cash.z.ecc.android.sdk.MigrationBlocker
 import cash.z.ecc.android.sdk.MigrationState
+import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.model.Zatoshi
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
+import co.electriccoin.zcash.ui.common.datasource.WalletSnapshotDataSource
 import co.electriccoin.zcash.ui.common.migration.MigrationHomeMessageSource
 import co.electriccoin.zcash.ui.common.model.migration.LiveMigrationSnapshot
 import co.electriccoin.zcash.ui.common.model.migration.MIGRATION_DUST_THRESHOLD_ZATOSHI
@@ -61,6 +63,7 @@ class MigrationHomeMessageSourceImpl(
     private val getOrchardMigrationSdk: GetOrchardMigrationSdkUseCase,
     private val observeMigrationLiveReadout: ObserveMigrationLiveReadoutUseCase,
     private val getOrchardBalance: GetOrchardBalanceUseCase,
+    private val walletSnapshotDataSource: WalletSnapshotDataSource,
     private val hasSeenMigrationCompleteStorageProvider: HasSeenMigrationCompleteStorageProvider,
     private val isBackgroundExecutionAvailableProvider: IsBackgroundExecutionAvailableProvider,
     private val navigationRouter: NavigationRouter,
@@ -84,7 +87,14 @@ class MigrationHomeMessageSourceImpl(
                 // never touches the engine) the balance is the only input that can hide the
                 // "Migrate required" banner once the Orchard funds are spent.
                 getOrchardBalance.observe(),
-            ) { hasSeenComplete, readout, orchardBalance ->
+                // Mirrors HomeVM's isSyncComplete (iOS: SmartBannerStore.isSyncComplete) — the
+                // RESIDUE branch below reads a live balance/migratable-total pair that can
+                // disagree with each other mid-sync (two different queries against the same,
+                // still-changing DB), so it must not fire until the wallet has caught up with
+                // the chain tip. See MOB-1750 mid-sync race investigation.
+                walletSnapshotDataSource.observe(),
+            ) { hasSeenComplete, readout, orchardBalance, walletSnapshot ->
+                val isFullySynced = walletSnapshot?.status == Synchronizer.Status.SYNCED
                 val sdkState = readout?.migrationState
                 val states = readout?.states
                 val snapshot =
@@ -137,6 +147,7 @@ class MigrationHomeMessageSourceImpl(
                     orchardBalanceZatoshi = orchardBalanceZatoshi,
                     migratableOrchardTotalZatoshi = migratableOrchardTotal,
                     dustThresholdZatoshi = dustThreshold,
+                    isFullySynced = isFullySynced,
                     isBackgroundExecutionAvailable = isBackgroundExecutionAvailableProvider.isAvailable(),
                     hasOverdueTransfers = readout?.hasOverdueTransfers ?: false,
                     attentionKind = attentionKind,
@@ -311,6 +322,14 @@ class MigrationHomeMessageSourceImpl(
  * worth spending. The displayed amount ([MigrationHomeMessageData.residualBalanceZatoshi]) still
  * uses the raw balance — the user's real, current Orchard balance — only the "is this worth
  * prompting about" gate uses the net-of-fee total.
+ *
+ * The residue branch is additionally gated on [isFullySynced]: [orchardBalanceZatoshi] and
+ * [migratableOrchardTotalZatoshi] are two independent reads of the same, still-changing DB while
+ * the wallet is mid-sync, and can disagree window-to-window — firing the residue prompt on that
+ * stale pair produced a bogus balance and a "Migrate anyway" that failed with "no Orchard input
+ * found" once the notes it referenced had moved on. Not applied to the other branches above: the
+ * celebration branch is explicitly out of scope for this fix, and the plain "Migrate now" branch
+ * only shows a CTA (no one-click transfer proposal) so the same race isn't user-visible there.
  */
 @Suppress("CyclomaticComplexMethod")
 internal fun migrationMessageFor(
@@ -320,6 +339,7 @@ internal fun migrationMessageFor(
     orchardBalanceZatoshi: Long,
     migratableOrchardTotalZatoshi: Long = orchardBalanceZatoshi,
     dustThresholdZatoshi: Long = MIGRATION_DUST_THRESHOLD_ZATOSHI,
+    isFullySynced: Boolean = true,
     isBackgroundExecutionAvailable: Boolean = true,
     hasOverdueTransfers: Boolean = false,
     now: Instant = Clock.System.now(),
@@ -407,8 +427,15 @@ internal fun migrationMessageFor(
         // the user LOCK it or MIGRATE it anyway. The reported balance is the *spendable* Orchard
         // balance (locked notes excluded), so locking makes this stop firing on its own.
         // Lower bound uses migratableOrchardTotalZatoshi (per-note, net of MARGINAL_FEE), not the
-        // raw balance — see the function doc.
+        // raw balance — see the function doc. Gated on isFullySynced: orchardBalanceZatoshi (live
+        // synchronizer balance) and migratableOrchardTotalZatoshi (one-shot SQLite query) can
+        // disagree with each other while the wallet is still catching up to the chain tip — both
+        // read the same DB but at different consistency points during active scanning. Firing this
+        // branch on stale/mid-sync data showed a bogus "X ZEC left in Orchard" popup and let
+        // "Migrate anyway" propose a transfer against notes that no longer existed by the time the
+        // proposal ran (Slack repro, 2026-08-24).
         !midRunAttention &&
+            isFullySynced &&
             migratableOrchardTotalZatoshi > dustThresholdZatoshi &&
             orchardBalanceZatoshi < MIGRATION_RESIDUAL_MIN_ZATOSHI -> {
             MigrationHomeMessageData(

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteScreen.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteScreen.kt
@@ -55,6 +55,7 @@ import co.electriccoin.zcash.ui.screen.common.PrivacyDisclaimerCard
 import co.electriccoin.zcash.ui.screen.migration.component.MigrationFailureBottomSheet
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
+import org.koin.core.parameter.parametersOf
 import co.electriccoin.zcash.ui.design.R as DesignR
 
 data class MigrationCompleteState(
@@ -70,14 +71,20 @@ data class MigrationCompleteState(
     val isMigrating: Boolean = false,
     val isLocking: Boolean = false,
     val failureSheet: co.electriccoin.zcash.ui.common.model.migration.MigrationTransferFailureState? = null,
+    // MOB-1750: true for a small leftover Orchard balance not tied to an unseen in-app migration
+    // celebration ("You've moved to Ironwood" copy, no Transfers/Duration rows) — false for the
+    // original post-migration celebration variant ("Migration Complete"), unchanged.
+    val isResidueOnly: Boolean = false,
 )
 
 @Serializable
-data object MigrationCompleteArgs
+data class MigrationCompleteArgs(
+    val isResidueOnly: Boolean = false
+)
 
 @Composable
-fun MigrationCompleteScreen() {
-    val vm = koinViewModel<MigrationCompleteVM>()
+fun MigrationCompleteScreen(args: MigrationCompleteArgs) {
+    val vm = koinViewModel<MigrationCompleteVM> { parametersOf(args) }
     val state by vm.state.collectAsStateWithLifecycle()
     LceRenderer(
         state = state,
@@ -141,7 +148,14 @@ fun MigrationCompleteView(state: MigrationCompleteState) {
                 )
                 Spacer(Modifier.height(24.dp))
                 Text(
-                    text = stringRes(DesignR.string.migrationComplete_title).getValue(),
+                    text =
+                        stringRes(
+                            if (state.isResidueOnly) {
+                                DesignR.string.migrationComplete_residueTitle
+                            } else {
+                                DesignR.string.migrationComplete_title
+                            }
+                        ).getValue(),
                     style = ZashiTypography.header5,
                     fontWeight = FontWeight.SemiBold,
                     color = ZashiColors.Text.textPrimary,
@@ -149,40 +163,20 @@ fun MigrationCompleteView(state: MigrationCompleteState) {
                 )
                 Spacer(Modifier.height(4.dp))
                 Text(
-                    text = stringRes(DesignR.string.migrationComplete_subtitle).getValue(),
+                    text =
+                        stringRes(
+                            if (state.isResidueOnly) {
+                                DesignR.string.migrationComplete_residueSubtitle
+                            } else {
+                                DesignR.string.migrationComplete_subtitle
+                            }
+                        ).getValue(),
                     style = ZashiTypography.textSm,
                     color = ZashiColors.Text.textTertiary,
                     textAlign = TextAlign.Center,
                 )
                 Spacer(Modifier.height(24.dp))
-                Column(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(16.dp))
-                            .background(ZashiColors.Surfaces.bgSecondary)
-                            .padding(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(10.dp),
-                ) {
-                    SummaryRow(
-                        label = stringRes(DesignR.string.migrationComplete_totalTransferredLabel).getValue(),
-                        value = state.totalTransferred.getValue(),
-                    )
-                    state.remainingDust?.let { dust ->
-                        SummaryRow(
-                            label = stringRes(DesignR.string.migrationComplete_remainingDustLabel).getValue(),
-                            value = dust.getValue(),
-                        )
-                    }
-                    SummaryRow(
-                        label = stringRes(DesignR.string.migrationComplete_transfersLabel).getValue(),
-                        value = state.transfersProgress.getValue(),
-                    )
-                    SummaryRow(
-                        label = stringRes(DesignR.string.migrationComplete_durationLabel).getValue(),
-                        value = state.duration.getValue(),
-                    )
-                }
+                SummaryCard(state)
                 Spacer(Modifier.weight(1f))
                 when {
                     state.remainingDust == null -> {
@@ -216,7 +210,11 @@ fun MigrationCompleteView(state: MigrationCompleteState) {
                             title = stringRes(DesignR.string.migrationComplete_orchardBalanceRemainingTitle).getValue(),
                             body =
                                 stringRes(
-                                    DesignR.string.migrationComplete_orchardBalanceRemainingBody,
+                                    if (state.isResidueOnly) {
+                                        DesignR.string.migrationComplete_residueRecommendationBody
+                                    } else {
+                                        DesignR.string.migrationComplete_orchardBalanceRemainingBody
+                                    },
                                     state.remainingDust.getValue()
                                 ).getValue(),
                         )
@@ -267,6 +265,54 @@ fun MigrationCompleteView(state: MigrationCompleteState) {
         }
     }
     MigrationFailureBottomSheet(state.failureSheet)
+}
+
+@Composable
+private fun SummaryCard(state: MigrationCompleteState) {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+                .background(ZashiColors.Surfaces.bgSecondary)
+                .padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        if (state.isResidueOnly) {
+            // MOB-1750: reduced summary — no Transfers/Duration rows, since a residue not tied
+            // to an unseen in-app celebration has no round-trip campaign to report on (whether
+            // it's genuinely 0 sent-in-app, or an already-seen completion's leftover residue).
+            SummaryRow(
+                label = stringRes(DesignR.string.migrationComplete_inIronwoodLabel).getValue(),
+                value = state.totalTransferred.getValue(),
+            )
+            state.remainingDust?.let { dust ->
+                SummaryRow(
+                    label = stringRes(DesignR.string.migrationComplete_leftInOrchardLabel).getValue(),
+                    value = dust.getValue(),
+                )
+            }
+        } else {
+            SummaryRow(
+                label = stringRes(DesignR.string.migrationComplete_totalTransferredLabel).getValue(),
+                value = state.totalTransferred.getValue(),
+            )
+            state.remainingDust?.let { dust ->
+                SummaryRow(
+                    label = stringRes(DesignR.string.migrationComplete_remainingDustLabel).getValue(),
+                    value = dust.getValue(),
+                )
+            }
+            SummaryRow(
+                label = stringRes(DesignR.string.migrationComplete_transfersLabel).getValue(),
+                value = state.transfersProgress.getValue(),
+            )
+            SummaryRow(
+                label = stringRes(DesignR.string.migrationComplete_durationLabel).getValue(),
+                value = state.duration.getValue(),
+            )
+        }
+    }
 }
 
 @Composable
@@ -376,6 +422,27 @@ private fun PreviewNoDust() =
                     isDustLocked = false,
                     transfersProgress = stringRes("5 of 5 sent"),
                     duration = stringRes("~24 hours"),
+                    onDone = {},
+                    onMigrateAnyway = {},
+                    onLockBalance = {},
+                    onHelp = {},
+                )
+        )
+    }
+
+@PreviewScreens
+@Composable
+private fun PreviewResidueOnly() =
+    ZcashTheme {
+        MigrationCompleteView(
+            state =
+                MigrationCompleteState(
+                    totalTransferred = stringRes("12.45 ZEC"),
+                    remainingDust = stringRes("0.008 ZEC"),
+                    isDustLocked = false,
+                    transfersProgress = stringRes("0 of 0 sent"),
+                    duration = stringRes("~0 hours"),
+                    isResidueOnly = true,
                     onDone = {},
                     onMigrateAnyway = {},
                     onLockBalance = {},

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVM.kt
@@ -29,6 +29,7 @@ import co.electriccoin.zcash.ui.common.repository.BiometricsCancelledException
 import co.electriccoin.zcash.ui.common.repository.BiometricsFailureException
 import co.electriccoin.zcash.ui.common.repository.KeystoneProposalRepository
 import co.electriccoin.zcash.ui.common.usecase.ErrorMapperUseCase
+import co.electriccoin.zcash.ui.common.usecase.GetIronwoodBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardMigrationSdkUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetSelectedWalletAccountUseCase
@@ -50,6 +51,7 @@ import co.electriccoin.zcash.ui.design.R as DesignR
 class MigrationCompleteVM(
     private val args: MigrationCompleteArgs,
     private val getOrchardBalance: GetOrchardBalanceUseCase,
+    private val getIronwoodBalance: GetIronwoodBalanceUseCase,
     private val hasSeenMigrationCompleteStorageProvider: HasSeenMigrationCompleteStorageProvider,
     private val hasLockedOrchardDustStorageProvider: HasLockedOrchardDustStorageProvider,
     private val getSelectedWalletAccount: GetSelectedWalletAccountUseCase,
@@ -95,22 +97,41 @@ class MigrationCompleteVM(
 
     init {
         loadLce.execute {
-            // Read the REAL migration summary (amount migrated, transfer count, duration) from the
-            // ENGINE's persisted migration data — the single source of truth that survives
-            // completion. The app-side plan is cleared once migration finishes, so it can no longer
-            // supply these (it would read 0.000 ZEC / 0 of 0). Null-safe: a missing summary
-            // falls back to zeros.
-            val summary = getOrchardMigrationSdk().getMigrationSummary()
-            // Whatever's still in the real Orchard balance once every transfer has sent is the
-            // dust/residual left behind (below the migratable threshold, or an un-migrated
-            // opt-in residual — either way, it's what's actually still sitting in Orchard).
-            Summary(
-                totalTransferred = summary?.totalMigratedZatoshi ?: 0L,
-                totalCount = summary?.transferCount ?: 0,
-                firstAt = summary?.firstMinedEpochSeconds ?: 0L,
-                lastAt = summary?.lastMinedEpochSeconds ?: 0L,
-                dustZatoshi = getOrchardBalance().value,
-            )
+            // MOB-1750: the residue variant's "In Ironwood" row is the live Ironwood pool
+            // balance (GetIronwoodBalanceUseCase, same source GetBalancePoolsUseCase's Balance
+            // Breakdown sheet already uses) rather than the migration engine's own campaign-
+            // scoped bookkeeping — and the view never shows totalCount/duration for this variant
+            // (SummaryCard's residue branch omits those rows), so there's nothing to gain from
+            // reading getMigrationSummary() here at all. That engine summary can genuinely have
+            // no rows for this account (e.g. after a debug migration restart, or a residue not
+            // tied to any in-app-run campaign at all) even though the wallet's real Ironwood
+            // balance is very much nonzero — reading it here would show a misleading
+            // "0.000 ZEC" next to real prior "Migrated" activity.
+            if (args.isResidueOnly) {
+                Summary(
+                    totalTransferred = getIronwoodBalance().value,
+                    totalCount = 0,
+                    firstAt = 0L,
+                    lastAt = 0L,
+                    dustZatoshi = getOrchardBalance().value,
+                )
+            } else {
+                // Read the REAL migration summary (amount migrated, transfer count, duration)
+                // from the ENGINE's persisted migration data — the single source of truth that
+                // survives completion. The app-side plan is cleared once migration finishes, so
+                // it can no longer supply these (it would read 0.000 ZEC / 0 of 0). Null-safe: a
+                // missing summary falls back to zeros. "Total transferred" here is deliberately
+                // about *this specific completed campaign*, not the account's current Ironwood
+                // total (see the residue branch above for that).
+                val summary = getOrchardMigrationSdk().getMigrationSummary()
+                Summary(
+                    totalTransferred = summary?.totalMigratedZatoshi ?: 0L,
+                    totalCount = summary?.transferCount ?: 0,
+                    firstAt = summary?.firstMinedEpochSeconds ?: 0L,
+                    lastAt = summary?.lastMinedEpochSeconds ?: 0L,
+                    dustZatoshi = getOrchardBalance().value,
+                )
+            }
         }
         // Cancel the background chain and clear any leftover notification as soon as THIS screen
         // is shown, not deferred until the user taps "Got it" (the previous behavior — onDone()

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVM.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.withContext
 import co.electriccoin.zcash.ui.design.R as DesignR
 
 class MigrationCompleteVM(
+    private val args: MigrationCompleteArgs,
     private val getOrchardBalance: GetOrchardBalanceUseCase,
     private val hasSeenMigrationCompleteStorageProvider: HasSeenMigrationCompleteStorageProvider,
     private val hasLockedOrchardDustStorageProvider: HasLockedOrchardDustStorageProvider,
@@ -170,6 +171,7 @@ class MigrationCompleteVM(
                 ),
             isMigrating = isMigrating,
             isLocking = isLocking,
+            isResidueOnly = args.isResidueOnly,
             onDone = ::onDone,
             onMigrateAnyway = { migrateAnywayLce.guardLoading(::onMigrateAnyway) },
             onLockBalance = { lockLce.guardLoading(::onLockBalance) },

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/sending/MigrationSendingVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/sending/MigrationSendingVM.kt
@@ -170,7 +170,7 @@ class MigrationSendingVM(
                             // This was the plan's last transfer — one Migration Complete screen covers
                             // both this (foreground, just confirmed) and the background-completion case
                             // (CheckMigrationRecoveryUseCase, on next app open), rather than two.
-                            navigationRouter.forward(MigrationCompleteArgs)
+                            navigationRouter.forward(MigrationCompleteArgs())
                         } else {
                             navigationRouter.forward(MigrationSuccessArgs(r.txId.txIdString()))
                         }

--- a/feature-migration/src/test/java/co/electriccoin/zcash/di/MigrationKoinGraphSmokeTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/di/MigrationKoinGraphSmokeTest.kt
@@ -52,6 +52,7 @@ import co.electriccoin.zcash.ui.common.repository.ZashiProposalRepository
 import co.electriccoin.zcash.ui.common.usecase.ErrorMapperUseCase
 import co.electriccoin.zcash.ui.common.usecase.FinalizeMigrationScheduleUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetBalancePoolsUseCase
+import co.electriccoin.zcash.ui.common.usecase.GetIronwoodBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetMigrationPrivacyOrReviewDestinationUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardMigrationSdkUseCase
@@ -126,6 +127,7 @@ class MigrationKoinGraphSmokeTest {
                 factory { mockk<GetOrchardMigrationSdkUseCase>(relaxed = true) }
                 factory { mockk<GetSelectedWalletAccountUseCase>(relaxed = true) }
                 factory { mockk<GetOrchardBalanceUseCase>(relaxed = true) }
+                factory { mockk<GetIronwoodBalanceUseCase>(relaxed = true) }
                 factory { mockk<GetBalancePoolsUseCase>(relaxed = true) }
                 factory { mockk<LockOrchardBalanceUseCase>(relaxed = true) }
                 factory { mockk<FinalizeMigrationScheduleUseCase>(relaxed = true) }

--- a/feature-migration/src/test/java/co/electriccoin/zcash/di/MigrationKoinGraphSmokeTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/di/MigrationKoinGraphSmokeTest.kt
@@ -61,6 +61,7 @@ import co.electriccoin.zcash.ui.common.usecase.ScheduleNextMigrationWindowUseCas
 import co.electriccoin.zcash.ui.common.usecase.SubmitProposalUseCase
 import co.electriccoin.zcash.ui.common.usecase.ViewTransactionDetailAfterSuccessfulProposalUseCase
 import co.electriccoin.zcash.ui.screen.migration.battery.MigrationBatteryVM
+import co.electriccoin.zcash.ui.screen.migration.complete.MigrationCompleteArgs
 import co.electriccoin.zcash.ui.screen.migration.complete.MigrationCompleteVM
 import co.electriccoin.zcash.ui.screen.migration.customservertor.MigrationCustomServerTorArgs
 import co.electriccoin.zcash.ui.screen.migration.customservertor.MigrationCustomServerTorVM
@@ -169,6 +170,7 @@ class MigrationKoinGraphSmokeTest {
                 factory { MigrationPrivacyArgs(mode = MigrationMode.AUTOMATIC) }
                 factory { MigrationReviewArgs(mode = MigrationMode.AUTOMATIC) }
                 factory { MigrationSuccessArgs(txId = null) }
+                factory { MigrationCompleteArgs() }
             }
 
         koin =

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/model/migration/sim/FakeOrchardMigrationSdk.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/model/migration/sim/FakeOrchardMigrationSdk.kt
@@ -90,8 +90,8 @@ class FakeOrchardMigrationSdk : OrchardMigrationSdk {
     /** Seconds-per-block the harness reports; testnet-fast by default to match live tuning. */
     var secondsPerBlock: Long = 28L
 
-    /** Dust threshold — the fixed protocol constant (0.001 ZEC). */
-    var dustThresholdZatoshi: Long = 100_000L
+    /** Dust threshold — the fixed protocol constant (0.0001 ZEC). */
+    var dustThresholdZatoshi: Long = 10_000L
 
     /**
      * The Orchard balance the fake reports as *still migratable* — i.e. the residual left after

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/model/migration/sim/FakeOrchardMigrationSdk.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/model/migration/sim/FakeOrchardMigrationSdk.kt
@@ -443,6 +443,8 @@ class FakeOrchardMigrationSdk : OrchardMigrationSdk {
 
     override suspend fun migrationDustThresholdZatoshi(): Long = dustThresholdZatoshi
 
+    override suspend fun migratableOrchardTotal(): Long = migratableOrchardZatoshi
+
     override fun isSyncBlocked(): Flow<Boolean> = syncBlocked.asStateFlow()
 
     override fun privacySyncBufferDuration(): Duration = 30.seconds

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/model/migration/sim/MigrationKeystoneMultiRoundScenarioTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/model/migration/sim/MigrationKeystoneMultiRoundScenarioTest.kt
@@ -36,7 +36,7 @@ class MigrationKeystoneMultiRoundScenarioTest {
 
         // Per-run migratable ceiling the engine's note cap imposes.
         const val PER_RUN_CAP: Long = 1_000_000L // 0.01 ZEC per run
-        const val DUST: Long = 100_000L // 0.001 ZEC — the protocol dust threshold
+        const val DUST: Long = 10_000L // 0.0001 ZEC — the protocol dust threshold
 
         // Start with 2.5x a single run's reach: three rounds' worth (ceil(2_500_000/1_000_000) = 3).
         const val INITIAL_RESIDUAL: Long = 2_500_000L
@@ -94,7 +94,7 @@ class MigrationKeystoneMultiRoundScenarioTest {
             assertEquals(2, afterRound1, "1_500_000 / 1_000_000 = 2 runs still to go.")
             assertTrue(
                 anotherRoundNeeded(sdk),
-                "residual 1_500_000 > dust 100_000 and needs >0 further runs — round 2 expected.",
+                "residual 1_500_000 > dust 10_000 and needs >0 further runs — round 2 expected.",
             )
 
             // ── Round 2 completes: another run's worth clears. ──
@@ -104,7 +104,7 @@ class MigrationKeystoneMultiRoundScenarioTest {
             assertTrue(anotherRoundNeeded(sdk), "500_000 > dust — round 3 expected.")
 
             // ── Round 3 clears all but dust. ──
-            driver.setMigratableResidual(zatoshi = DUST - 1L) // 99_999 — below the dust threshold
+            driver.setMigratableResidual(zatoshi = DUST - 1L) // 9_999 — below the dust threshold
             assertEquals(
                 1,
                 sdk.estimateMigrationRunCount(),
@@ -112,7 +112,7 @@ class MigrationKeystoneMultiRoundScenarioTest {
             )
             assertFalse(
                 anotherRoundNeeded(sdk),
-                "…but the app gates on the dust threshold: 99_999 < 100_000 is negligible — campaign ends.",
+                "…but the app gates on the dust threshold: 9_999 < 10_000 is negligible — campaign ends.",
             )
 
             // Exactly-zero residual is unambiguously done.

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/CheckMigrationRecoveryUseCaseTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/CheckMigrationRecoveryUseCaseTest.kt
@@ -162,7 +162,7 @@ class CheckMigrationRecoveryUseCaseTest {
 
             coVerify(exactly = 0) { router.replaceAll(HomeArgs, MigrationTransferInvalidArgs) }
             coVerify(exactly = 0) { router.replaceAll(HomeArgs, MigrationProgressArgs) }
-            coVerify(exactly = 0) { router.replaceAll(HomeArgs, MigrationCompleteArgs) }
+            coVerify(exactly = 0) { router.replaceAll(HomeArgs, MigrationCompleteArgs()) }
         }
 
     @Test
@@ -265,7 +265,7 @@ class CheckMigrationRecoveryUseCaseTest {
                 pendingMigrationTorFailure = false,
             ).invoke()
 
-            coVerify(exactly = 0) { router.replaceAll(HomeArgs, MigrationCompleteArgs) }
+            coVerify(exactly = 0) { router.replaceAll(HomeArgs, MigrationCompleteArgs()) }
             coVerify(exactly = 0) { router.replaceAll(any()) }
         }
 

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCaseMigrationTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCaseMigrationTest.kt
@@ -102,7 +102,15 @@ class GetHomeMessageUseCaseMigrationTest {
                 hasSeenComplete = false,
                 orchardBalanceZatoshi = 500_000L,
             )
-        assertEquals(MigrationHomeMessageData(isRunActive = false, isComplete = true), result)
+        assertEquals(
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = 500_000L,
+            ),
+            result,
+        )
     }
 
     @Test
@@ -114,7 +122,15 @@ class GetHomeMessageUseCaseMigrationTest {
                 hasSeenComplete = false,
                 orchardBalanceZatoshi = MIGRATION_RESIDUAL_MIN_ZATOSHI - 1L,
             )
-        assertEquals(MigrationHomeMessageData(isRunActive = false, isComplete = true), result)
+        assertEquals(
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = MIGRATION_RESIDUAL_MIN_ZATOSHI - 1L,
+            ),
+            result,
+        )
     }
 
     @Test
@@ -126,7 +142,15 @@ class GetHomeMessageUseCaseMigrationTest {
                 hasSeenComplete = false,
                 orchardBalanceZatoshi = MIGRATION_DUST_THRESHOLD_ZATOSHI + 1L,
             )
-        assertEquals(MigrationHomeMessageData(isRunActive = false, isComplete = true), result)
+        assertEquals(
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = MIGRATION_DUST_THRESHOLD_ZATOSHI + 1L,
+            ),
+            result,
+        )
     }
 
     @Test

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/MigrationBannerStateTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/MigrationBannerStateTest.kt
@@ -140,7 +140,15 @@ class MigrationBannerStateTest {
                 hasSeenComplete = false,
                 orchardBalanceZatoshi = 500_000L, // in the (dust, min) gap — residue
             )
-        assertEquals(MigrationHomeMessageData(isRunActive = false, isComplete = true), result)
+        assertEquals(
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = 500_000L,
+            ),
+            result,
+        )
     }
 
     /**
@@ -273,7 +281,15 @@ class MigrationBannerStateTest {
                 hasSeenComplete = false,
                 orchardBalanceZatoshi = 500_000L, // in (dust, min) gap — residue, un-migratable
             )
-        assertEquals(MigrationHomeMessageData(isRunActive = false, isComplete = true), result)
+        assertEquals(
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = 500_000L,
+            ),
+            result,
+        )
     }
 
     // ─── §3 Cross-branch: SyncRequiredBeforeNext during InProgress ────────────

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/MigrationBannerStateTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/MigrationBannerStateTest.kt
@@ -472,4 +472,73 @@ class MigrationBannerStateTest {
             result,
         )
     }
+
+    // ─── §6 RESIDUE gated on isFullySynced (mid-sync race) ────────────────────
+
+    /**
+     * Neal's repro (Slack, 2026-08-24): a wallet that was already fully swept elsewhere (0 ZEC)
+     * but hadn't finished syncing this instance showed a bogus "X ZEC left in Orchard" residue
+     * popup, and its "Migrate anyway" action failed with "no Orchard input found for TXID..." —
+     * orchardBalanceZatoshi and migratableOrchardTotalZatoshi are two independent reads of the
+     * same, still-changing DB mid-sync and can disagree window-to-window. The residue branch must
+     * not fire until the wallet has caught up with the chain tip.
+     */
+    @Test
+    fun residueBranchSuppressedWhileNotFullySynced() {
+        val result =
+            migrationMessageFor(
+                sdkState = null,
+                snapshot = null,
+                hasSeenComplete = false,
+                orchardBalanceZatoshi = 500_000L, // in (dust, min) gap — would be residue if synced
+                migratableOrchardTotalZatoshi = MIGRATION_DUST_THRESHOLD_ZATOSHI + 1L,
+                isFullySynced = false,
+            )
+        assertNull(result, "Residue banner must not fire while the wallet is still mid-sync")
+    }
+
+    /**
+     * Contrast case: identical inputs, but the wallet is fully synced — the residue banner fires
+     * exactly as before. Confirms the new gate doesn't change behavior once sync has caught up.
+     */
+    @Test
+    fun residueBranchFiresOnceFullySynced() {
+        val result =
+            migrationMessageFor(
+                sdkState = null,
+                snapshot = null,
+                hasSeenComplete = false,
+                orchardBalanceZatoshi = 500_000L,
+                migratableOrchardTotalZatoshi = MIGRATION_DUST_THRESHOLD_ZATOSHI + 1L,
+                isFullySynced = true,
+            )
+        assertEquals(
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = 500_000L,
+            ),
+            result,
+        )
+    }
+
+    /**
+     * The plain "Migrate now" branch (raw balance ≥ [MIGRATION_RESIDUAL_MIN_ZATOSHI], no run) is
+     * deliberately NOT gated on [isFullySynced] — unlike the residue branch it only surfaces a CTA
+     * (no one-click transfer proposal reading stale notes), so the same mid-sync race isn't
+     * user-visible there. This pins that it still fires while mid-sync.
+     */
+    @Test
+    fun migrateNowBranchStillFiresWhileNotFullySynced() {
+        val result =
+            migrationMessageFor(
+                sdkState = null,
+                snapshot = null,
+                hasSeenComplete = false,
+                orchardBalanceZatoshi = MIGRATION_RESIDUAL_MIN_ZATOSHI + 1_000_000L,
+                isFullySynced = false,
+            )
+        assertEquals(MigrationHomeMessageData(isRunActive = false), result)
+    }
 }

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/MigrationBannerStateTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/MigrationBannerStateTest.kt
@@ -391,4 +391,85 @@ class MigrationBannerStateTest {
         // ready-to-send branch must not have fired despite its other preconditions being met.
         assertEquals(MigrationHomeMessageData(isRunActive = false, completedCount = 1, totalCount = 2), result)
     }
+
+    // ─── §5 Per-note dust gate (Kris Nuttycombe's formula) ────────────────────
+
+    /**
+     * A raw Orchard balance above [MIGRATION_DUST_THRESHOLD_ZATOSHI] can still be true dust if it's
+     * made up of notes too small individually to be worth spending net of MARGINAL_FEE — e.g. many
+     * sub-MARGINAL_FEE notes, or few notes just barely above MARGINAL_FEE. In that case the SDK's
+     * migratableOrchardTotal() (per-note, net of MARGINAL_FEE) reports at or below the threshold
+     * even though the raw balance does not. [migrationMessageFor] must gate the residue banner on
+     * the per-note total, not the raw balance — otherwise it prompts to migrate/lock a balance that
+     * costs more to move than it's worth.
+     */
+    @Test
+    fun rawBalanceAboveDustButPerNoteTotalAtDustShowsNothing() {
+        val result =
+            migrationMessageFor(
+                sdkState = null,
+                snapshot = null,
+                hasSeenComplete = false,
+                orchardBalanceZatoshi = MIGRATION_DUST_THRESHOLD_ZATOSHI + 50_000L, // raw: well above dust
+                migratableOrchardTotalZatoshi = MIGRATION_DUST_THRESHOLD_ZATOSHI, // per-note: at the threshold
+            )
+        // No banner — the per-note total is not strictly above the threshold, even though the raw
+        // balance is. Falls through both the residue branch (gated on the per-note total) and the
+        // "Migrate now" branch (raw balance is still below MIGRATION_RESIDUAL_MIN_ZATOSHI).
+        assertNull(result)
+    }
+
+    /**
+     * Contrast case: when the per-note total genuinely exceeds the threshold, the residue banner
+     * fires exactly as before, and still displays the raw balance (not the net-of-fee total) as
+     * [MigrationHomeMessageData.residualBalanceZatoshi] — the user should see what they actually
+     * hold, not the fee-adjusted figure used only for the internal gate.
+     */
+    @Test
+    fun rawBalanceAndPerNoteTotalBothAboveDustShowsResidueWithRawBalanceDisplayed() {
+        val rawBalance = MIGRATION_DUST_THRESHOLD_ZATOSHI + 50_000L
+        val result =
+            migrationMessageFor(
+                sdkState = null,
+                snapshot = null,
+                hasSeenComplete = false,
+                orchardBalanceZatoshi = rawBalance,
+                migratableOrchardTotalZatoshi = MIGRATION_DUST_THRESHOLD_ZATOSHI + 1L,
+            )
+        assertEquals(
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = rawBalance,
+            ),
+            result,
+        )
+    }
+
+    /**
+     * Omitting [migrationMessageFor]'s migratableOrchardTotalZatoshi parameter defaults it to
+     * orchardBalanceZatoshi — i.e. legacy raw-balance behavior — so every pre-existing call site in
+     * this file and [GetHomeMessageUseCaseMigrationTest] that doesn't pass it keeps its original
+     * meaning unchanged.
+     */
+    @Test
+    fun migratableOrchardTotalZatoshiDefaultsToRawBalance() {
+        val result =
+            migrationMessageFor(
+                sdkState = null,
+                snapshot = null,
+                hasSeenComplete = false,
+                orchardBalanceZatoshi = 500_000L, // in (dust, min) gap — residue, per legacy behavior
+            )
+        assertEquals(
+            MigrationHomeMessageData(
+                isRunActive = false,
+                isComplete = true,
+                isResidueOnly = true,
+                residualBalanceZatoshi = 500_000L,
+            ),
+            result,
+        )
+    }
 }

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVMTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVMTest.kt
@@ -208,7 +208,7 @@ class MigrationCompleteVMTest {
         runTest {
             // Regression guard for the threshold discrepancy this test used to reproduce: onDone()'s
             // `moreRoundsNeeded` check used to compare the residual only against
-            // MIGRATION_DUST_THRESHOLD_ZATOSHI (0.001 ZEC) instead of MIGRATION_RESIDUAL_MIN_ZATOSHI
+            // MIGRATION_DUST_THRESHOLD_ZATOSHI (0.0001 ZEC) instead of MIGRATION_RESIDUAL_MIN_ZATOSHI
             // (0.01 ZEC) -- the actual engine minimum below which proposeMigrationTransfers() returns
             // NothingToMigrate. For a balance in the gap between the two (e.g. the live-observed
             // 0.005 ZEC / 500_000L zatoshi used by GetHomeMessageUseCaseMigrationTest's own
@@ -385,6 +385,52 @@ class MigrationCompleteVMTest {
             collectJob.cancel()
         }
 
+    @Test
+    fun isResidueOnlyArgPropagatesThroughToState() =
+        runTest {
+            // MOB-1750: MigrationCompleteArgs.isResidueOnly must reach MigrationCompleteState
+            // unchanged — this is what MigrationCompleteScreen branches its copy/summary card on.
+            val vm =
+                vm(
+                    account = mockk<KeystoneAccount>(relaxed = true),
+                    orchardBalanceZatoshi = 500_000L,
+                    router = FakeNavigationRouter(),
+                    args = MigrationCompleteArgs(isResidueOnly = true),
+                )
+
+            val collectJob = launch { vm.state.collect {} }
+            advanceUntilIdle()
+
+            assertEquals(
+                true,
+                vm.state.value.content
+                    ?.isResidueOnly
+            )
+            collectJob.cancel()
+        }
+
+    @Test
+    fun isResidueOnlyDefaultsToFalseForTheOriginalCelebrationVariant() =
+        runTest {
+            val vm =
+                vm(
+                    account = mockk<KeystoneAccount>(relaxed = true),
+                    orchardBalanceZatoshi = 500_000L,
+                    router = FakeNavigationRouter(),
+                    args = MigrationCompleteArgs(isResidueOnly = false),
+                )
+
+            val collectJob = launch { vm.state.collect {} }
+            advanceUntilIdle()
+
+            assertEquals(
+                false,
+                vm.state.value.content
+                    ?.isResidueOnly
+            )
+            collectJob.cancel()
+        }
+
     private fun invokeOnDone(vm: MigrationCompleteVM) {
         val onDone = MigrationCompleteVM::class.java.getDeclaredMethod("onDone")
         onDone.isAccessible = true
@@ -403,6 +449,7 @@ class MigrationCompleteVMTest {
         account: WalletAccount,
         orchardBalanceZatoshi: Long,
         router: FakeNavigationRouter,
+        args: MigrationCompleteArgs = MigrationCompleteArgs(),
         getOrchardMigrationSdk: GetOrchardMigrationSdkUseCase =
             mockk {
                 coEvery { this@mockk() } returns mockk(relaxed = true)
@@ -414,6 +461,7 @@ class MigrationCompleteVMTest {
         migrationScheduler: MigrationScheduler = mockk(relaxed = true),
         migrationNotifier: MigrationNotifier = mockk(relaxed = true),
     ) = MigrationCompleteVM(
+        args = args,
         getOrchardBalance =
             mockk<GetOrchardBalanceUseCase> {
                 coEvery { this@mockk() } returns Zatoshi(orchardBalanceZatoshi)

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVMTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/complete/MigrationCompleteVMTest.kt
@@ -25,6 +25,7 @@ import co.electriccoin.zcash.ui.common.provider.MigrationNotifier
 import co.electriccoin.zcash.ui.common.repository.BiometricRepository
 import co.electriccoin.zcash.ui.common.repository.KeystoneProposalRepository
 import co.electriccoin.zcash.ui.common.usecase.ErrorMapperUseCase
+import co.electriccoin.zcash.ui.common.usecase.GetIronwoodBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardMigrationSdkUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetSelectedWalletAccountUseCase
@@ -345,6 +346,47 @@ class MigrationCompleteVMTest {
         }
 
     @Test
+    fun residueVariantReadsTotalTransferredFromLiveIronwoodBalanceNotEngineSummary() =
+        runTest {
+            // MOB-1750: for isResidueOnly, "In Ironwood" must be the live Ironwood pool balance
+            // (GetIronwoodBalanceUseCase) -- never the migration engine's campaign-scoped
+            // getMigrationSummary(), which can genuinely have no rows for this account (e.g.
+            // after a debug migration restart) even though the wallet's real Ironwood balance is
+            // nonzero. Pins that the engine summary is never even queried for this variant, and
+            // a mismatched summary value (999 ZEC) is ignored in favor of the real balance.
+            val sdk =
+                mockk<OrchardMigrationSdk> {
+                    coEvery { getMigrationSummary() } returns
+                        MigrationSummary(
+                            totalMigratedZatoshi = 99_900_000_000L,
+                            transferCount = 5,
+                            firstMinedEpochSeconds = 1_785_281_502L,
+                            lastMinedEpochSeconds = 1_785_283_542L,
+                        )
+                }
+            val vm =
+                vm(
+                    account = mockk<KeystoneAccount>(relaxed = true),
+                    orchardBalanceZatoshi = 500_000L,
+                    router = FakeNavigationRouter(),
+                    args = MigrationCompleteArgs(isResidueOnly = true),
+                    ironwoodBalanceZatoshi = 12_450_000L,
+                    getOrchardMigrationSdk = mockk { coEvery { this@mockk() } returns sdk },
+                )
+
+            val collectJob = launch { vm.state.collect {} }
+            advanceUntilIdle()
+
+            assertEquals(
+                stringRes(Zatoshi(12_450_000L)),
+                vm.state.value.content
+                    ?.totalTransferred
+            )
+            coVerify(exactly = 0) { sdk.getMigrationSummary() }
+            collectJob.cancel()
+        }
+
+    @Test
     fun durationDoesNotApplyThePrivacyFloorSinceBothTimestampsAreAlreadyMined() =
         runTest {
             // The displayed duration spans the campaign's first to last MINED transfer -- both
@@ -450,6 +492,7 @@ class MigrationCompleteVMTest {
         orchardBalanceZatoshi: Long,
         router: FakeNavigationRouter,
         args: MigrationCompleteArgs = MigrationCompleteArgs(),
+        ironwoodBalanceZatoshi: Long = 0L,
         getOrchardMigrationSdk: GetOrchardMigrationSdkUseCase =
             mockk {
                 coEvery { this@mockk() } returns mockk(relaxed = true)
@@ -465,6 +508,10 @@ class MigrationCompleteVMTest {
         getOrchardBalance =
             mockk<GetOrchardBalanceUseCase> {
                 coEvery { this@mockk() } returns Zatoshi(orchardBalanceZatoshi)
+            },
+        getIronwoodBalance =
+            mockk<GetIronwoodBalanceUseCase> {
+                coEvery { this@mockk() } returns Zatoshi(ironwoodBalanceZatoshi)
             },
         hasSeenMigrationCompleteStorageProvider = seen,
         hasLockedOrchardDustStorageProvider =

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/confirmsubmission/VoteConfirmSubmissionComponents.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/confirmsubmission/VoteConfirmSubmissionComponents.kt
@@ -114,7 +114,7 @@ internal fun VoteSubmissionBottomSection(state: VoteConfirmSubmissionState) {
                 }
             }
         val progressNote: StringResource? =
-            if (state.status is VoteSubmissionStatus.Submitting) {
+            if (progressTitle != null) {
                 stringRes(R.string.coinVote_confirmSubmission_submittingExplainerNote)
             } else {
                 null

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/confirmsubmission/VoteConfirmSubmissionComponents.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/confirmsubmission/VoteConfirmSubmissionComponents.kt
@@ -113,10 +113,17 @@ internal fun VoteSubmissionBottomSection(state: VoteConfirmSubmissionState) {
                     null
                 }
             }
+        val progressNote: StringResource? =
+            if (state.status is VoteSubmissionStatus.Submitting) {
+                stringRes(R.string.coinVote_confirmSubmission_submittingExplainerNote)
+            } else {
+                null
+            }
 
         if (progressTitle != null) {
             VoteSubmissionProgressCard(
                 title = progressTitle,
+                note = progressNote,
                 progress = submissionProgress,
                 ctaButton = state.ctaButton
             )
@@ -158,6 +165,7 @@ private fun VoteSubmissionProgressCard(
     title: StringResource,
     progress: Float,
     ctaButton: ButtonState,
+    note: StringResource? = null,
 ) {
     val animatedProgress by animateFloatAsState(
         targetValue = progress,
@@ -185,6 +193,14 @@ private fun VoteSubmissionProgressCard(
                 )
                 VerticalSpacer(12.dp)
                 ZashiLinearProgressIndicator(progress = animatedProgress)
+                if (note != null) {
+                    VerticalSpacer(12.dp)
+                    Text(
+                        text = note.getValue(),
+                        style = ZashiTypography.textXs,
+                        color = ZashiColors.Text.textTertiary,
+                    )
+                }
             }
             HorizontalDivider(color = ZashiColors.Surfaces.strokeSecondary)
             ZashiButton(

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=7093188d380d8152fa6780c2a7b039549540025c
+SDK_COMMIT_PIN=1bf61214d7ff460d9faaea30baf84729b07c826e
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ NDK_DEBUG_SYMBOL_LEVEL=symbol_table
 # VERSION_CODE is effectively ignored. VERSION_NAME is suffixed with the version code.
 # If not using automated Google Play deployment, then these serve as the actual version numbers.
 ZCASH_VERSION_CODE=1
-ZCASH_VERSION_NAME=3.10.0
+ZCASH_VERSION_NAME=3.10.1
 # Set these fields, as you need them (e.g. with values "Zcash X" and "co.electriccoin.zcash.x")
 # to distinguish a different release build that can be installed alongside the official version
 # available on Google Play. This is useful for testing, or for a forked version of the app.
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=0ef67b411f0a51aae00346fef18286505e1bcfd1
+SDK_COMMIT_PIN=
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=
@@ -203,7 +203,7 @@ KTOR_VERSION=3.4.0
 # WARNING: Ensure a non-snapshot version is used before releasing to production
 ZCASH_BIP39_VERSION=1.0.9
 # WARNING: Ensure a non-snapshot version is used before releasing to production
-ZCASH_SDK_VERSION=3.1.0-SNAPSHOT
+ZCASH_SDK_VERSION=3.1.1-SNAPSHOT
 # Toolchain is the Java version used to build the application, which is separate from the
 # Java version used to run the application.
 # Must be >=21: the zip321 dependency ships Java 21 bytecode (class file v65), so JVM unit tests

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=d15f8472ef071357a253f32da8e2de9b62699b81
+SDK_COMMIT_PIN=4b39e71fab64aeab65d34f1aa8ba97ffee1155ee
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=1bf61214d7ff460d9faaea30baf84729b07c826e
+SDK_COMMIT_PIN=e607703f56312d826accad5da0abcaa897bb0bd0
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=26dab43dbf6d8f2c8cbb5739686c71685f9e7981
+SDK_COMMIT_PIN=7093188d380d8152fa6780c2a7b039549540025c
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=26dab43dbf6d8f2c8cbb5739686c71685f9e7981
+SDK_COMMIT_PIN=d15f8472ef071357a253f32da8e2de9b62699b81
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/preference-impl-android-lib/build.gradle.kts
+++ b/preference-impl-android-lib/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.coroutines.core)
     implementation(projects.preferenceApiLib)
+    implementation(projects.spackleAndroidLib)
 
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/preference-impl-android-lib/src/androidTest/java/co/electriccoin/zcash/preference/EncryptedPreferenceProviderTest.kt
+++ b/preference-impl-android-lib/src/androidTest/java/co/electriccoin/zcash/preference/EncryptedPreferenceProviderTest.kt
@@ -3,6 +3,8 @@
 package co.electriccoin.zcash.preference
 
 import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.filters.SmallTest
 import co.electriccoin.zcash.preference.test.fixture.StringDefaultPreferenceFixture
@@ -13,6 +15,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.io.File
+import java.security.KeyStore
 
 // Areas that are not covered yet:
 // 1. Test observer behavior
@@ -120,9 +123,48 @@ class EncryptedPreferenceProviderTest {
             assertFalse(restoredProvider.hasKey(StringDefaultPreferenceFixture.KEY))
         }
 
+    @Test
+    @SmallTest
+    fun graceful_recovery_when_master_key_is_lost_in_migration() =
+        runBlocking {
+            val context = ApplicationProvider.getApplicationContext<Context>()
+
+            // Faithful D2D simulation: the prefs file holds keysets encrypted with a Keystore
+            // master key, and that hardware-bound key does not exist on the target device.
+            // We reproduce this by writing through EncryptedSharedPreferences directly (bypassing
+            // the factory cache) and then deleting the master key from the Keystore.
+            val masterKey =
+                MasterKey
+                    .Builder(context)
+                    .apply { setKeyScheme(MasterKey.KeyScheme.AES256_GCM) }
+                    .build()
+            EncryptedSharedPreferences
+                .create(
+                    context,
+                    D2D_FILENAME,
+                    masterKey,
+                    EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                    EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+                ).edit()
+                .putString(StringDefaultPreferenceFixture.KEY.key, "secret")
+                .commit()
+
+            KeyStore.getInstance("AndroidKeyStore").apply {
+                load(null)
+                deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+            }
+
+            // Should NOT throw — the orphaned file is provably undecryptable, so it is recreated
+            val restoredProvider = AndroidPreferenceProvider.newEncrypted(context, D2D_FILENAME)
+
+            // Prefs are empty: user will re-enter seed phrase to recover wallet
+            assertFalse(restoredProvider.hasKey(StringDefaultPreferenceFixture.KEY))
+        }
+
     companion object {
         private const val FILENAME = "encrypted_preference_test"
         private const val RECOVERY_FILENAME = "encrypted_preference_recovery_test"
+        private const val D2D_FILENAME = "encrypted_preference_d2d_test"
 
         // Internal keyset key names used by EncryptedSharedPreferences to store Tink keysets
         private const val KEY_KEYSET = "__androidx_security_crypto_encrypted_prefs_key_keyset__"

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
@@ -322,14 +322,15 @@ private fun androidKeyStore(): KeyStore =
  * True only for failures that are deterministic for the stored ciphertext or this device's
  * Keystore: an AEAD/padding authentication failure, a Tink keyset that no longer decodes
  * ([CharConversionException] is Tink's malformed-hex signature, InvalidProtocolBufferException its
- * malformed-proto one), Tink's Keystore self-test failure ([KeyStoreException] — thrown by
- * `AndroidKeystoreKmsClient` after its own internal retry when the Keystore provably cannot
- * round-trip data, a permanent condition on devices with a buggy hardware Keystore), or
- * [InvalidKeyException], the failure [createEncryptedSharedPreferences] actually throws for a
- * genuinely device-to-device-orphaned file when [isEncryptedFileOrphaned]'s Keystore query itself
- * failed twice (see [retryOnceOrDefault]) and so could not flag the orphan first — this is the
- * second line of defense for that case. Other Keystore and general IO failures are excluded
- * because they can be transient.
+ * malformed-proto one), Tink's Keystore self-test failure ([KeyStoreException] — in tink-android
+ * 1.8.0, `AndroidKeystoreKmsClient` throws it from exactly one place, `validateAead()`, when a
+ * post-key-creation AEAD encrypt/decrypt round-trip of a random message doesn't match; a
+ * permanent condition on devices with a buggy hardware Keystore), or [InvalidKeyException], the
+ * failure [createEncryptedSharedPreferences] actually throws for a genuinely
+ * device-to-device-orphaned file when [isEncryptedFileOrphaned]'s Keystore query itself failed
+ * twice (see [retryOnceOrDefault]) and so could not flag the orphan first — this is the second
+ * line of defense for that case. Other Keystore and general IO failures are excluded because they
+ * can be transient.
  */
 internal fun isUnrecoverableCorruption(exception: Exception): Boolean =
     generateSequence<Throwable>(exception) { it.cause }

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.withContext
 import java.io.CharConversionException
 import java.io.File
 import java.security.KeyStore
+import java.security.KeyStoreException
 import javax.crypto.BadPaddingException
 
 /**
@@ -243,8 +244,13 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
     /**
      * The device-to-device migration signature: the encrypted preferences file exists, but a
      * working Keystore definitively reports the master key absent, so nothing can ever decrypt
-     * the file. A Keystore that cannot even be queried yields false — an unknown Keystore state
-     * must never authorize deleting the stored secrets.
+     * the file. The query is retried once so that a momentary Keystore hiccup does not disguise
+     * a genuinely orphaned file as healthy; a Keystore that still cannot be queried yields false —
+     * an unknown Keystore state must never authorize deleting the stored secrets.
+     *
+     * Must be evaluated before attempting [createEncryptedSharedPreferences]: a failed attempt has
+     * already recreated the master key alias via [MasterKey.Builder.build], so querying the
+     * Keystore afterwards would always report the alias present and never detect the orphan.
      */
     private fun isEncryptedFileOrphaned(
         context: Context,
@@ -253,27 +259,10 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
         if (!encryptedPreferencesFile(context, filename).exists()) {
             return false
         }
-        return runCatching {
-            val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE)
-            keyStore.load(null)
-            !keyStore.containsAlias(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
-        }.getOrDefault(false)
+        return retryOnceOrDefault(false) {
+            !androidKeyStore().containsAlias(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+        }
     }
-
-    /**
-     * True only for failures that are deterministic for the stored ciphertext: an AEAD/padding
-     * authentication failure, or a Tink keyset that no longer decodes ([CharConversionException]
-     * is Tink's malformed-hex signature, InvalidProtocolBufferException its malformed-proto one).
-     * Keystore and general IO failures are excluded because they can be transient.
-     */
-    private fun isUnrecoverableCorruption(exception: Exception): Boolean =
-        generateSequence<Throwable>(exception) { it.cause }
-            .take(CAUSE_CHAIN_LIMIT)
-            .any {
-                it is BadPaddingException ||
-                    it is CharConversionException ||
-                    it.javaClass.simpleName == "InvalidProtocolBufferException"
-            }
 
     private fun createEncryptedSharedPreferences(
         context: Context,
@@ -298,9 +287,7 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
         filename: String
     ) {
         runCatching {
-            val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE)
-            keyStore.load(null)
-            keyStore.deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+            androidKeyStore().deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
         }
         // Clear in-memory SharedPreferences cache so the retry gets a clean instance.
         // Without this, Android returns the cached (corrupted) instance even after file deletion.
@@ -320,9 +307,42 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
         context: Context,
         filename: String
     ) = File(context.filesDir.parent, "shared_prefs/$filename.xml")
-
-    companion object {
-        private const val ANDROID_KEYSTORE = "AndroidKeyStore"
-        private const val CAUSE_CHAIN_LIMIT = 10
-    }
 }
+
+private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+private const val CAUSE_CHAIN_LIMIT = 10
+
+private fun androidKeyStore(): KeyStore =
+    KeyStore
+        .getInstance(ANDROID_KEYSTORE)
+        .apply { load(null) }
+
+/**
+ * True only for failures that are deterministic for the stored ciphertext or this device's
+ * Keystore: an AEAD/padding authentication failure, a Tink keyset that no longer decodes
+ * ([CharConversionException] is Tink's malformed-hex signature, InvalidProtocolBufferException its
+ * malformed-proto one), or Tink's Keystore self-test failure ([KeyStoreException] — thrown by
+ * `AndroidKeystoreKmsClient` after its own internal retry when the Keystore provably cannot
+ * round-trip data, a permanent condition on devices with a buggy hardware Keystore). Other
+ * Keystore and general IO failures are excluded because they can be transient.
+ */
+internal fun isUnrecoverableCorruption(exception: Exception): Boolean =
+    generateSequence<Throwable>(exception) { it.cause }
+        .take(CAUSE_CHAIN_LIMIT)
+        .any {
+            it is BadPaddingException ||
+                it is CharConversionException ||
+                it is KeyStoreException ||
+                it.javaClass.simpleName == "InvalidProtocolBufferException"
+        }
+
+/**
+ * Runs [block], retrying once if it throws; returns [default] when both attempts throw.
+ */
+internal fun <T> retryOnceOrDefault(
+    default: T,
+    block: () -> T
+): T =
+    runCatching(block)
+        .recoverCatching { block() }
+        .getOrDefault(default)

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
@@ -9,6 +9,7 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
 import co.electriccoin.zcash.preference.api.PreferenceProvider
 import co.electriccoin.zcash.preference.model.entry.PreferenceKey
+import co.electriccoin.zcash.spackle.Twig
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
@@ -21,8 +22,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import java.io.CharConversionException
 import java.io.File
 import java.security.KeyStore
+import javax.crypto.BadPaddingException
 
 /**
  * Provides an Android implementation of shared preferences.
@@ -201,26 +204,76 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
     /**
      * Android Keystore keys are hardware-bound and not transferred during device-to-device
      * migration, so the encrypted prefs file arrives on the new device but cannot be decrypted.
-     * On failure, [deleteCorruptedEncryptedPreferences] wipes the orphaned file and creation is
-     * retried fresh.
+     * Only failures that provably mean the stored data can never be decrypted again trigger
+     * [deleteCorruptedEncryptedPreferences] and a fresh start: the master key being verifiably
+     * absent while the file exists ([isEncryptedFileOrphaned]), or a deterministic decryption or
+     * keyset-parse failure ([isUnrecoverableCorruption]). Every other failure — for example a
+     * transient Keystore outage — is logged and rethrown, because misclassifying it as corruption
+     * would irreversibly destroy the stored secrets.
      */
-    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    @Suppress("TooGenericExceptionCaught")
     override suspend fun newEncrypted(context: Context, filename: String): PreferenceProvider =
         encryptedCache.getOrCreate(filename) {
             val dispatcher = Dispatchers.IO.limitedParallelism(1)
 
             val sharedPreferences =
                 withContext(dispatcher) {
+                    val isOrphaned = isEncryptedFileOrphaned(context, filename)
                     try {
                         createEncryptedSharedPreferences(context, filename)
-                    } catch (_: Exception) {
-                        deleteCorruptedEncryptedPreferences(context, filename)
-                        createEncryptedSharedPreferences(context, filename)
+                    } catch (e: Exception) {
+                        if (isOrphaned || isUnrecoverableCorruption(e)) {
+                            Twig.error(e) {
+                                "Encrypted preferences $filename can never be decrypted again; recreating them"
+                            }
+                            deleteCorruptedEncryptedPreferences(context, filename)
+                            createEncryptedSharedPreferences(context, filename)
+                        } else {
+                            Twig.error(e) {
+                                "Opening encrypted preferences $filename failed; keeping data intact for a retry"
+                            }
+                            throw e
+                        }
                     }
                 }
 
             AndroidPreferenceProvider(sharedPreferences, dispatcher)
         }
+
+    /**
+     * The device-to-device migration signature: the encrypted preferences file exists, but a
+     * working Keystore definitively reports the master key absent, so nothing can ever decrypt
+     * the file. A Keystore that cannot even be queried yields false — an unknown Keystore state
+     * must never authorize deleting the stored secrets.
+     */
+    private fun isEncryptedFileOrphaned(
+        context: Context,
+        filename: String
+    ): Boolean {
+        if (!encryptedPreferencesFile(context, filename).exists()) {
+            return false
+        }
+        return runCatching {
+            val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE)
+            keyStore.load(null)
+            !keyStore.containsAlias(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+        }.getOrDefault(false)
+    }
+
+    /**
+     * True only for failures that are deterministic for the stored ciphertext: an AEAD/padding
+     * authentication failure, or a Tink keyset that no longer decodes ([CharConversionException]
+     * is Tink's malformed-hex signature, InvalidProtocolBufferException its malformed-proto one).
+     * Keystore and general IO failures are excluded because they can be transient.
+     */
+    private fun isUnrecoverableCorruption(exception: Exception): Boolean =
+        generateSequence<Throwable>(exception) { it.cause }
+            .take(CAUSE_CHAIN_LIMIT)
+            .any {
+                it is BadPaddingException ||
+                    it is CharConversionException ||
+                    it.javaClass.simpleName == "InvalidProtocolBufferException"
+            }
 
     private fun createEncryptedSharedPreferences(
         context: Context,
@@ -245,7 +298,7 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
         filename: String
     ) {
         runCatching {
-            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE)
             keyStore.load(null)
             keyStore.deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
         }
@@ -259,7 +312,17 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
                 .commit()
         }
         runCatching {
-            File(context.filesDir.parent, "shared_prefs/$filename.xml").delete()
+            encryptedPreferencesFile(context, filename).delete()
         }
+    }
+
+    private fun encryptedPreferencesFile(
+        context: Context,
+        filename: String
+    ) = File(context.filesDir.parent, "shared_prefs/$filename.xml")
+
+    companion object {
+        private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        private const val CAUSE_CHAIN_LIMIT = 10
     }
 }

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.CharConversionException
 import java.io.File
+import java.security.InvalidKeyException
 import java.security.KeyStore
 import java.security.KeyStoreException
 import javax.crypto.BadPaddingException
@@ -321,10 +322,14 @@ private fun androidKeyStore(): KeyStore =
  * True only for failures that are deterministic for the stored ciphertext or this device's
  * Keystore: an AEAD/padding authentication failure, a Tink keyset that no longer decodes
  * ([CharConversionException] is Tink's malformed-hex signature, InvalidProtocolBufferException its
- * malformed-proto one), or Tink's Keystore self-test failure ([KeyStoreException] — thrown by
+ * malformed-proto one), Tink's Keystore self-test failure ([KeyStoreException] — thrown by
  * `AndroidKeystoreKmsClient` after its own internal retry when the Keystore provably cannot
- * round-trip data, a permanent condition on devices with a buggy hardware Keystore). Other
- * Keystore and general IO failures are excluded because they can be transient.
+ * round-trip data, a permanent condition on devices with a buggy hardware Keystore), or
+ * [InvalidKeyException], the failure [createEncryptedSharedPreferences] actually throws for a
+ * genuinely device-to-device-orphaned file when [isEncryptedFileOrphaned]'s Keystore query itself
+ * failed twice (see [retryOnceOrDefault]) and so could not flag the orphan first — this is the
+ * second line of defense for that case. Other Keystore and general IO failures are excluded
+ * because they can be transient.
  */
 internal fun isUnrecoverableCorruption(exception: Exception): Boolean =
     generateSequence<Throwable>(exception) { it.cause }
@@ -333,6 +338,7 @@ internal fun isUnrecoverableCorruption(exception: Exception): Boolean =
             it is BadPaddingException ||
                 it is CharConversionException ||
                 it is KeyStoreException ||
+                it is InvalidKeyException ||
                 it.javaClass.simpleName == "InvalidProtocolBufferException"
         }
 

--- a/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceRecoveryTest.kt
+++ b/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceRecoveryTest.kt
@@ -3,6 +3,7 @@ package co.electriccoin.zcash.preference
 import java.io.CharConversionException
 import java.io.IOException
 import java.security.GeneralSecurityException
+import java.security.InvalidKeyException
 import java.security.KeyStoreException
 import javax.crypto.AEADBadTagException
 import javax.crypto.BadPaddingException
@@ -40,6 +41,16 @@ class EncryptedPreferenceRecoveryTest {
             )
         )
         assertTrue(isUnrecoverableCorruption(GeneralSecurityException(KeyStoreException())))
+    }
+
+    @Test
+    fun `Keystore-orphaned file failure is unrecoverable corruption`() {
+        assertTrue(
+            isUnrecoverableCorruption(
+                InvalidKeyException("Failed to unwrap key")
+            )
+        )
+        assertTrue(isUnrecoverableCorruption(GeneralSecurityException(InvalidKeyException())))
     }
 
     @Test

--- a/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceRecoveryTest.kt
+++ b/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceRecoveryTest.kt
@@ -1,0 +1,95 @@
+package co.electriccoin.zcash.preference
+
+import java.io.CharConversionException
+import java.io.IOException
+import java.security.GeneralSecurityException
+import java.security.KeyStoreException
+import javax.crypto.AEADBadTagException
+import javax.crypto.BadPaddingException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the recovery heuristics of `AndroidPreferenceProvider.newEncrypted`: which failures are
+ * allowed to trigger wipe-and-recreate of the encrypted preferences, and how the orphaned-file
+ * Keystore query degrades when the Keystore itself misbehaves. Widening or narrowing either
+ * behavior must be a deliberate change that shows up here.
+ */
+class EncryptedPreferenceRecoveryTest {
+    @Test
+    fun `AEAD authentication failure is unrecoverable corruption`() {
+        assertTrue(isUnrecoverableCorruption(AEADBadTagException("decryption failed")))
+        assertTrue(isUnrecoverableCorruption(BadPaddingException("decryption failed")))
+    }
+
+    @Test
+    fun `malformed Tink keyset is unrecoverable corruption`() {
+        assertTrue(isUnrecoverableCorruption(CharConversionException()))
+        assertTrue(
+            isUnrecoverableCorruption(GeneralSecurityException(InvalidProtocolBufferException()))
+        )
+    }
+
+    @Test
+    fun `Keystore self-test failure is unrecoverable corruption`() {
+        assertTrue(
+            isUnrecoverableCorruption(
+                KeyStoreException("cannot use Android Keystore: encryption/decryption failed")
+            )
+        )
+        assertTrue(isUnrecoverableCorruption(GeneralSecurityException(KeyStoreException())))
+    }
+
+    @Test
+    fun `corruption signature is found deep in the cause chain`() {
+        val exception = RuntimeException(IOException(GeneralSecurityException(AEADBadTagException())))
+
+        assertTrue(isUnrecoverableCorruption(exception))
+    }
+
+    @Test
+    fun `potentially transient failures are not corruption`() {
+        assertFalse(isUnrecoverableCorruption(IOException("Keystore temporarily unavailable")))
+        assertFalse(isUnrecoverableCorruption(GeneralSecurityException("cannot get keystore key")))
+        assertFalse(isUnrecoverableCorruption(RuntimeException(IllegalStateException())))
+    }
+
+    @Test
+    fun `retry recovers from a single transient failure`() {
+        var attempts = 0
+
+        val result =
+            retryOnceOrDefault(false) {
+                attempts++
+                if (attempts == 1) {
+                    error("transient Keystore failure")
+                }
+                true
+            }
+
+        assertTrue(result)
+        assertEquals(2, attempts)
+    }
+
+    @Test
+    fun `retry yields the default when the failure persists`() {
+        var attempts = 0
+
+        val result =
+            retryOnceOrDefault(false) {
+                attempts++
+                error("persistent Keystore failure")
+            }
+
+        assertFalse(result)
+        assertEquals(2, attempts)
+    }
+}
+
+/**
+ * Stand-in matching Tink's shaded `InvalidProtocolBufferException` by simple name, which is how
+ * production code recognizes it without depending on Tink's shaded protobuf package.
+ */
+private class InvalidProtocolBufferException : IOException()

--- a/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
@@ -1076,6 +1076,11 @@
     <string name="migrationComplete_migrateAnywayFailureRejected">La red rechazó esta transacción. Comunícate con el soporte.</string>
     <string name="migrationComplete_migrateAnywayFailureError">Ocurrió un error al enviar. Comunícate con el soporte.</string>
     <string name="migrationComplete_migrateAnywayFailurePartial">Se enviaron algunas partes de esta transacción, pero no todas. Comunícate con el soporte.</string>
+    <string name="migrationComplete_residueTitle">Te has movido a Ironwood</string>
+    <string name="migrationComplete_residueSubtitle">Un pequeño saldo todavía permanece en Orchard.</string>
+    <string name="migrationComplete_inIronwoodLabel">En Ironwood</string>
+    <string name="migrationComplete_leftInOrchardLabel">Restante en Orchard</string>
+    <string name="migrationComplete_residueRecommendationBody">%1$s todavía está en Orchard. Mover un monto tan específico podría vincular tus fondos de Ironwood con tu historial de Orchard. Te recomendamos bloquearlo en su lugar.</string>
 
     <string name="migrationNotifPermission_title">Permitir notificaciones</string>
     <string name="migrationNotifPermission_subtitle">Si se pierde una transferencia programada o falla un envío en segundo plano, podemos enviarte una notificación local para que abras Zodl. Recibe avisos sobre:</string>
@@ -1203,5 +1208,7 @@
     <string name="migrationHome_readyToSendTitle">Transferencia lista</string>
     <string name="migrationHome_attentionTitle">El plan de migración necesita actualización</string>
     <string name="migrationHome_defaultSubtitle">Mueve tus fondos a Ironwood.</string>
+    <string name="migrationHome_residueTitle">%1$s restante en Orchard</string>
+    <string name="migrationHome_residueSubtitle">Toca para decidir qué hacer con él</string>
 
 </resources>

--- a/ui-design-lib/src/main/res/ui/common/values/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values/strings.xml
@@ -1134,6 +1134,7 @@ Your vote can no longer be submitted.</string>
     <string name="vote_confirm_cta_submitting" tools:ignore="MissingTranslation">Submitting vote %1$d of %2$d</string>
     <string name="coinVote_store_submissionAuthorizingVote" tools:ignore="MissingTranslation">Authorizing vote...</string>
     <string name="coinVote_confirmSubmission_progressSubmittingVoteCount" tools:ignore="MissingTranslation">Submitting vote %1$d of %2$d...</string>
+    <string name="coinVote_confirmSubmission_submittingExplainerNote" tools:ignore="MissingTranslation">This can take a few minutes. Wallets with more voting weight take longer to process.</string>
     <string name="coinVote_results_percentValue" tools:ignore="MissingTranslation">%1$d%%</string>
     <string name="coinVote_common_submission" tools:ignore="MissingTranslation">Submission</string>
     <string name="coinVote_confirmSubmission_headerTitleIdle" tools:ignore="MissingTranslation">Confirm &amp; Submit</string>

--- a/ui-design-lib/src/main/res/ui/common/values/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values/strings.xml
@@ -1357,6 +1357,11 @@ Your vote can no longer be submitted.</string>
     <string name="migrationComplete_migrateAnywayFailureRejected">The network rejected this transaction. Please contact support.</string>
     <string name="migrationComplete_migrateAnywayFailureError">Something went wrong while sending. Please contact support.</string>
     <string name="migrationComplete_migrateAnywayFailurePartial">Some but not all of this transaction\'s parts were sent. Please contact support.</string>
+    <string name="migrationComplete_residueTitle">You’ve moved to Ironwood</string>
+    <string name="migrationComplete_residueSubtitle">A small balance is still sitting in Orchard.</string>
+    <string name="migrationComplete_inIronwoodLabel">In Ironwood</string>
+    <string name="migrationComplete_leftInOrchardLabel">Left in Orchard</string>
+    <string name="migrationComplete_residueRecommendationBody">%1$s is still in Orchard. Moving an amount this specific would link your Ironwood funds back to your Orchard history. We recommend locking it instead.</string>
 
     <string name="migrationNotifPermission_title">Allow Notifications</string>
     <string name="migrationNotifPermission_subtitle">If a scheduled transfer is missed or a background submission fails, we can send you a local notification and prompt you to open Zodl. Get notified about:</string>
@@ -1484,5 +1489,7 @@ Your vote can no longer be submitted.</string>
     <string name="migrationHome_readyToSendTitle">Transfer Ready</string>
     <string name="migrationHome_attentionTitle">Migration plan needs update</string>
     <string name="migrationHome_defaultSubtitle">Move your funds to Ironwood.</string>
+    <string name="migrationHome_residueTitle">%1$s left in Orchard</string>
+    <string name="migrationHome_residueSubtitle">Tap to decide what happens to it</string>
 
 </resources>

--- a/ui-lib/src/main/java/co/electriccoin/zcash/di/ProviderModule.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/di/ProviderModule.kt
@@ -10,6 +10,7 @@ import co.electriccoin.zcash.ui.common.provider.CrashReportingStorageProvider
 import co.electriccoin.zcash.ui.common.provider.CrashReportingStorageProviderImpl
 import co.electriccoin.zcash.ui.common.provider.EphemeralAddressStorageProvider
 import co.electriccoin.zcash.ui.common.provider.EphemeralAddressStorageProviderImpl
+import co.electriccoin.zcash.ui.common.provider.GetMonotonicTimeProvider
 import co.electriccoin.zcash.ui.common.provider.GetVersionInfoProvider
 import co.electriccoin.zcash.ui.common.provider.GetZcashCurrencyProvider
 import co.electriccoin.zcash.ui.common.provider.HasSeenHowToVoteKeystoneStorageProvider
@@ -72,6 +73,7 @@ import org.koin.dsl.module
 val providerModule =
     module {
         factoryOf(::LightWalletEndpointProvider)
+        singleOf(::GetMonotonicTimeProvider)
         singleOf(::GetVersionInfoProvider)
         singleOf(::GetZcashCurrencyProvider)
         singleOf(::SelectedAccountUUIDProviderImpl) bind SelectedAccountUUIDProvider::class

--- a/ui-lib/src/main/java/co/electriccoin/zcash/di/UseCaseModule.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/di/UseCaseModule.kt
@@ -38,6 +38,7 @@ import co.electriccoin.zcash.ui.common.usecase.GetExchangeRateUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetFilteredActivitiesUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetFlexaStatusUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetHomeMessageUseCase
+import co.electriccoin.zcash.ui.common.usecase.GetIronwoodBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetKeystoneStatusUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetOrchardBalanceUseCase
 import co.electriccoin.zcash.ui.common.usecase.GetPersistableWalletUseCase
@@ -170,6 +171,7 @@ val useCaseModule =
         factoryOf(::Zip321ParseUriValidationUseCase)
         factoryOf(::GetPersistableWalletUseCase)
         factoryOf(::GetOrchardBalanceUseCase)
+        factoryOf(::GetIronwoodBalanceUseCase)
         factoryOf(::GetSupportUseCase)
         factoryOf(::GetWalletSeedBytesUseCase)
         factoryOf(::ErrorMapperUseCase)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/MainActivity.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/MainActivity.kt
@@ -125,7 +125,7 @@ class MainActivity : FragmentActivity() {
 
     override fun onStop() {
         Twig.debug { "Activity state: Stop" }
-        authenticationViewModel.persistGoToBackgroundTime(System.currentTimeMillis())
+        authenticationViewModel.onEnteredBackground()
         super.onStop()
     }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -18,7 +18,6 @@ import cash.z.ecc.android.sdk.model.proposeSend
 import cash.z.ecc.android.sdk.type.AddressType
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
 import co.electriccoin.zcash.spackle.Twig
-import co.electriccoin.zcash.ui.common.model.KeystoneAccount
 import co.electriccoin.zcash.ui.common.model.NetworkDimension
 import co.electriccoin.zcash.ui.common.model.SubmitResult
 import co.electriccoin.zcash.ui.common.model.SwapQuote
@@ -35,36 +34,20 @@ import org.zecdev.zip321.parser.ParserContext
 import java.math.BigDecimal
 
 interface ProposalDataSource {
-    @Throws(
-        TransactionProposalNotCreatedException::class,
-        InsufficientFundsException::class,
-        TexUnsupportedOnKSException::class
-    )
+    @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createProposal(account: WalletAccount, send: ZecSend): RegularTransactionProposal
 
-    @Throws(
-        TransactionProposalNotCreatedException::class,
-        InsufficientFundsException::class,
-        TexUnsupportedOnKSException::class
-    )
+    @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createZip321Proposal(account: WalletAccount, zip321Uri: String): Zip321TransactionProposal
 
-    @Throws(
-        TransactionProposalNotCreatedException::class,
-        InsufficientFundsException::class,
-        TexUnsupportedOnKSException::class
-    )
+    @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createExactInputProposal(
         account: WalletAccount,
         send: ZecSend,
         quote: SwapQuote,
     ): ExactInputSwapTransactionProposal
 
-    @Throws(
-        TransactionProposalNotCreatedException::class,
-        InsufficientFundsException::class,
-        TexUnsupportedOnKSException::class
-    )
+    @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createExactOutputProposal(
         account: WalletAccount,
         send: ZecSend,
@@ -74,7 +57,7 @@ interface ProposalDataSource {
     @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createShieldProposal(account: WalletAccount): ShieldTransactionProposal
 
-    @Throws(PcztException.CreatePcztFromProposalException::class)
+    @Throws(PcztException.CreatePcztFromProposalException::class, TexUnsupportedOnKSException::class)
     suspend fun createPcztFromProposal(account: WalletAccount, proposal: Proposal): Pczt
 
     @Throws(PcztException.AddProofsToPcztException::class)
@@ -92,7 +75,9 @@ class TransactionProposalNotCreatedException(
     cause: Exception
 ) : Exception(cause)
 
-class InsufficientFundsException : Exception()
+class InsufficientFundsException(
+    cause: Throwable? = null
+) : Exception(cause)
 
 class TexUnsupportedOnKSException : Exception("TEX addresses are unsupported on Keystone")
 
@@ -106,7 +91,6 @@ class ProposalDataSourceImpl(
     override suspend fun createProposal(account: WalletAccount, send: ZecSend): RegularTransactionProposal =
         withContext(Dispatchers.IO) {
             getOrThrow { synchronizer ->
-                validate(account, synchronizer, send.destination.address)
                 RegularTransactionProposal(
                     destination = send.destination,
                     amount = send.amount,
@@ -140,8 +124,6 @@ class ProposalDataSourceImpl(
                         )
                     }
 
-                validate(account, synchronizer, payment.recipientAddress.value)
-
                 if (payment.nonNegativeAmount == null) {
                     throw TransactionProposalNotCreatedException(IllegalArgumentException("Null amount"))
                 }
@@ -171,7 +153,6 @@ class ProposalDataSourceImpl(
     ): ExactInputSwapTransactionProposal =
         withContext(Dispatchers.IO) {
             getOrThrow { synchronizer ->
-                validate(account, synchronizer, send.destination.address)
                 ExactInputSwapTransactionProposal(
                     destination = send.destination,
                     amount = send.amount,
@@ -189,7 +170,6 @@ class ProposalDataSourceImpl(
     ): ExactOutputSwapTransactionProposal =
         withContext(Dispatchers.IO) {
             getOrThrow { synchronizer ->
-                validate(account, synchronizer, send.destination.address)
                 ExactOutputSwapTransactionProposal(
                     destination = send.destination,
                     amount = send.amount,
@@ -221,11 +201,14 @@ class ProposalDataSourceImpl(
 
     override suspend fun createPcztFromProposal(account: WalletAccount, proposal: Proposal): Pczt =
         withContext(Dispatchers.IO) {
-            val synchronizer = synchronizerProvider.getSynchronizer()
-            synchronizer.createPcztFromProposal(
-                accountUuid = account.sdkAccount.accountUuid,
-                proposal = proposal
-            )
+            try {
+                synchronizerProvider.getSynchronizer().createPcztFromProposal(
+                    accountUuid = account.sdkAccount.accountUuid,
+                    proposal = proposal
+                )
+            } catch (_: PcztException.MultiStepProposalUnsupportedException) {
+                throw TexUnsupportedOnKSException()
+            }
         }
 
     override suspend fun addProofsToPczt(pczt: Pczt): Pczt =
@@ -257,20 +240,6 @@ class ProposalDataSourceImpl(
                 .getSynchronizer()
                 .redactPcztForSigner(pczt)
         }
-
-    /**
-     * @throws TexUnsupportedOnKSException if the address is a TEX address and the account is a Keystone account
-     */
-    @Throws(TexUnsupportedOnKSException::class)
-    private suspend fun validate(
-        account: WalletAccount,
-        synchronizer: Synchronizer,
-        address: String
-    ) {
-        if (account is KeystoneAccount && synchronizer.validateAddress(address) == AddressType.Tex) {
-            throw TexUnsupportedOnKSException()
-        }
-    }
 
     @Suppress("CyclomaticComplexMethod", "TooGenericExceptionCaught")
     private suspend fun submitTransactionInternal(
@@ -355,17 +324,8 @@ class ProposalDataSourceImpl(
         try {
             val synchronizer = synchronizerProvider.getSynchronizer()
             block(synchronizer)
-        } catch (e: TransactionEncoderException.ProposalFromParametersException) {
-            val message = e.rootCause.message ?: ""
-            if (message.contains("Insufficient balance", true) ||
-                message.contains("The transaction requires an additional change output of", true)
-            ) {
-                throw InsufficientFundsException()
-            } else {
-                throw TransactionProposalNotCreatedException(e)
-            }
-        } catch (e: TexUnsupportedOnKSException) {
-            throw e
+        } catch (e: TransactionEncoderException.InsufficientFundsException) {
+            throw InsufficientFundsException(e)
         } catch (e: TransactionProposalNotCreatedException) {
             throw e
         } catch (e: Exception) {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSource.kt
@@ -57,7 +57,16 @@ interface ProposalDataSource {
     @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createShieldProposal(account: WalletAccount): ShieldTransactionProposal
 
-    @Throws(PcztException.CreatePcztFromProposalException::class, TexUnsupportedOnKSException::class)
+    /**
+     * Propagates the SDK's [PcztException.MultiStepProposalUnsupportedException] untouched: whether a
+     * multi-step rejection means "TEX is unsupported on Keystone" depends on what the proposal was
+     * for, which only the caller knows (see
+     * [co.electriccoin.zcash.ui.common.repository.KeystoneProposalRepository.createPCZTFromProposal]).
+     */
+    @Throws(
+        PcztException.CreatePcztFromProposalException::class,
+        PcztException.MultiStepProposalUnsupportedException::class
+    )
     suspend fun createPcztFromProposal(account: WalletAccount, proposal: Proposal): Pczt
 
     @Throws(PcztException.AddProofsToPcztException::class)
@@ -201,14 +210,10 @@ class ProposalDataSourceImpl(
 
     override suspend fun createPcztFromProposal(account: WalletAccount, proposal: Proposal): Pczt =
         withContext(Dispatchers.IO) {
-            try {
-                synchronizerProvider.getSynchronizer().createPcztFromProposal(
-                    accountUuid = account.sdkAccount.accountUuid,
-                    proposal = proposal
-                )
-            } catch (_: PcztException.MultiStepProposalUnsupportedException) {
-                throw TexUnsupportedOnKSException()
-            }
+            synchronizerProvider.getSynchronizer().createPcztFromProposal(
+                accountUuid = account.sdkAccount.accountUuid,
+                proposal = proposal
+            )
         }
 
     override suspend fun addProofsToPczt(pczt: Pczt): Pczt =

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/WalletAccount.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/WalletAccount.kt
@@ -174,3 +174,17 @@ data class SaplingInfo(
     val address: WalletAddress.Sapling,
     val balance: WalletBalance
 )
+
+/**
+ * The single spendability primitive the whole app validates against, so a typing-time check and the
+ * proposal-time check in the SDK can never disagree. A null receiver (no account selected yet) can
+ * spend nothing.
+ */
+fun WalletAccount?.canSpend(amount: Zatoshi): Boolean = this?.canSpend(amount) ?: false
+
+/**
+ * The spendable balance a screen may display for a possibly-not-yet-selected account, zero when no
+ * account is available.
+ */
+val WalletAccount?.totalSpendableBalance: Zatoshi
+    get() = this?.spendableShieldedBalance ?: Zatoshi(0)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/migration/MigrationDustThreshold.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/migration/MigrationDustThreshold.kt
@@ -9,7 +9,7 @@ package co.electriccoin.zcash.ui.common.model.migration
 // Lives in ui-lib (not feature-migration) so ui-lib-level callers -- e.g.
 // WalletViewModel.shouldShowIronwoodAnnouncement -- can share the same gate feature-migration
 // uses, instead of each module inventing its own threshold.
-const val MIGRATION_DUST_THRESHOLD_ZATOSHI = 100_000L
+const val MIGRATION_DUST_THRESHOLD_ZATOSHI = 10_000L
 
 // The smallest Orchard balance the migration engine will actually migrate. Mirrors librustzcash's
 // `RESIDUAL_MIGRATION_MIN` in `zcash_pool_migration/src/denomination.rs` (0.01 ZEC): below this,

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/GetMonotonicTimeProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/GetMonotonicTimeProvider.kt
@@ -1,0 +1,13 @@
+package co.electriccoin.zcash.ui.common.provider
+
+import android.os.SystemClock
+
+/**
+ * Provides a monotonic timestamp, i.e. milliseconds elapsed since boot (including deep sleep),
+ * via [SystemClock.elapsedRealtime]. Unlike [System.currentTimeMillis], this clock cannot be
+ * changed by the user, which makes it the only safe source of truth for security-relevant
+ * elapsed-time checks such as the app-lock re-authentication timeout.
+ */
+class GetMonotonicTimeProvider {
+    operator fun invoke() = SystemClock.elapsedRealtime()
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/KeystoneProposalRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/KeystoneProposalRepository.kt
@@ -45,32 +45,16 @@ interface KeystoneProposalRepository {
 
     val submitState: StateFlow<SubmitProposalState?>
 
-    @Throws(
-        TransactionProposalNotCreatedException::class,
-        InsufficientFundsException::class,
-        TexUnsupportedOnKSException::class
-    )
+    @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createProposal(zecSend: ZecSend)
 
-    @Throws(
-        TransactionProposalNotCreatedException::class,
-        InsufficientFundsException::class,
-        TexUnsupportedOnKSException::class
-    )
+    @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createExactInputSwapProposal(zecSend: ZecSend, quote: SwapQuote): ExactInputSwapTransactionProposal
 
-    @Throws(
-        TransactionProposalNotCreatedException::class,
-        InsufficientFundsException::class,
-        TexUnsupportedOnKSException::class
-    )
+    @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createExactOutputSwapProposal(zecSend: ZecSend, quote: SwapQuote): ExactOutputSwapTransactionProposal
 
-    @Throws(
-        TransactionProposalNotCreatedException::class,
-        InsufficientFundsException::class,
-        TexUnsupportedOnKSException::class
-    )
+    @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
     suspend fun createZip321Proposal(zip321Uri: String): Zip321TransactionProposal
 
     @Throws(TransactionProposalNotCreatedException::class, InsufficientFundsException::class)
@@ -83,7 +67,7 @@ interface KeystoneProposalRepository {
      */
     fun setMigrationSweepProposal(proposal: Proposal, amount: Zatoshi)
 
-    @Throws(PcztException.CreatePcztFromProposalException::class)
+    @Throws(PcztException.CreatePcztFromProposalException::class, TexUnsupportedOnKSException::class)
     suspend fun createPCZTFromProposal()
 
     @Throws(IllegalStateException::class)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/KeystoneProposalRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/KeystoneProposalRepository.kt
@@ -219,8 +219,9 @@ class KeystoneProposalRepositoryImpl(
                 try {
                     val result = proposalDataSource.addProofsToPczt(proposalPczt.clonePczt())
                     pcztWithProofs.update { PcztState(isLoading = false, pczt = result) }
-                } catch (_: PcztException.AddProofsToPcztException) {
-                    pcztWithProofs.update { PcztState(isLoading = false, pczt = null) }
+                } catch (e: PcztException.AddProofsToPcztException) {
+                    Twig.error(e) { "Failed to add proofs to PCZT" }
+                    pcztWithProofs.update { PcztState(isLoading = false, pczt = null, error = e) }
                 }
             }
     }
@@ -276,9 +277,12 @@ class KeystoneProposalRepositoryImpl(
                     throw cause
                 } else {
                     submitState.update { SubmitProposalState.Submitting }
-                    val pcztWithProofs = pcztWithProofs.filter { !it.isLoading }.first().pczt
+                    val pcztWithProofsState = pcztWithProofs.filter { !it.isLoading }.first()
+                    val pcztWithProofs = pcztWithProofsState.pczt
                     if (pcztWithProofs == null) {
-                        val cause = IllegalStateException("PCZT with proofs is null")
+                        val cause =
+                            pcztWithProofsState.error
+                                ?: IllegalStateException("PCZT with proofs is null")
                         submitState.update { SubmitProposalState.Result(SubmitResult.Error(cause)) }
                         throw cause
                     } else {
@@ -334,5 +338,6 @@ class KeystoneProposalRepositoryImpl(
 
 private data class PcztState(
     val isLoading: Boolean,
-    val pczt: Pczt?
+    val pczt: Pczt?,
+    val error: Exception? = null
 )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/KeystoneProposalRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/KeystoneProposalRepository.kt
@@ -3,6 +3,7 @@ package co.electriccoin.zcash.ui.common.repository
 import cash.z.ecc.android.sdk.exception.PcztException
 import cash.z.ecc.android.sdk.model.Pczt
 import cash.z.ecc.android.sdk.model.Proposal
+import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.model.ZecSend
 import co.electriccoin.zcash.spackle.Twig
@@ -12,6 +13,7 @@ import co.electriccoin.zcash.ui.common.datasource.ExactOutputSwapTransactionProp
 import co.electriccoin.zcash.ui.common.datasource.InsufficientFundsException
 import co.electriccoin.zcash.ui.common.datasource.MigrationSweepTransactionProposal
 import co.electriccoin.zcash.ui.common.datasource.ProposalDataSource
+import co.electriccoin.zcash.ui.common.datasource.SendTransactionProposal
 import co.electriccoin.zcash.ui.common.datasource.TexUnsupportedOnKSException
 import co.electriccoin.zcash.ui.common.datasource.TransactionProposal
 import co.electriccoin.zcash.ui.common.datasource.TransactionProposalNotCreatedException
@@ -67,7 +69,19 @@ interface KeystoneProposalRepository {
      */
     fun setMigrationSweepProposal(proposal: Proposal, amount: Zatoshi)
 
-    @Throws(PcztException.CreatePcztFromProposalException::class, TexUnsupportedOnKSException::class)
+    /**
+     * The SDK rejects any multi-step proposal for PCZT generation. That rejection is surfaced as
+     * [TexUnsupportedOnKSException] only when the current proposal actually pays a TEX (ZIP-320)
+     * address — the one flow where a multi-step proposal is the expected shape. For every other
+     * proposal (shielding, migration sweeps), the raw
+     * [PcztException.MultiStepProposalUnsupportedException] propagates so a TEX-specific error can
+     * never be shown for a failure unrelated to TEX.
+     */
+    @Throws(
+        PcztException.CreatePcztFromProposalException::class,
+        PcztException.MultiStepProposalUnsupportedException::class,
+        TexUnsupportedOnKSException::class
+    )
     suspend fun createPCZTFromProposal()
 
     @Throws(IllegalStateException::class)
@@ -186,14 +200,22 @@ class KeystoneProposalRepositoryImpl(
     }
 
     override suspend fun createPCZTFromProposal() {
+        val transactionProposal = getTransactionProposal()
         val result =
-            proposalDataSource.createPcztFromProposal(
-                account = accountDataSource.getSelectedAccount(),
-                proposal = getTransactionProposal().proposal
-            )
+            try {
+                proposalDataSource.createPcztFromProposal(
+                    account = accountDataSource.getSelectedAccount(),
+                    proposal = transactionProposal.proposal
+                )
+            } catch (e: PcztException.MultiStepProposalUnsupportedException) {
+                if (transactionProposal.paysTexAddress()) throw TexUnsupportedOnKSException() else throw e
+            }
         proposalPczt = result
         addProofsToPczt(result)
     }
+
+    private fun TransactionProposal.paysTexAddress(): Boolean =
+        this is SendTransactionProposal && destination is WalletAddress.Tex
 
     private fun addProofsToPczt(proposalPczt: Pczt) {
         pcztWithProofsJob?.cancel()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/WalletRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/WalletRepository.kt
@@ -11,6 +11,7 @@ import cash.z.ecc.sdk.ANDROID_STATE_FLOW_TIMEOUT
 import cash.z.ecc.sdk.type.fromResources
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
 import co.electriccoin.zcash.preference.StandardPreferenceProvider
+import co.electriccoin.zcash.spackle.Twig
 import co.electriccoin.zcash.ui.common.datasource.RestoreTimestampDataSource
 import co.electriccoin.zcash.ui.common.model.FastestServersState
 import co.electriccoin.zcash.ui.common.model.OnboardingState
@@ -196,8 +197,15 @@ class WalletRepositoryImpl(
                 initialValue = WalletRestoringState.NONE
             )
 
+    @Suppress("TooGenericExceptionCaught")
     override fun init() {
-        scope.launch { migrateDecommissionedEndpointIfNeeded() }
+        scope.launch {
+            try {
+                migrateDecommissionedEndpointIfNeeded()
+            } catch (e: Exception) {
+                Twig.error(e) { "Decommissioned endpoint migration failed; will retry on next launch" }
+            }
+        }
     }
 
     private suspend fun migrateDecommissionedEndpointIfNeeded() {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetIronwoodBalanceUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetIronwoodBalanceUseCase.kt
@@ -1,0 +1,33 @@
+package co.electriccoin.zcash.ui.common.usecase
+
+import cash.z.ecc.android.sdk.model.Zatoshi
+import cash.z.ecc.sdk.extension.ZERO
+import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
+import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+
+/**
+ * The live Ironwood pool balance for the currently selected wallet account, read straight from
+ * the synchronizer (mirrors [GetOrchardBalanceUseCase]'s pattern) rather than reconstructed from
+ * the migration engine's own campaign-scoped bookkeeping
+ * ([cash.z.ecc.android.sdk.OrchardMigrationSdk.getMigrationSummary]).
+ *
+ * `total + locked`, matching [GetBalancePoolsUseCase]'s display semantics (see its kdoc for why
+ * `locked` must be added back in) — this is "what the user currently owns in Ironwood", not "how
+ * much this app's migration engine has moved there", which is a real but narrower fact that can
+ * read zero/stale when the engine's own tracking doesn't have a row for it (e.g. after a debug
+ * migration restart, or funds that arrived in Ironwood some other way).
+ */
+class GetIronwoodBalanceUseCase(
+    private val synchronizerProvider: SynchronizerProvider,
+    private val accountDataSource: AccountDataSource,
+) {
+    suspend operator fun invoke(): Zatoshi {
+        synchronizerProvider.getSynchronizer()
+        val account = accountDataSource.getSelectedAccount()
+        val balances = synchronizerProvider.walletBalances.filterNotNull().first()
+        val ironwood = balances[account.sdkAccount.accountUuid]?.ironwood ?: return Zatoshi.ZERO
+        return ironwood.total + ironwood.locked
+    }
+}

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
@@ -1,5 +1,6 @@
 package co.electriccoin.zcash.ui.common.usecase
 
+import cash.z.ecc.android.sdk.ext.convertZecToZatoshi
 import cash.z.ecc.android.sdk.model.Memo
 import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.model.Zatoshi
@@ -47,6 +48,11 @@ class RequestSwapQuoteUseCase(
         slippage: BigDecimal,
         canNavigateToSwapQuote: () -> Boolean
     ) {
+        if (!accountDataSource.getSelectedAccount().canSpend(amount.convertZecToZatoshi())) {
+            navigationRouter.forward(InsufficientFundsArgs)
+            return
+        }
+
         val newAddress = accountDataSource.requestNextShieldedAddress()
         requestQuote(
             requestQuote = {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
@@ -24,14 +24,12 @@ import co.electriccoin.zcash.ui.common.repository.ZashiProposalRepository
 import co.electriccoin.zcash.ui.screen.error.ErrorArgs
 import co.electriccoin.zcash.ui.screen.error.NavigateToErrorUseCase
 import co.electriccoin.zcash.ui.screen.insufficientfunds.InsufficientFundsArgs
-import co.electriccoin.zcash.ui.screen.swap.convertZecToZatoshi
 import co.electriccoin.zcash.ui.screen.swap.quote.SwapQuoteArgs
 import co.electriccoin.zcash.ui.screen.texunsupported.TEXUnsupportedArgs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import java.math.BigDecimal
-import java.math.MathContext
 
 class RequestSwapQuoteUseCase(
     private val navigationRouter: NavigationRouter,
@@ -42,13 +40,6 @@ class RequestSwapQuoteUseCase(
     private val accountDataSource: AccountDataSource,
     private val synchronizerProvider: SynchronizerProvider,
 ) {
-    /**
-     * The balance pre-check here is a best-effort fast path against a snapshot of the selected
-     * account: it saves the address rotation and the provider round-trip when the amount is plainly
-     * unaffordable. The authoritative check is the SDK's typed insufficient-funds failure at
-     * proposal time, which is evaluated against the account the proposal is actually built for and
-     * lands on the same Insufficient Funds sheet.
-     */
     suspend fun requestExactInput(
         amount: BigDecimal,
         address: String,
@@ -56,14 +47,6 @@ class RequestSwapQuoteUseCase(
         slippage: BigDecimal,
         canNavigateToSwapQuote: () -> Boolean
     ) {
-        if (!accountDataSource.getSelectedAccount().canSpend(amount.convertZecToZatoshi())) {
-            swapRepository.clearQuote()
-            zashiProposalRepository.clear()
-            keystoneProposalRepository.clear()
-            navigationRouter.forward(InsufficientFundsArgs)
-            return
-        }
-
         val newAddress = accountDataSource.requestNextShieldedAddress()
         requestQuote(
             requestQuote = {
@@ -80,19 +63,6 @@ class RequestSwapQuoteUseCase(
         )
     }
 
-    /**
-     * The balance pre-check here is a best-effort fast path against a snapshot of the selected
-     * account: it saves the address rotation and the provider round-trip when the amount is plainly
-     * unaffordable. The authoritative check is the SDK's typed insufficient-funds failure at
-     * proposal time, which is evaluated against the account the proposal is actually built for and
-     * lands on the same Insufficient Funds sheet.
-     *
-     * Unlike [requestExactInput], [amount] here is denominated in [selectedAsset]'s units, not ZEC
-     * (it is the destination amount the caller typed in), so it must go through the same USD
-     * cross-rate conversion as the pre-quote ZEC estimate before the check can run at all. When the
-     * ZEC or destination asset price isn't loaded yet, the pre-check is skipped rather than blocking
-     * on an unpriced amount, leaving the authoritative proposal-time check to decide.
-     */
     suspend fun requestExactOutput(
         amount: BigDecimal,
         address: String,
@@ -100,15 +70,6 @@ class RequestSwapQuoteUseCase(
         slippage: BigDecimal,
         canNavigateToSwapQuote: () -> Boolean
     ) {
-        val destinationZatoshi = amount.toDestinationAssetZatoshi(selectedAsset)
-        if (destinationZatoshi != null && !accountDataSource.getSelectedAccount().canSpend(destinationZatoshi)) {
-            swapRepository.clearQuote()
-            zashiProposalRepository.clear()
-            keystoneProposalRepository.clear()
-            navigationRouter.forward(InsufficientFundsArgs)
-            return
-        }
-
         val newAddress = accountDataSource.requestNextShieldedAddress()
         requestQuote(
             requestQuote = {
@@ -215,26 +176,6 @@ class RequestSwapQuoteUseCase(
                     FLEX_INPUT -> throw UnsupportedOperationException("Flex input swap not supported")
                 }
             }
-        }
-    }
-
-    /**
-     * Converts an amount denominated in [destinationAsset]'s units into the ZEC it costs to buy, via
-     * the same USD cross-rate [co.electriccoin.zcash.ui.screen.pay.ExactOutputVMMapper] already uses
-     * for its own zatoshi estimate, then clamps it to zatoshi through [convertZecToZatoshi]. Returns
-     * null when either price isn't loaded yet.
-     */
-    private fun BigDecimal.toDestinationAssetZatoshi(destinationAsset: SwapAsset): Zatoshi? {
-        val zecPrice =
-            swapRepository.assets.value.zecAsset
-                ?.usdPrice
-        val assetPrice = destinationAsset.usdPrice
-        return if (zecPrice == null || assetPrice == null) {
-            null
-        } else {
-            multiply(assetPrice, MathContext.DECIMAL128)
-                .divide(zecPrice, MathContext.DECIMAL128)
-                .convertZecToZatoshi()
         }
     }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import java.math.BigDecimal
+import java.math.MathContext
 
 class RequestSwapQuoteUseCase(
     private val navigationRouter: NavigationRouter,
@@ -85,6 +86,12 @@ class RequestSwapQuoteUseCase(
      * unaffordable. The authoritative check is the SDK's typed insufficient-funds failure at
      * proposal time, which is evaluated against the account the proposal is actually built for and
      * lands on the same Insufficient Funds sheet.
+     *
+     * Unlike [requestExactInput], [amount] here is denominated in [selectedAsset]'s units, not ZEC
+     * (it is the destination amount the caller typed in), so it must go through the same USD
+     * cross-rate conversion as the pre-quote ZEC estimate before the check can run at all. When the
+     * ZEC or destination asset price isn't loaded yet, the pre-check is skipped rather than blocking
+     * on an unpriced amount, leaving the authoritative proposal-time check to decide.
      */
     suspend fun requestExactOutput(
         amount: BigDecimal,
@@ -93,7 +100,8 @@ class RequestSwapQuoteUseCase(
         slippage: BigDecimal,
         canNavigateToSwapQuote: () -> Boolean
     ) {
-        if (!accountDataSource.getSelectedAccount().canSpend(amount.convertZecToZatoshi())) {
+        val destinationZatoshi = amount.toDestinationAssetZatoshi(selectedAsset)
+        if (destinationZatoshi != null && !accountDataSource.getSelectedAccount().canSpend(destinationZatoshi)) {
             swapRepository.clearQuote()
             zashiProposalRepository.clear()
             keystoneProposalRepository.clear()
@@ -207,6 +215,26 @@ class RequestSwapQuoteUseCase(
                     FLEX_INPUT -> throw UnsupportedOperationException("Flex input swap not supported")
                 }
             }
+        }
+    }
+
+    /**
+     * Converts an amount denominated in [destinationAsset]'s units into the ZEC it costs to buy, via
+     * the same USD cross-rate [co.electriccoin.zcash.ui.screen.pay.ExactOutputVMMapper] already uses
+     * for its own zatoshi estimate, then clamps it to zatoshi through [convertZecToZatoshi]. Returns
+     * null when either price isn't loaded yet.
+     */
+    private fun BigDecimal.toDestinationAssetZatoshi(destinationAsset: SwapAsset): Zatoshi? {
+        val zecPrice =
+            swapRepository.assets.value.zecAsset
+                ?.usdPrice
+        val assetPrice = destinationAsset.usdPrice
+        return if (zecPrice == null || assetPrice == null) {
+            null
+        } else {
+            multiply(assetPrice, MathContext.DECIMAL128)
+                .divide(zecPrice, MathContext.DECIMAL128)
+                .convertZecToZatoshi()
         }
     }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
@@ -79,6 +79,13 @@ class RequestSwapQuoteUseCase(
         )
     }
 
+    /**
+     * The balance pre-check here is a best-effort fast path against a snapshot of the selected
+     * account: it saves the address rotation and the provider round-trip when the amount is plainly
+     * unaffordable. The authoritative check is the SDK's typed insufficient-funds failure at
+     * proposal time, which is evaluated against the account the proposal is actually built for and
+     * lands on the same Insufficient Funds sheet.
+     */
     suspend fun requestExactOutput(
         amount: BigDecimal,
         address: String,
@@ -86,6 +93,14 @@ class RequestSwapQuoteUseCase(
         slippage: BigDecimal,
         canNavigateToSwapQuote: () -> Boolean
     ) {
+        if (!accountDataSource.getSelectedAccount().canSpend(amount.convertZecToZatoshi())) {
+            swapRepository.clearQuote()
+            zashiProposalRepository.clear()
+            keystoneProposalRepository.clear()
+            navigationRouter.forward(InsufficientFundsArgs)
+            return
+        }
+
         val newAddress = accountDataSource.requestNextShieldedAddress()
         requestQuote(
             requestQuote = {
@@ -140,9 +155,11 @@ class RequestSwapQuoteUseCase(
             try {
                 createProposal(result.quote)
             } catch (_: TexUnsupportedOnKSException) {
-                navigationRouter.forward(TEXUnsupportedArgs)
-                keystoneProposalRepository.clear()
+                swapRepository.clearQuote()
                 zashiProposalRepository.clear()
+                keystoneProposalRepository.clear()
+                navigationRouter.forward(TEXUnsupportedArgs)
+                return@withContext
             } catch (_: InsufficientFundsException) {
                 swapRepository.clearQuote()
                 zashiProposalRepository.clear()

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
@@ -1,6 +1,5 @@
 package co.electriccoin.zcash.ui.common.usecase
 
-import cash.z.ecc.android.sdk.ext.convertZecToZatoshi
 import cash.z.ecc.android.sdk.model.Memo
 import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.model.Zatoshi
@@ -25,6 +24,7 @@ import co.electriccoin.zcash.ui.common.repository.ZashiProposalRepository
 import co.electriccoin.zcash.ui.screen.error.ErrorArgs
 import co.electriccoin.zcash.ui.screen.error.NavigateToErrorUseCase
 import co.electriccoin.zcash.ui.screen.insufficientfunds.InsufficientFundsArgs
+import co.electriccoin.zcash.ui.screen.swap.convertZecToZatoshi
 import co.electriccoin.zcash.ui.screen.swap.quote.SwapQuoteArgs
 import co.electriccoin.zcash.ui.screen.texunsupported.TEXUnsupportedArgs
 import kotlinx.coroutines.Dispatchers
@@ -41,6 +41,13 @@ class RequestSwapQuoteUseCase(
     private val accountDataSource: AccountDataSource,
     private val synchronizerProvider: SynchronizerProvider,
 ) {
+    /**
+     * The balance pre-check here is a best-effort fast path against a snapshot of the selected
+     * account: it saves the address rotation and the provider round-trip when the amount is plainly
+     * unaffordable. The authoritative check is the SDK's typed insufficient-funds failure at
+     * proposal time, which is evaluated against the account the proposal is actually built for and
+     * lands on the same Insufficient Funds sheet.
+     */
     suspend fun requestExactInput(
         amount: BigDecimal,
         address: String,
@@ -49,6 +56,9 @@ class RequestSwapQuoteUseCase(
         canNavigateToSwapQuote: () -> Boolean
     ) {
         if (!accountDataSource.getSelectedAccount().canSpend(amount.convertZecToZatoshi())) {
+            swapRepository.clearQuote()
+            zashiProposalRepository.clear()
+            keystoneProposalRepository.clear()
             navigationRouter.forward(InsufficientFundsArgs)
             return
         }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/AuthenticationViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/AuthenticationViewModel.kt
@@ -15,6 +15,7 @@ import co.electriccoin.zcash.preference.model.entry.BooleanPreferenceDefault
 import co.electriccoin.zcash.spackle.AndroidApiVersion
 import co.electriccoin.zcash.spackle.Twig
 import co.electriccoin.zcash.ui.R
+import co.electriccoin.zcash.ui.common.provider.GetMonotonicTimeProvider
 import co.electriccoin.zcash.ui.common.provider.GetVersionInfoProvider
 import co.electriccoin.zcash.ui.preference.StandardPreferenceKeys
 import co.electriccoin.zcash.ui.screen.authentication.AuthenticationUseCase
@@ -40,6 +41,7 @@ private val AUTHENTICATE_TIMEOUT = 15.minutes.inWholeMilliseconds
 class AuthenticationViewModel(
     application: Application,
     private val biometricManager: BiometricManager,
+    private val getMonotonicTime: GetMonotonicTimeProvider,
     private val getVersionInfo: GetVersionInfoProvider,
     private val standardPreferenceProvider: StandardPreferenceProvider,
     private val walletViewModel: WalletViewModel,
@@ -143,20 +145,19 @@ class AuthenticationViewModel(
         showWelcomeAnimation.value = true
     }
 
-    fun runAuthenticationRequiredCheck() =
-        viewModelScope.launch {
-            val latestAppBackgroundedTimeMillis =
-                StandardPreferenceKeys.LATEST_APP_BACKGROUND_TIME_MILLIS.getValue(standardPreferenceProvider())
+    private var latestAppBackgroundedElapsedRealtimeMillis: Long? = null
 
-            if ((System.currentTimeMillis() - latestAppBackgroundedTimeMillis) > AUTHENTICATE_TIMEOUT) {
-                resetEntireAuthenticationState()
-            }
-        }
+    fun runAuthenticationRequiredCheck() {
+        val latestAppBackgroundedElapsedRealtimeMillis = latestAppBackgroundedElapsedRealtimeMillis ?: return
 
-    fun persistGoToBackgroundTime(millis: Long) =
-        viewModelScope.launch {
-            StandardPreferenceKeys.LATEST_APP_BACKGROUND_TIME_MILLIS.putValue(standardPreferenceProvider(), millis)
+        if ((getMonotonicTime() - latestAppBackgroundedElapsedRealtimeMillis) > AUTHENTICATE_TIMEOUT) {
+            resetEntireAuthenticationState()
         }
+    }
+
+    fun onEnteredBackground() {
+        latestAppBackgroundedElapsedRealtimeMillis = getMonotonicTime()
+    }
 
     /**
      * Authentication framework result

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/preference/StandardPreferenceKeys.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/preference/StandardPreferenceKeys.kt
@@ -2,7 +2,6 @@ package co.electriccoin.zcash.ui.preference
 
 import co.electriccoin.zcash.preference.model.entry.BooleanPreferenceDefault
 import co.electriccoin.zcash.preference.model.entry.IntegerPreferenceDefault
-import co.electriccoin.zcash.preference.model.entry.LongPreferenceDefault
 import co.electriccoin.zcash.preference.model.entry.PreferenceKey
 import co.electriccoin.zcash.ui.common.model.OnboardingState
 
@@ -31,10 +30,5 @@ object StandardPreferenceKeys {
         BooleanPreferenceDefault(
             PreferenceKey("IS_HIDE_BALANCES"),
             false
-        )
-    val LATEST_APP_BACKGROUND_TIME_MILLIS =
-        LongPreferenceDefault(
-            PreferenceKey("LATEST_APP_BACKGROUND_TIME_MILLIS"),
-            Long.MAX_VALUE
         )
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/migration/MigrationMessage.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/migration/MigrationMessage.kt
@@ -203,6 +203,25 @@ private fun PreviewComplete() =
 
 @PreviewScreens
 @Composable
+private fun PreviewCompleteResidue() =
+    ZcashTheme {
+        BlankSurface {
+            MigrationMessage(
+                contentPadding = PaddingValues(),
+                state =
+                    MigrationMessageState(
+                        phase = MigrationBannerPhase.COMPLETE,
+                        title = "0.008 ZEC left in Orchard",
+                        progressLabel = "Tap to decide what happens to it",
+                        onClick = {},
+                        onButtonClick = {},
+                    ),
+            )
+        }
+    }
+
+@PreviewScreens
+@Composable
 private fun PreviewReadyToSend() =
     ZcashTheme {
         BlankSurface {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/ExactOutputVMMapper.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/ExactOutputVMMapper.kt
@@ -103,7 +103,7 @@ internal class ExactOutputVMMapper {
         return stringResByDynamicCurrencyNumber(state.getZec() ?: BigDecimal(0), CURRENCY_TICKER).withStyle(
             StyledStringStyle(
                 color =
-                    if (zatoshi != null && state.totalSpendableBalance < zatoshi) {
+                    if (zatoshi != null && !state.canSpend(zatoshi)) {
                         StringResourceColor.HINT_ERROR
                     } else {
                         StringResourceColor.PRIMARY
@@ -137,7 +137,7 @@ internal class ExactOutputVMMapper {
 
     private fun createAmountErrorState(state: ExactOutputInternalState): StringResource? {
         val zatoshi = state.getZatoshi()
-        return if (zatoshi != null && state.totalSpendableBalance < zatoshi) {
+        return if (zatoshi != null && !state.canSpend(zatoshi)) {
             stringRes(R.string.send_error_insufficientFunds)
         } else {
             null
@@ -181,7 +181,7 @@ internal class ExactOutputVMMapper {
             },
             isEnabled = !state.isRequestingQuote,
             explicitError =
-                if (zatoshi != null && state.totalSpendableBalance < zatoshi) {
+                if (zatoshi != null && !state.canSpend(zatoshi)) {
                     stringRes("")
                 } else {
                     null
@@ -223,7 +223,7 @@ internal class ExactOutputVMMapper {
             },
             isEnabled = !state.isRequestingQuote,
             explicitError =
-                if (zatoshi != null && state.totalSpendableBalance < zatoshi) {
+                if (zatoshi != null && !state.canSpend(zatoshi)) {
                     stringRes("")
                 } else {
                     null

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/ExactOutputVMMapper.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/ExactOutputVMMapper.kt
@@ -98,19 +98,17 @@ internal class ExactOutputVMMapper {
         )
     }
 
-    private fun createZecAmount(state: ExactOutputInternalState): StyledStringResource {
-        val zatoshi = state.getZatoshi()
-        return stringResByDynamicCurrencyNumber(state.getZec() ?: BigDecimal(0), CURRENCY_TICKER).withStyle(
+    private fun createZecAmount(state: ExactOutputInternalState): StyledStringResource =
+        stringResByDynamicCurrencyNumber(state.getZec() ?: BigDecimal(0), CURRENCY_TICKER).withStyle(
             StyledStringStyle(
                 color =
-                    if (zatoshi != null && !state.canSpend(zatoshi)) {
+                    if (state.isInsufficientFunds) {
                         StringResourceColor.HINT_ERROR
                     } else {
                         StringResourceColor.PRIMARY
                     }
             )
         )
-    }
 
     fun createFiatAmountInnerState(
         amountInnerState: NumberTextFieldInnerState,
@@ -135,21 +133,18 @@ internal class ExactOutputVMMapper {
         )
     }
 
-    private fun createAmountErrorState(state: ExactOutputInternalState): StringResource? {
-        val zatoshi = state.getZatoshi()
-        return if (zatoshi != null && !state.canSpend(zatoshi)) {
+    private fun createAmountErrorState(state: ExactOutputInternalState): StringResource? =
+        if (state.isInsufficientFunds) {
             stringRes(R.string.send_error_insufficientFunds)
         } else {
             null
         }
-    }
 
     private fun createAmountState(
         state: ExactOutputInternalState,
         onTextFieldChange: (amount: NumberTextFieldInnerState, fiat: NumberTextFieldInnerState) -> Unit,
-    ): NumberTextFieldState {
-        val zatoshi = state.getZatoshi()
-        return NumberTextFieldState(
+    ): NumberTextFieldState =
+        NumberTextFieldState(
             innerState = state.amount,
             onValueChange = { amountInnerState ->
                 val amount = amountInnerState.amount
@@ -181,20 +176,18 @@ internal class ExactOutputVMMapper {
             },
             isEnabled = !state.isRequestingQuote,
             explicitError =
-                if (zatoshi != null && !state.canSpend(zatoshi)) {
+                if (state.isInsufficientFunds) {
                     stringRes("")
                 } else {
                     null
                 }
         )
-    }
 
     private fun createFiatAmountState(
         state: ExactOutputInternalState,
         onTextFieldChange: (amount: NumberTextFieldInnerState, fiat: NumberTextFieldInnerState) -> Unit,
-    ): NumberTextFieldState {
-        val zatoshi = state.getZatoshi()
-        return NumberTextFieldState(
+    ): NumberTextFieldState =
+        NumberTextFieldState(
             innerState = state.fiatAmount,
             onValueChange = { fiatInnerState ->
                 val fiat = fiatInnerState.amount
@@ -223,13 +216,12 @@ internal class ExactOutputVMMapper {
             },
             isEnabled = !state.isRequestingQuote,
             explicitError =
-                if (zatoshi != null && !state.canSpend(zatoshi)) {
+                if (state.isInsufficientFunds) {
                     stringRes("")
                 } else {
                     null
                 }
         )
-    }
 
     private fun createAssetState(
         state: ExactOutputInternalState,
@@ -418,6 +410,13 @@ private data class ExactOutputInternalState(
         isABHintVisible = original.isABHintVisible,
         isEphemeralAddressLocked = original.isEphemeralAddressLocked
     )
+
+    /**
+     * The one insufficient-funds signal every facet of this screen (ZEC amount color, error label,
+     * both text fields) renders from, computed once per state instance so the rule can never drift
+     * between them.
+     */
+    val isInsufficientFunds: Boolean = getZatoshi()?.let { !canSpend(it) } == true
 
     fun getOriginFiatAmount(): BigDecimal? {
         val tokenAmount = amount.amount

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayVM.kt
@@ -317,6 +317,13 @@ internal interface InternalState {
 
     val totalSpendableBalance: Zatoshi
         get() = account?.spendableShieldedBalance ?: Zatoshi(0)
+
+    /**
+     * The single spendability primitive the whole app validates against, so the typing-time check and
+     * the proposal-time check in the SDK can never disagree. Re-evaluated whenever the selected
+     * account emits a new balance.
+     */
+    fun canSpend(amount: Zatoshi): Boolean = account?.canSpend(amount) ?: false
 }
 
 internal data class InternalStateImpl(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayVM.kt
@@ -9,6 +9,8 @@ import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.model.SwapAsset
 import co.electriccoin.zcash.ui.common.model.SwapMode
 import co.electriccoin.zcash.ui.common.model.WalletAccount
+import co.electriccoin.zcash.ui.common.model.canSpend
+import co.electriccoin.zcash.ui.common.model.totalSpendableBalance
 import co.electriccoin.zcash.ui.common.repository.DEFAULT_SLIPPAGE
 import co.electriccoin.zcash.ui.common.repository.EnhancedABContact
 import co.electriccoin.zcash.ui.common.repository.SwapAssetsData
@@ -316,14 +318,13 @@ internal interface InternalState {
     val isEphemeralAddressLocked: Boolean
 
     val totalSpendableBalance: Zatoshi
-        get() = account?.spendableShieldedBalance ?: Zatoshi(0)
+        get() = account.totalSpendableBalance
 
     /**
-     * The single spendability primitive the whole app validates against, so the typing-time check and
-     * the proposal-time check in the SDK can never disagree. Re-evaluated whenever the selected
-     * account emits a new balance.
+     * Delegates to the shared [co.electriccoin.zcash.ui.common.model.canSpend] primitive.
+     * Re-evaluated whenever the selected account emits a new balance.
      */
-    fun canSpend(amount: Zatoshi): Boolean = account?.canSpend(amount) ?: false
+    fun canSpend(amount: Zatoshi): Boolean = account.canSpend(amount)
 }
 
 internal data class InternalStateImpl(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVM.kt
@@ -374,6 +374,14 @@ internal interface InternalState {
 
     val totalSpendableBalance: Zatoshi
         get() = account?.spendableShieldedBalance ?: Zatoshi(0)
+
+    /**
+     * The single spendability primitive the whole app validates against, so the typing-time check and
+     * the pre-quote check in
+     * [co.electriccoin.zcash.ui.common.usecase.RequestSwapQuoteUseCase.requestExactInput] can never
+     * disagree. Re-evaluated whenever the selected account emits a new balance.
+     */
+    fun canSpend(amount: Zatoshi): Boolean = account?.canSpend(amount) ?: false
 }
 
 internal data class InternalStateImpl(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVM.kt
@@ -12,6 +12,8 @@ import co.electriccoin.zcash.ui.common.model.SwapDirection.SWAP_FROM_ZEC
 import co.electriccoin.zcash.ui.common.model.SwapDirection.SWAP_INTO_ZEC
 import co.electriccoin.zcash.ui.common.model.SwapMode
 import co.electriccoin.zcash.ui.common.model.WalletAccount
+import co.electriccoin.zcash.ui.common.model.canSpend
+import co.electriccoin.zcash.ui.common.model.totalSpendableBalance
 import co.electriccoin.zcash.ui.common.repository.DEFAULT_SLIPPAGE
 import co.electriccoin.zcash.ui.common.repository.EnhancedABContact
 import co.electriccoin.zcash.ui.common.repository.SwapAssetsData
@@ -373,15 +375,15 @@ internal interface InternalState {
     val isEphemeralAddressLocked: Boolean
 
     val totalSpendableBalance: Zatoshi
-        get() = account?.spendableShieldedBalance ?: Zatoshi(0)
+        get() = account.totalSpendableBalance
 
     /**
-     * The single spendability primitive the whole app validates against, so the typing-time check and
-     * the pre-quote check in
-     * [co.electriccoin.zcash.ui.common.usecase.RequestSwapQuoteUseCase.requestExactInput] can never
-     * disagree. Re-evaluated whenever the selected account emits a new balance.
+     * Delegates to the shared [co.electriccoin.zcash.ui.common.model.canSpend] primitive — the same
+     * one the pre-quote check in
+     * [co.electriccoin.zcash.ui.common.usecase.RequestSwapQuoteUseCase.requestExactInput] validates
+     * against. Re-evaluated whenever the selected account emits a new balance.
      */
-    fun canSpend(amount: Zatoshi): Boolean = account?.canSpend(amount) ?: false
+    fun canSpend(amount: Zatoshi): Boolean = account.canSpend(amount)
 }
 
 internal data class InternalStateImpl(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVMMapper.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVMMapper.kt
@@ -161,9 +161,7 @@ internal class SwapVMMapper {
             error =
                 when (state.swapDirection) {
                     SWAP_FROM_ZEC -> {
-                        if (originAmount != null &&
-                            state.totalSpendableBalance.value < originAmount.convertZecToZatoshi().value
-                        ) {
+                        if (originAmount != null && !state.canSpend(originAmount.convertZecToZatoshi())) {
                             stringRes(R.string.send_error_insufficientFunds)
                         } else {
                             null

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSourceTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSourceTest.kt
@@ -89,18 +89,24 @@ class ProposalDataSourceTest {
             assertSame(alreadyMapped, thrown)
         }
 
+    /**
+     * The multi-step rejection must reach the caller untouched: only
+     * [co.electriccoin.zcash.ui.common.repository.KeystoneProposalRepository] knows whether the
+     * proposal pays a TEX address and may therefore remap it to [TexUnsupportedOnKSException].
+     */
     @Test
-    fun aMultiStepProposalBecomesTexUnsupportedOnKeystone() =
+    fun aMultiStepProposalFailurePropagatesUntouched() =
         runBlocking {
             val synchronizer = mockk<Synchronizer>()
-            coEvery { synchronizer.createPcztFromProposal(any(), any()) } throws
-                PcztException.MultiStepProposalUnsupportedException()
+            val sdkException = PcztException.MultiStepProposalUnsupportedException()
+            coEvery { synchronizer.createPcztFromProposal(any(), any()) } throws sdkException
 
-            assertFailsWith<TexUnsupportedOnKSException> {
-                dataSource(synchronizer).createPcztFromProposal(account, mockk<Proposal>())
-            }
+            val thrown =
+                assertFailsWith<PcztException.MultiStepProposalUnsupportedException> {
+                    dataSource(synchronizer).createPcztFromProposal(account, mockk<Proposal>())
+                }
 
-            Unit
+            assertTrue(thrown.causeChain().any { it === sdkException })
         }
 
     @Test

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSourceTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/ProposalDataSourceTest.kt
@@ -1,0 +1,147 @@
+package co.electriccoin.zcash.ui.common.datasource
+
+import cash.z.ecc.android.sdk.Synchronizer
+import cash.z.ecc.android.sdk.exception.PcztException
+import cash.z.ecc.android.sdk.exception.TransactionEncoderException
+import cash.z.ecc.android.sdk.model.Memo
+import cash.z.ecc.android.sdk.model.Proposal
+import cash.z.ecc.android.sdk.model.WalletAddress
+import cash.z.ecc.android.sdk.model.Zatoshi
+import cash.z.ecc.android.sdk.model.ZecSend
+import co.electriccoin.zcash.ui.common.model.ZashiAccount
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * The proposal failure mapping the app relies on: since MOB-1723 the SDK reports an
+ * insufficient-funds proposal failure and a PCZT-unsupported (TEX) proposal as dedicated types, so
+ * this layer maps purely by type - no error-message matching anywhere.
+ */
+class ProposalDataSourceTest {
+    private val account =
+        mockk<ZashiAccount> {
+            every { sdkAccount } returns mockk(relaxed = true)
+        }
+
+    @Test
+    fun sdkInsufficientFundsBecomesTheAppInsufficientFundsException() =
+        runBlocking {
+            val synchronizer = mockk<Synchronizer>()
+            val sdkException = TransactionEncoderException.InsufficientFundsException(RuntimeException("raw"))
+            coEvery { synchronizer.proposeTransfer(any(), any(), any(), any()) } throws sdkException
+
+            val thrown =
+                assertFailsWith<InsufficientFundsException> {
+                    dataSource(synchronizer).createProposal(account, send())
+                }
+
+            assertTrue(thrown.causeChain().any { it === sdkException })
+        }
+
+    @Test
+    fun anUnmatchedProposalFailureBecomesTransactionProposalNotCreated() =
+        runBlocking {
+            val synchronizer = mockk<Synchronizer>()
+            val sdkException = TransactionEncoderException.ProposalFromParametersException(RuntimeException("raw"))
+            coEvery { synchronizer.proposeTransfer(any(), any(), any(), any()) } throws sdkException
+
+            val thrown =
+                assertFailsWith<TransactionProposalNotCreatedException> {
+                    dataSource(synchronizer).createProposal(account, send())
+                }
+
+            assertSame(sdkException, thrown.cause)
+        }
+
+    @Test
+    fun anArbitraryFailureBecomesTransactionProposalNotCreated() =
+        runBlocking {
+            val synchronizer = mockk<Synchronizer>()
+            val raw = RuntimeException("anything")
+            coEvery { synchronizer.proposeTransfer(any(), any(), any(), any()) } throws raw
+
+            val thrown =
+                assertFailsWith<TransactionProposalNotCreatedException> {
+                    dataSource(synchronizer).createProposal(account, send())
+                }
+
+            assertSame(raw, thrown.cause)
+        }
+
+    @Test
+    fun anAlreadyMappedFailureIsRethrownWithoutDoubleWrapping() =
+        runBlocking {
+            val synchronizer = mockk<Synchronizer>()
+            val alreadyMapped = TransactionProposalNotCreatedException(IllegalArgumentException("Invalid ZIP321 URI"))
+            coEvery { synchronizer.proposeTransfer(any(), any(), any(), any()) } throws alreadyMapped
+
+            val thrown =
+                assertFailsWith<TransactionProposalNotCreatedException> {
+                    dataSource(synchronizer).createProposal(account, send())
+                }
+
+            assertSame(alreadyMapped, thrown)
+        }
+
+    @Test
+    fun aMultiStepProposalBecomesTexUnsupportedOnKeystone() =
+        runBlocking {
+            val synchronizer = mockk<Synchronizer>()
+            coEvery { synchronizer.createPcztFromProposal(any(), any()) } throws
+                PcztException.MultiStepProposalUnsupportedException()
+
+            assertFailsWith<TexUnsupportedOnKSException> {
+                dataSource(synchronizer).createPcztFromProposal(account, mockk<Proposal>())
+            }
+
+            Unit
+        }
+
+    @Test
+    fun anyOtherPcztFailurePropagatesUntouched() =
+        runBlocking {
+            val synchronizer = mockk<Synchronizer>()
+            val raw = RuntimeException("PCZT creation failed")
+            coEvery { synchronizer.createPcztFromProposal(any(), any()) } throws raw
+
+            val thrown =
+                assertFailsWith<RuntimeException> {
+                    dataSource(synchronizer).createPcztFromProposal(account, mockk<Proposal>())
+                }
+
+            assertTrue(thrown.causeChain().any { it === raw })
+        }
+
+    /**
+     * The exception a coroutine hands back can be a stack-trace-recovered copy rather than the very
+     * instance that was thrown, so identity is asserted against the whole cause chain.
+     */
+    private fun Throwable.causeChain(): Sequence<Throwable> = generateSequence(this) { it.cause }
+
+    private fun dataSource(synchronizer: Synchronizer): ProposalDataSource =
+        ProposalDataSourceImpl(
+            synchronizerProvider = mockk { coEvery { getSynchronizer() } returns synchronizer },
+            lightWalletEndpointProvider = mockk(),
+            isServerSelectionAutomaticProvider = mockk(),
+            persistableWalletProvider = mockk()
+        )
+
+    private suspend fun send(): ZecSend =
+        ZecSend(
+            destination = WalletAddress.Unified.new(RECIPIENT),
+            amount = Zatoshi(AMOUNT),
+            memo = Memo(""),
+            proposal = null
+        )
+
+    private companion object {
+        const val RECIPIENT = "recipient"
+        const val AMOUNT = 100_000L
+    }
+}

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/KeystoneProposalRepositoryTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/KeystoneProposalRepositoryTest.kt
@@ -1,24 +1,37 @@
 package co.electriccoin.zcash.ui.common.repository
 
+import cash.z.ecc.android.sdk.exception.PcztException
+import cash.z.ecc.android.sdk.model.Memo
 import cash.z.ecc.android.sdk.model.Proposal
+import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.model.Zatoshi
+import cash.z.ecc.android.sdk.model.ZecSend
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.datasource.MigrationSweepTransactionProposal
 import co.electriccoin.zcash.ui.common.datasource.ProposalDataSource
+import co.electriccoin.zcash.ui.common.datasource.RegularTransactionProposal
+import co.electriccoin.zcash.ui.common.datasource.TexUnsupportedOnKSException
 import co.electriccoin.zcash.ui.common.provider.KeystoneSDKProvider
+import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class KeystoneProposalRepositoryTest {
+    private val accountDataSource = mockk<AccountDataSource>()
+    private val proposalDataSource = mockk<ProposalDataSource>()
+
+    private val repository: KeystoneProposalRepository =
+        KeystoneProposalRepositoryImpl(
+            accountDataSource = accountDataSource,
+            proposalDataSource = proposalDataSource,
+            keystoneSDKProvider = mockk<KeystoneSDKProvider>(),
+        )
+
     @Test
     fun setMigrationSweepProposalPublishesAMigrationSweepTransactionProposal() {
-        val repository: KeystoneProposalRepository =
-            KeystoneProposalRepositoryImpl(
-                accountDataSource = mockk<AccountDataSource>(),
-                proposalDataSource = mockk<ProposalDataSource>(),
-                keystoneSDKProvider = mockk<KeystoneSDKProvider>(),
-            )
         val proposal = mockk<Proposal>()
         val amount = Zatoshi(1234L)
 
@@ -26,5 +39,79 @@ class KeystoneProposalRepositoryTest {
 
         val stored = repository.transactionProposal.value
         assertEquals(MigrationSweepTransactionProposal(amount, proposal), stored)
+    }
+
+    /**
+     * A multi-step PCZT rejection means "TEX is unsupported on Keystone" only when the proposal
+     * actually pays a TEX address — the one flow where a multi-step proposal is the expected shape.
+     */
+    @Test
+    fun aMultiStepPcztRejectionOfATexPaymentBecomesTexUnsupportedOnKeystone() =
+        runBlocking {
+            givenCurrentProposalPays(WalletAddress.Tex.new(RECIPIENT))
+            coEvery { proposalDataSource.createPcztFromProposal(any(), any()) } throws
+                PcztException.MultiStepProposalUnsupportedException()
+
+            assertFailsWith<TexUnsupportedOnKSException> {
+                repository.createPCZTFromProposal()
+            }
+
+            Unit
+        }
+
+    @Test
+    fun aMultiStepPcztRejectionOfANonTexPaymentPropagatesUntouched() =
+        runBlocking {
+            givenCurrentProposalPays(WalletAddress.Unified.new(RECIPIENT))
+            coEvery { proposalDataSource.createPcztFromProposal(any(), any()) } throws
+                PcztException.MultiStepProposalUnsupportedException()
+
+            assertFailsWith<PcztException.MultiStepProposalUnsupportedException> {
+                repository.createPCZTFromProposal()
+            }
+
+            Unit
+        }
+
+    /**
+     * Migration sweeps have no payment destination at all, so their multi-step rejection must never
+     * be dressed up as a TEX error.
+     */
+    @Test
+    fun aMultiStepPcztRejectionOfAMigrationSweepPropagatesUntouched() =
+        runBlocking {
+            repository.setMigrationSweepProposal(mockk<Proposal>(), Zatoshi(1234L))
+            coEvery { accountDataSource.getSelectedAccount() } returns mockk(relaxed = true)
+            coEvery { proposalDataSource.createPcztFromProposal(any(), any()) } throws
+                PcztException.MultiStepProposalUnsupportedException()
+
+            assertFailsWith<PcztException.MultiStepProposalUnsupportedException> {
+                repository.createPCZTFromProposal()
+            }
+
+            Unit
+        }
+
+    private suspend fun givenCurrentProposalPays(destination: WalletAddress) {
+        coEvery { accountDataSource.getSelectedAccount() } returns mockk(relaxed = true)
+        coEvery { proposalDataSource.createProposal(any(), any()) } returns
+            RegularTransactionProposal(
+                destination = destination,
+                amount = Zatoshi(1234L),
+                memo = Memo(""),
+                proposal = mockk<Proposal>()
+            )
+        repository.createProposal(
+            ZecSend(
+                destination = destination,
+                amount = Zatoshi(1234L),
+                memo = Memo(""),
+                proposal = null
+            )
+        )
+    }
+
+    private companion object {
+        const val RECIPIENT = "recipient"
     }
 }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
@@ -63,6 +63,8 @@ class RequestSwapQuoteUseCaseTest {
     private val navigateToError = mockk<NavigateToErrorUseCase>(relaxed = true)
     private val zashiProposalRepository = mockk<ZashiProposalRepository>(relaxed = true)
     private val keystoneProposalRepository = mockk<KeystoneProposalRepository>(relaxed = true)
+    private val swapRepository = mockk<SwapRepository>(relaxed = true)
+    private val accountDataSource = mockk<AccountDataSource>()
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private val dispatcher = StandardTestDispatcher()
@@ -144,6 +146,20 @@ class RequestSwapQuoteUseCaseTest {
             useCase(swapQuote(originAsset = zec, destinationAsset = btc, amountIn = BigDecimal("100.5")), zashi())
                 .exactInput()
             assertNavigatedToError()
+        }
+
+    @Test
+    fun exactInputZashiWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
+        runBlocking {
+            useCase(swapQuote(originAsset = zec, destinationAsset = btc), zashi(canSpend = false)).exactInput()
+            assertBlockedBeforeTheQuote()
+        }
+
+    @Test
+    fun exactInputKeystoneWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
+        runBlocking {
+            useCase(swapQuote(originAsset = zec, destinationAsset = btc), keystone(canSpend = false)).exactInput()
+            assertBlockedBeforeTheQuote()
         }
 
     // endregion
@@ -228,8 +244,25 @@ class RequestSwapQuoteUseCaseTest {
             assertForwardedToQuote()
         }
 
+    @Test
+    fun flexNeverChecksSpendableBalance() =
+        runBlocking {
+            // Nothing is spent from the wallet on the way into ZEC, so the pre-quote check must not apply.
+            val account = zashi(canSpend = false)
+            useCase(flexQuote(), account).flex()
+            verify(exactly = 0) { account.canSpend(any()) }
+            assertForwardedToQuote()
+        }
+
     // endregion
     // region helpers
+
+    private fun assertBlockedBeforeTheQuote() {
+        verify { navigationRouter.forward(InsufficientFundsArgs) }
+        coVerify(exactly = 0) { accountDataSource.requestNextShieldedAddress() }
+        verify(exactly = 0) { swapRepository.requestExactInputQuote(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { navigationRouter.forward(SwapQuoteArgs) }
+    }
 
     private fun assertForwardedToQuote() {
         verify { navigationRouter.forward(SwapQuoteArgs) }
@@ -250,9 +283,15 @@ class RequestSwapQuoteUseCaseTest {
         verify { navigationRouter.forward(TEXUnsupportedArgs) }
     }
 
-    private fun zashi(): WalletAccount = mockk<ZashiAccount>()
+    /**
+     * [canSpend] must be stubbed explicitly: mockk does not fall through to the interface's default
+     * body, and the pre-quote balance check calls it on the selected account.
+     */
+    private fun zashi(canSpend: Boolean = true): WalletAccount =
+        mockk<ZashiAccount> { every { this@mockk.canSpend(any()) } returns canSpend }
 
-    private fun keystone(): WalletAccount = mockk<KeystoneAccount>()
+    private fun keystone(canSpend: Boolean = true): WalletAccount =
+        mockk<KeystoneAccount> { every { this@mockk.canSpend(any()) } returns canSpend }
 
     private suspend fun RequestSwapQuoteUseCase.exactInput(selectedAsset: SwapAsset = btc) =
         requestExactInput(
@@ -283,21 +322,17 @@ class RequestSwapQuoteUseCaseTest {
 
     private suspend fun useCase(
         swapQuote: SwapQuote,
-        selectedAccount: WalletAccount = mockk<ZashiAccount>(),
+        selectedAccount: WalletAccount = zashi(),
         supportedData: List<SwapAsset> = listOf(btc)
     ): RequestSwapQuoteUseCase {
-        val swapRepository = mockk<SwapRepository>(relaxed = true)
         every { swapRepository.assets } returns MutableStateFlow(SwapAssetsData(data = supportedData, zecAsset = zec))
         every { swapRepository.quote } returns MutableStateFlow(SwapQuoteData.Success(swapQuote))
 
         val shieldedAddress = WalletAddress.Unified.new("deposit")
         val synchronizer = mockk<Synchronizer> { coEvery { validateAddress(any()) } returns AddressType.Unified }
         val synchronizerProvider = mockk<SynchronizerProvider> { coEvery { getSynchronizer() } returns synchronizer }
-        val accountDataSource =
-            mockk<AccountDataSource> {
-                coEvery { requestNextShieldedAddress() } returns shieldedAddress
-                coEvery { getSelectedAccount() } returns selectedAccount
-            }
+        coEvery { accountDataSource.requestNextShieldedAddress() } returns shieldedAddress
+        coEvery { accountDataSource.getSelectedAccount() } returns selectedAccount
         return RequestSwapQuoteUseCase(
             navigationRouter = navigationRouter,
             navigateToErrorUseCase = navigateToError,

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
@@ -2,6 +2,7 @@ package co.electriccoin.zcash.ui.common.usecase
 
 import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.model.WalletAddress
+import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.type.AddressType
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
@@ -23,6 +24,7 @@ import co.electriccoin.zcash.ui.common.repository.SwapRepository
 import co.electriccoin.zcash.ui.common.repository.ZashiProposalRepository
 import co.electriccoin.zcash.ui.screen.error.NavigateToErrorUseCase
 import co.electriccoin.zcash.ui.screen.insufficientfunds.InsufficientFundsArgs
+import co.electriccoin.zcash.ui.screen.swap.convertZecToZatoshi
 import co.electriccoin.zcash.ui.screen.swap.quote.SwapQuoteArgs
 import co.electriccoin.zcash.ui.screen.texunsupported.TEXUnsupportedArgs
 import io.mockk.coEvery
@@ -40,6 +42,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.Test
 import java.math.BigDecimal
+import java.math.MathContext
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 
@@ -235,15 +238,35 @@ class RequestSwapQuoteUseCaseTest {
     @Test
     fun exactOutputZashiWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
         runBlocking {
-            useCase(exactOutputQuote(), zashi(canSpend = false)).exactOutput()
+            val account = zashi(canSpend = false)
+            useCase(exactOutputQuote(), account).exactOutput()
+            verify { account.canSpend(exactOutputDestinationZatoshi()) }
             assertBlockedBeforeTheQuote()
         }
 
     @Test
     fun exactOutputKeystoneWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
         runBlocking {
-            useCase(exactOutputQuote(), keystone(canSpend = false)).exactOutput()
+            val account = keystone(canSpend = false)
+            useCase(exactOutputQuote(), account).exactOutput()
+            verify { account.canSpend(exactOutputDestinationZatoshi()) }
             assertBlockedBeforeTheQuote()
+        }
+
+    /**
+     * The pre-check needs both the destination asset's and ZEC's usdPrice to convert the
+     * destination-denominated amount into zatoshi; when either is missing it must not block,
+     * leaving the authoritative proposal-time check to decide.
+     */
+    @Test
+    fun exactOutputSkipsBalanceCheckWhenAssetPriceIsUnavailable() =
+        runBlocking {
+            val account = zashi(canSpend = false)
+            val unpriced = SwapAssetTestFixture.asset(tokenTicker = "eth", chainTicker = "eth", usdPrice = null)
+            useCase(exactOutputQuote(destinationAsset = unpriced), account, supportedData = listOf(unpriced))
+                .exactOutput(selectedAsset = unpriced)
+            verify(exactly = 0) { account.canSpend(any()) }
+            assertForwardedToQuote()
         }
 
     // endregion
@@ -315,6 +338,21 @@ class RequestSwapQuoteUseCaseTest {
 
     private fun keystone(canSpend: Boolean = true): WalletAccount =
         mockk<KeystoneAccount> { every { this@mockk.canSpend(any()) } returns canSpend }
+
+    /**
+     * The zatoshi the exact-output pre-check should compute for [amount] of [destinationAsset],
+     * via the same USD cross-rate the use case applies (destination amount * asset price / ZEC
+     * price) — used to assert the actual value reaches [WalletAccount.canSpend], not just that some
+     * value did.
+     */
+    private fun exactOutputDestinationZatoshi(
+        amount: BigDecimal = BigDecimal("1"),
+        destinationAsset: SwapAsset = btc
+    ): Zatoshi =
+        amount
+            .multiply(destinationAsset.usdPrice!!, MathContext.DECIMAL128)
+            .divide(zec.usdPrice!!, MathContext.DECIMAL128)
+            .convertZecToZatoshi()
 
     private suspend fun RequestSwapQuoteUseCase.exactInput(selectedAsset: SwapAsset = btc) =
         requestExactInput(

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
@@ -232,6 +232,20 @@ class RequestSwapQuoteUseCaseTest {
             assertNavigatedToError()
         }
 
+    @Test
+    fun exactOutputZashiWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
+        runBlocking {
+            useCase(exactOutputQuote(), zashi(canSpend = false)).exactOutput()
+            assertBlockedBeforeTheQuote()
+        }
+
+    @Test
+    fun exactOutputKeystoneWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
+        runBlocking {
+            useCase(exactOutputQuote(), keystone(canSpend = false)).exactOutput()
+            assertBlockedBeforeTheQuote()
+        }
+
     // endregion
     // region requestFlexInputIntoZec — happy (no proposal, no account branch)
 
@@ -268,6 +282,7 @@ class RequestSwapQuoteUseCaseTest {
         verify { keystoneProposalRepository.clear() }
         coVerify(exactly = 0) { accountDataSource.requestNextShieldedAddress() }
         verify(exactly = 0) { swapRepository.requestExactInputQuote(any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { swapRepository.requestExactOutputQuote(any(), any(), any(), any(), any()) }
         verify(exactly = 0) { navigationRouter.forward(SwapQuoteArgs) }
     }
 
@@ -288,6 +303,7 @@ class RequestSwapQuoteUseCaseTest {
 
     private fun assertNavigatedToTexUnsupported() {
         verify { navigationRouter.forward(TEXUnsupportedArgs) }
+        verify(exactly = 0) { navigationRouter.forward(SwapQuoteArgs) }
     }
 
     /**

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
@@ -2,7 +2,6 @@ package co.electriccoin.zcash.ui.common.usecase
 
 import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.model.WalletAddress
-import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.type.AddressType
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
@@ -18,13 +17,11 @@ import co.electriccoin.zcash.ui.common.model.WalletAccount
 import co.electriccoin.zcash.ui.common.model.ZashiAccount
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import co.electriccoin.zcash.ui.common.repository.KeystoneProposalRepository
-import co.electriccoin.zcash.ui.common.repository.SwapAssetsData
 import co.electriccoin.zcash.ui.common.repository.SwapQuoteData
 import co.electriccoin.zcash.ui.common.repository.SwapRepository
 import co.electriccoin.zcash.ui.common.repository.ZashiProposalRepository
 import co.electriccoin.zcash.ui.screen.error.NavigateToErrorUseCase
 import co.electriccoin.zcash.ui.screen.insufficientfunds.InsufficientFundsArgs
-import co.electriccoin.zcash.ui.screen.swap.convertZecToZatoshi
 import co.electriccoin.zcash.ui.screen.swap.quote.SwapQuoteArgs
 import co.electriccoin.zcash.ui.screen.texunsupported.TEXUnsupportedArgs
 import io.mockk.coEvery
@@ -42,7 +39,6 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.Test
 import java.math.BigDecimal
-import java.math.MathContext
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 
@@ -151,20 +147,6 @@ class RequestSwapQuoteUseCaseTest {
             assertNavigatedToError()
         }
 
-    @Test
-    fun exactInputZashiWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
-        runBlocking {
-            useCase(swapQuote(originAsset = zec, destinationAsset = btc), zashi(canSpend = false)).exactInput()
-            assertBlockedBeforeTheQuote()
-        }
-
-    @Test
-    fun exactInputKeystoneWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
-        runBlocking {
-            useCase(swapQuote(originAsset = zec, destinationAsset = btc), keystone(canSpend = false)).exactInput()
-            assertBlockedBeforeTheQuote()
-        }
-
     // endregion
     // region requestExactOutput — proposal happy + failures
 
@@ -235,40 +217,6 @@ class RequestSwapQuoteUseCaseTest {
             assertNavigatedToError()
         }
 
-    @Test
-    fun exactOutputZashiWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
-        runBlocking {
-            val account = zashi(canSpend = false)
-            useCase(exactOutputQuote(), account).exactOutput()
-            verify { account.canSpend(exactOutputDestinationZatoshi()) }
-            assertBlockedBeforeTheQuote()
-        }
-
-    @Test
-    fun exactOutputKeystoneWithoutSpendableBalanceIsBlockedBeforeTheQuote() =
-        runBlocking {
-            val account = keystone(canSpend = false)
-            useCase(exactOutputQuote(), account).exactOutput()
-            verify { account.canSpend(exactOutputDestinationZatoshi()) }
-            assertBlockedBeforeTheQuote()
-        }
-
-    /**
-     * The pre-check needs both the destination asset's and ZEC's usdPrice to convert the
-     * destination-denominated amount into zatoshi; when either is missing it must not block,
-     * leaving the authoritative proposal-time check to decide.
-     */
-    @Test
-    fun exactOutputSkipsBalanceCheckWhenAssetPriceIsUnavailable() =
-        runBlocking {
-            val account = zashi(canSpend = false)
-            val unpriced = SwapAssetTestFixture.asset(tokenTicker = "eth", chainTicker = "eth", usdPrice = null)
-            useCase(exactOutputQuote(destinationAsset = unpriced), account, supportedData = listOf(unpriced))
-                .exactOutput(selectedAsset = unpriced)
-            verify(exactly = 0) { account.canSpend(any()) }
-            assertForwardedToQuote()
-        }
-
     // endregion
     // region requestFlexInputIntoZec — happy (no proposal, no account branch)
 
@@ -281,33 +229,8 @@ class RequestSwapQuoteUseCaseTest {
             assertForwardedToQuote()
         }
 
-    @Test
-    fun flexNeverChecksSpendableBalance() =
-        runBlocking {
-            // Nothing is spent from the wallet on the way into ZEC, so the pre-quote check must not apply.
-            val account = zashi(canSpend = false)
-            useCase(flexQuote(), account).flex()
-            verify(exactly = 0) { account.canSpend(any()) }
-            assertForwardedToQuote()
-        }
-
     // endregion
     // region helpers
-
-    /**
-     * The pre-quote block must leave no stale state behind: it clears the previous quote and both
-     * proposal repositories exactly like the proposal-time insufficient-funds path does.
-     */
-    private fun assertBlockedBeforeTheQuote() {
-        verify { navigationRouter.forward(InsufficientFundsArgs) }
-        verify { swapRepository.clearQuote() }
-        verify { zashiProposalRepository.clear() }
-        verify { keystoneProposalRepository.clear() }
-        coVerify(exactly = 0) { accountDataSource.requestNextShieldedAddress() }
-        verify(exactly = 0) { swapRepository.requestExactInputQuote(any(), any(), any(), any(), any()) }
-        verify(exactly = 0) { swapRepository.requestExactOutputQuote(any(), any(), any(), any(), any()) }
-        verify(exactly = 0) { navigationRouter.forward(SwapQuoteArgs) }
-    }
 
     private fun assertForwardedToQuote() {
         verify { navigationRouter.forward(SwapQuoteArgs) }
@@ -329,30 +252,9 @@ class RequestSwapQuoteUseCaseTest {
         verify(exactly = 0) { navigationRouter.forward(SwapQuoteArgs) }
     }
 
-    /**
-     * [canSpend] must be stubbed explicitly: mockk does not fall through to the interface's default
-     * body, and the pre-quote balance check calls it on the selected account.
-     */
-    private fun zashi(canSpend: Boolean = true): WalletAccount =
-        mockk<ZashiAccount> { every { this@mockk.canSpend(any()) } returns canSpend }
+    private fun zashi(): WalletAccount = mockk<ZashiAccount>()
 
-    private fun keystone(canSpend: Boolean = true): WalletAccount =
-        mockk<KeystoneAccount> { every { this@mockk.canSpend(any()) } returns canSpend }
-
-    /**
-     * The zatoshi the exact-output pre-check should compute for [amount] of [destinationAsset],
-     * via the same USD cross-rate the use case applies (destination amount * asset price / ZEC
-     * price) — used to assert the actual value reaches [WalletAccount.canSpend], not just that some
-     * value did.
-     */
-    private fun exactOutputDestinationZatoshi(
-        amount: BigDecimal = BigDecimal("1"),
-        destinationAsset: SwapAsset = btc
-    ): Zatoshi =
-        amount
-            .multiply(destinationAsset.usdPrice!!, MathContext.DECIMAL128)
-            .divide(zec.usdPrice!!, MathContext.DECIMAL128)
-            .convertZecToZatoshi()
+    private fun keystone(): WalletAccount = mockk<KeystoneAccount>()
 
     private suspend fun RequestSwapQuoteUseCase.exactInput(selectedAsset: SwapAsset = btc) =
         requestExactInput(
@@ -383,10 +285,8 @@ class RequestSwapQuoteUseCaseTest {
 
     private suspend fun useCase(
         swapQuote: SwapQuote,
-        selectedAccount: WalletAccount = zashi(),
-        supportedData: List<SwapAsset> = listOf(btc)
+        selectedAccount: WalletAccount = zashi()
     ): RequestSwapQuoteUseCase {
-        every { swapRepository.assets } returns MutableStateFlow(SwapAssetsData(data = supportedData, zecAsset = zec))
         every { swapRepository.quote } returns MutableStateFlow(SwapQuoteData.Success(swapQuote))
 
         val shieldedAddress = WalletAddress.Unified.new("deposit")

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
@@ -257,8 +257,15 @@ class RequestSwapQuoteUseCaseTest {
     // endregion
     // region helpers
 
+    /**
+     * The pre-quote block must leave no stale state behind: it clears the previous quote and both
+     * proposal repositories exactly like the proposal-time insufficient-funds path does.
+     */
     private fun assertBlockedBeforeTheQuote() {
         verify { navigationRouter.forward(InsufficientFundsArgs) }
+        verify { swapRepository.clearQuote() }
+        verify { zashiProposalRepository.clear() }
+        verify { keystoneProposalRepository.clear() }
         coVerify(exactly = 0) { accountDataSource.requestNextShieldedAddress() }
         verify(exactly = 0) { swapRepository.requestExactInputQuote(any(), any(), any(), any(), any()) }
         verify(exactly = 0) { navigationRouter.forward(SwapQuoteArgs) }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/viewmodel/AuthenticationViewModelTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/viewmodel/AuthenticationViewModelTest.kt
@@ -6,6 +6,7 @@ import co.electriccoin.zcash.preference.StandardPreferenceProvider
 import co.electriccoin.zcash.preference.api.PreferenceProvider
 import co.electriccoin.zcash.preference.model.entry.PreferenceKey
 import co.electriccoin.zcash.spackle.AndroidApiVersion
+import co.electriccoin.zcash.ui.common.provider.GetMonotonicTimeProvider
 import co.electriccoin.zcash.ui.common.provider.GetVersionInfoProvider
 import co.electriccoin.zcash.ui.fixture.VersionInfoFixture
 import io.mockk.coEvery
@@ -28,6 +29,9 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
 
 /**
  * Regression coverage for MOB-1447: opening the app before any wallet has been created or
@@ -140,11 +144,56 @@ class AuthenticationViewModelTest {
             assertEquals(AuthenticationUIState.NotRequired, viewModel.appAccessAuthenticationResultState.value)
         }
 
+    @Test
+    fun recentBackgroundDoesNotResetAuthenticationState() =
+        runTest {
+            val (viewModel, _, setMonotonicTimeMillis) = newViewModel(secretState = SecretState.READY)
+            viewModel.appAccessAuthentication.value = AuthenticationUIState.Successful
+            viewModel.setWelcomeAnimationDisplayed()
+
+            setMonotonicTimeMillis(0L)
+            viewModel.onEnteredBackground()
+
+            setMonotonicTimeMillis(5.minutes.inWholeMilliseconds)
+            viewModel.runAuthenticationRequiredCheck()
+
+            assertEquals(AuthenticationUIState.Successful, viewModel.appAccessAuthentication.value)
+            assertFalse(viewModel.showWelcomeAnimation.value)
+        }
+
+    @Test
+    fun backgroundTimeoutResetsAuthenticationState() =
+        runTest {
+            val (viewModel, _, setMonotonicTimeMillis) = newViewModel(secretState = SecretState.READY)
+            viewModel.appAccessAuthentication.value = AuthenticationUIState.Successful
+            viewModel.setWelcomeAnimationDisplayed()
+
+            setMonotonicTimeMillis(0L)
+            viewModel.onEnteredBackground()
+
+            setMonotonicTimeMillis(16.minutes.inWholeMilliseconds)
+            viewModel.runAuthenticationRequiredCheck()
+
+            assertEquals(AuthenticationUIState.Initial, viewModel.appAccessAuthentication.value)
+            assertTrue(viewModel.showWelcomeAnimation.value)
+        }
+
+    @Test
+    fun authenticationCheckWithoutRecordedBackgroundTimeIsNoOp() =
+        runTest {
+            val (viewModel, _, _) = newViewModel(secretState = SecretState.READY)
+            viewModel.appAccessAuthentication.value = AuthenticationUIState.Successful
+
+            viewModel.runAuthenticationRequiredCheck()
+
+            assertEquals(AuthenticationUIState.Successful, viewModel.appAccessAuthentication.value)
+        }
+
     private fun newViewModel(
         secretState: SecretState,
         isAppAccessAuthenticationPreference: String? = null,
         isRunningUnderTestService: Boolean = false
-    ): Pair<AuthenticationViewModel, MutableStateFlow<SecretState>> {
+    ): Triple<AuthenticationViewModel, MutableStateFlow<SecretState>, (Long) -> Unit> {
         val secretStateFlow = MutableStateFlow(secretState)
         val walletViewModel = mockk<WalletViewModel>()
         every { walletViewModel.secretState } returns secretStateFlow
@@ -156,16 +205,21 @@ class AuthenticationViewModelTest {
         every { getVersionInfo() } returns
             VersionInfoFixture.new(isRunningUnderTestService = isRunningUnderTestService)
 
+        var monotonicTimeMillis = 0L
+        val getMonotonicTime = mockk<GetMonotonicTimeProvider>()
+        every { getMonotonicTime() } answers { monotonicTimeMillis }
+
         val viewModel =
             AuthenticationViewModel(
                 application = application,
                 biometricManager = biometricManager,
+                getMonotonicTime = getMonotonicTime,
                 getVersionInfo = getVersionInfo,
                 standardPreferenceProvider = standardPreferenceProvider,
                 walletViewModel = walletViewModel
             )
 
-        return viewModel to secretStateFlow
+        return Triple(viewModel, secretStateFlow) { monotonicTimeMillis = it }
     }
 }
 


### PR DESCRIPTION
Closes #2470

## [3.10.1 (2512)] - 2026-08-25

### Added:

- We added a home screen banner and follow-up screen for a small amount of ZEC that can be left in Orchard after migrating to Ironwood, so you can choose whether to lock it or move it.

### Fixed:

- We fixed migrating with a Keystone wallet, so migrations are now split into signing rounds correctly.

### Fixed:

- A temporary Android Keystore failure at startup is no longer mistaken for corrupted encrypted storage: the encrypted secret store is now
  recreated only when its data is provably undecryptable (for example after a device-to-device transfer, which cannot move hardware-bound
  keys), and any other failure keeps the stored data intact.

