### PR TITLE
MOB-1806/MOB-1809: Static voting config v2 with config mirror failover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 - Bottom sheets across the app now share one background color.
 - We rebuilt polling to work with your Ironwood-migrated funds.
 - We made poll loading more reliable during service outages.
+- Coinholder Polling now supports multiple dynamic configuration URLs and automatically falls back to the next one if the first is
+  unreachable, adding resilience against an ISP blocking the primary voting configuration host.
 
 ### Fixed:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,9 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 - Bottom sheets across the app now share one background color.
 - We rebuilt polling to work with your Ironwood-migrated funds.
 - We made poll loading more reliable during service outages.
-- Coinholder Polling now supports multiple dynamic configuration URLs and automatically falls back to the next one if the first is
-  unreachable, adding resilience against an ISP blocking the primary voting configuration host.
+- Coinholder Polling no longer becomes unavailable when the primary voting configuration service is unreachable or blocked: the app
+  verifies the same pinned configuration from a second independent mirror, walks the configuration's own mirror list, and config
+  requests now give up after 15 seconds instead of two minutes.
 
 ### Fixed:
 

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/model/voting/StaticVotingConfig.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/model/voting/StaticVotingConfig.kt
@@ -12,7 +12,7 @@ import java.util.Base64
 @Serializable
 data class StaticVotingConfig(
     @SerialName("static_config_version")
-    val staticConfigVersion: Int = STATIC_CONFIG_VERSION_V1,
+    val staticConfigVersion: Int,
     @SerialName("dynamic_config_url")
     val dynamicConfigURL: String? = null,
     @SerialName("dynamic_config_urls")
@@ -41,6 +41,7 @@ data class StaticVotingConfig(
                 if (dynamicConfigURL.isNullOrBlank()) {
                     throw VotingConfigException("dynamic_config_url must not be blank")
                 }
+                requireHttpsScheme(dynamicConfigURL, "dynamic_config_url")
             }
 
             STATIC_CONFIG_VERSION_V2 -> {
@@ -50,6 +51,7 @@ data class StaticVotingConfig(
                 if (dynamicConfigURLs.any(String::isBlank)) {
                     throw VotingConfigException("dynamic_config_urls must not contain blank entries")
                 }
+                dynamicConfigURLs.forEach { url -> requireHttpsScheme(url, "dynamic_config_urls") }
             }
         }
         if (trustedKeys.isEmpty()) {
@@ -109,11 +111,45 @@ data class StaticVotingConfig(
                 "28fc9b631091ae8bc2f8635d8930489238ce144174cbd15a03efb0530b301ebe/v2-static-voting-config.json" +
                 "?checksum=sha256:28fc9b631091ae8bc2f8635d8930489238ce144174cbd15a03efb0530b301ebe"
 
+        /**
+         * Mirror of [BUNDLED_PINNED_SOURCE] on raw.githubusercontent.com, serving the identical
+         * content-addressed bytes (same checksum, both in the path segment and the query param).
+         * Trust here is carried entirely by the checksum, not by which origin served the bytes —
+         * this mirror is exactly as trustworthy as the gateway itself. It exists for networks
+         * where the voting.valargroup.dev domain is blocked outright (the gateway's own
+         * GitHub-outage fallback does not help if the gateway domain cannot be reached at all).
+         * Bump alongside [BUNDLED_PINNED_SOURCE] whenever the checksum moves forward.
+         */
+        const val BUNDLED_PINNED_SOURCE_MIRROR =
+            "https://raw.githubusercontent.com/valargroup/token-holder-voting-config/main/pins/prod/" +
+                "28fc9b631091ae8bc2f8635d8930489238ce144174cbd15a03efb0530b301ebe/v2-static-voting-config.json" +
+                "?checksum=sha256:28fc9b631091ae8bc2f8635d8930489238ce144174cbd15a03efb0530b301ebe"
+
+        /**
+         * The static-config trust anchor's full mirror list, canonical origin
+         * ([BUNDLED_PINNED_SOURCE]) first. Walked in order when no override is configured (or
+         * the configured override resolves to one of these entries), falling through to the
+         * next mirror on transport failure, a non-200 response, or a checksum mismatch.
+         */
+        val BUNDLED_PINNED_SOURCES: List<String> = listOf(BUNDLED_PINNED_SOURCE, BUNDLED_PINNED_SOURCE_MIRROR)
+
+        /** [BUNDLED_PINNED_SOURCES], pre-parsed. */
+        val BUNDLED_PINNED_CONFIG_SOURCES: List<PinnedConfigSource> by lazy {
+            BUNDLED_PINNED_SOURCES.map(PinnedConfigSource::parse)
+        }
+
+        /**
+         * Per-attempt request timeout for both the static and dynamic config fetch legs: a
+         * blackholed route must fail fast enough to fall through to the next mirror, rather
+         * than hanging for the client's session-wide default (two minutes).
+         */
+        const val CONFIG_REQUEST_TIMEOUT_MS = 15_000L
+
         fun decodeAndVerify(data: ByteArray, expectedSHA256: ByteArray?): StaticVotingConfig {
             if (expectedSHA256 != null) {
                 val actualSHA256 = MessageDigest.getInstance("SHA-256").digest(data)
                 if (!actualSHA256.contentEquals(expectedSHA256)) {
-                    throw VotingConfigException(
+                    throw StaticVotingConfigHashMismatchException(
                         "Static voting config hash mismatch: expected ${expectedSHA256.toLowerHex()}, " +
                             "got ${actualSHA256.toLowerHex()}"
                     )
@@ -131,6 +167,28 @@ data class StaticVotingConfig(
             config.validate()
             return config
         }
+    }
+}
+
+/**
+ * Thrown by [StaticVotingConfig.decodeAndVerify] specifically for a checksum mismatch against
+ * the pinned expected hash, as distinct from a decode or [StaticVotingConfig.validate] failure.
+ * A mirror walk (see `KtorVotingApiProvider`) must retry the next mirror on this exception but
+ * treat every other [VotingConfigException] from the same call as authoritative — decode or
+ * validation failing after the hash matched means the mirror served identical, malformed bytes,
+ * and every other pinned mirror serves the same bytes by definition.
+ */
+class StaticVotingConfigHashMismatchException(
+    message: String
+) : VotingConfigException(message)
+
+private fun requireHttpsScheme(
+    url: String,
+    fieldName: String
+) {
+    val scheme = runCatching { URI(url).scheme }.getOrNull()
+    if (!scheme.equals("https", ignoreCase = true)) {
+        throw VotingConfigException("$fieldName must use https; got $url")
     }
 }
 

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/model/voting/StaticVotingConfig.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/model/voting/StaticVotingConfig.kt
@@ -12,9 +12,11 @@ import java.util.Base64
 @Serializable
 data class StaticVotingConfig(
     @SerialName("static_config_version")
-    val staticConfigVersion: Int = SUPPORTED_VERSION,
+    val staticConfigVersion: Int = STATIC_CONFIG_VERSION_V1,
     @SerialName("dynamic_config_url")
-    val dynamicConfigURL: String,
+    val dynamicConfigURL: String? = null,
+    @SerialName("dynamic_config_urls")
+    val dynamicConfigURLs: List<String> = emptyList(),
     @SerialName("trusted_keys")
     val trustedKeys: List<TrustedKey> = emptyList(),
 ) {
@@ -31,8 +33,24 @@ data class StaticVotingConfig(
     }
 
     fun validate() {
-        if (staticConfigVersion != SUPPORTED_VERSION) {
+        if (staticConfigVersion !in SUPPORTED_VERSIONS) {
             throw VotingConfigException("Unsupported static_config_version $staticConfigVersion")
+        }
+        when (staticConfigVersion) {
+            STATIC_CONFIG_VERSION_V1 -> {
+                if (dynamicConfigURL.isNullOrBlank()) {
+                    throw VotingConfigException("dynamic_config_url must not be blank")
+                }
+            }
+
+            STATIC_CONFIG_VERSION_V2 -> {
+                if (dynamicConfigURLs.isEmpty()) {
+                    throw VotingConfigException("dynamic_config_urls must contain at least one entry")
+                }
+                if (dynamicConfigURLs.any(String::isBlank)) {
+                    throw VotingConfigException("dynamic_config_urls must not contain blank entries")
+                }
+            }
         }
         if (trustedKeys.isEmpty()) {
             throw VotingConfigException("trusted_keys must contain at least one entry")
@@ -47,27 +65,49 @@ data class StaticVotingConfig(
         }
     }
 
+    /**
+     * Unifies the v1 singular `dynamic_config_url` and the v2 `dynamic_config_urls` array
+     * behind one accessor, so callers never need to branch on [staticConfigVersion]: for v2 this
+     * is [dynamicConfigURLs] verbatim, for v1 it is [dynamicConfigURL] wrapped in a single-item
+     * list.
+     */
+    fun resolvedDynamicConfigUrls(): List<String> =
+        if (staticConfigVersion == STATIC_CONFIG_VERSION_V2) {
+            dynamicConfigURLs
+        } else {
+            listOfNotNull(dynamicConfigURL)
+        }
+
     companion object {
-        const val SUPPORTED_VERSION = 1
+        const val STATIC_CONFIG_VERSION_V1 = 1
+        const val STATIC_CONFIG_VERSION_V2 = 2
         const val ALG_ED25519 = "ed25519"
 
+        private val SUPPORTED_VERSIONS = setOf(STATIC_CONFIG_VERSION_V1, STATIC_CONFIG_VERSION_V2)
         private const val ED25519_PUBLIC_KEY_BYTES = 32
 
-        // Content-addressed pin (checksum fb62a56f) via the resilient voting.valargroup.dev
-        // gateway — MOB-1678 hardening (analog of iOS zodl-ios#1996). The gateway serves this
-        // exact content-addressed path (/pins/prod/<sha>/...) immutably, same as the previous
-        // raw.githubusercontent.com blob pin, but reads from GitHub normally and falls back to
-        // an automatically published Cloudflare copy during a GitHub outage — so a GitHub outage
-        // no longer blocks default-configured users from loading their voting trust anchor. This
-        // is NOT the mutable https://voting.valargroup.dev/prod/static-voting-config.json URL:
-        // that one gets republished on every new round/key rotation, which would break this
-        // bundled checksum for every default-configured user on the very next republish and
-        // brick voting until an app update. Bump the checksum (in both the path and the query
-        // param) whenever this bundled fallback needs to move forward to a newer trusted_keys set.
+        /**
+         * Content-addressed pin (checksum 28fc9b63) via the resilient voting.valargroup.dev
+         * gateway — MOB-1678 hardening (analog of iOS zodl-ios#1996), bumped to static config
+         * version 2 for MOB-1806 (analog of iOS MOB-1801): the only schema change from v1 is
+         * `dynamic_config_url` (singular) becoming `dynamic_config_urls` (an array — currently
+         * the valargroup.dev URL plus a raw.githubusercontent.com mirror), which is Valar's
+         * defense against an ISP blocking `voting.valargroup.dev` outright; `trusted_keys` is
+         * unchanged. The gateway serves this exact content-addressed path (/pins/prod/<sha>/...)
+         * immutably, same as the previous raw.githubusercontent.com blob pin, but reads from
+         * GitHub normally and falls back to an automatically published Cloudflare copy during a
+         * GitHub outage — so a GitHub outage no longer blocks default-configured users from
+         * loading their voting trust anchor. This is NOT the mutable
+         * https://voting.valargroup.dev/prod/static-voting-config.json URL: that one gets
+         * republished on every new round/key rotation, which would break this bundled checksum
+         * for every default-configured user on the very next republish and brick voting until an
+         * app update. Bump the checksum (in both the path and the query param) whenever this
+         * bundled fallback needs to move forward to a newer trusted_keys set.
+         */
         const val BUNDLED_PINNED_SOURCE =
             "https://voting.valargroup.dev/pins/prod/" +
-                "fb62a56fae28debfdaa092f163cda0dab13295f87d25bbc4d0064d6ccdeb6943/static-voting-config.json" +
-                "?checksum=sha256:fb62a56fae28debfdaa092f163cda0dab13295f87d25bbc4d0064d6ccdeb6943"
+                "28fc9b631091ae8bc2f8635d8930489238ce144174cbd15a03efb0530b301ebe/v2-static-voting-config.json" +
+                "?checksum=sha256:28fc9b631091ae8bc2f8635d8930489238ce144174cbd15a03efb0530b301ebe"
 
         fun decodeAndVerify(data: ByteArray, expectedSHA256: ByteArray?): StaticVotingConfig {
             if (expectedSHA256 != null) {

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -1,6 +1,7 @@
 package co.electriccoin.zcash.ui.common.provider
 
 import android.util.Log
+import co.electriccoin.zcash.spackle.Twig
 import co.electriccoin.zcash.ui.common.model.voting.CastVoteSignature
 import co.electriccoin.zcash.ui.common.model.voting.ChainActiveRoundResponse
 import co.electriccoin.zcash.ui.common.model.voting.ChainRoundsResponse
@@ -13,6 +14,7 @@ import co.electriccoin.zcash.ui.common.model.voting.RoundAuthenticator
 import co.electriccoin.zcash.ui.common.model.voting.ShareConfirmationResult
 import co.electriccoin.zcash.ui.common.model.voting.SharePayload
 import co.electriccoin.zcash.ui.common.model.voting.StaticVotingConfig
+import co.electriccoin.zcash.ui.common.model.voting.StaticVotingConfigHashMismatchException
 import co.electriccoin.zcash.ui.common.model.voting.TallyResults
 import co.electriccoin.zcash.ui.common.model.voting.TxConfirmation
 import co.electriccoin.zcash.ui.common.model.voting.TxEvent
@@ -56,6 +58,8 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
+import java.net.URI
+import java.util.UUID
 import kotlin.math.max
 
 data class RoundsListResult(
@@ -131,7 +135,7 @@ class KtorVotingApiProvider(
     private val serverHealthTracker = VotingServerHealthTracker()
 
     override suspend fun validateConfigSource(source: PinnedConfigSource) {
-        fetchStaticConfig(source)
+        fetchStaticConfig(listOf(source))
     }
 
     override suspend fun invalidateConfigCache() {
@@ -390,18 +394,18 @@ class KtorVotingApiProvider(
 
     private suspend fun getResolvedConfig(forceRefresh: Boolean = false): ResolvedVotingConfig =
         configMutex.withLock {
-            val source = resolveConfigSource()
+            val sources = resolveConfigSources()
             val cached = cachedResolvedConfig
-            if (!forceRefresh && cached?.source == source) {
+            if (!forceRefresh && cached?.sources == sources) {
                 cached
             } else {
-                fetchTrustedConfig(source).also { resolved ->
+                fetchTrustedConfig(sources).also { resolved ->
                     cachedResolvedConfig = resolved
                 }
             }
         }
 
-    private suspend fun resolveConfigSource(): PinnedConfigSource {
+    private suspend fun resolveConfigSources(): List<PinnedConfigSource> {
         val selectedPinnedSource = votingChainConfigRepository.get().selectedPinnedSource
         if (selectedPinnedSource != null) {
             return resolvePinnedConfigSource(selectedPinnedSource)
@@ -412,83 +416,138 @@ class KtorVotingApiProvider(
         return resolvePinnedConfigSource(configUrl)
     }
 
-    private suspend fun fetchStaticConfig(source: PinnedConfigSource): StaticVotingConfig =
-        execute {
-            val bytes =
-                try {
-                    get(source.url) {
-                        noCache()
-                    }.bodyAsBytes()
-                } catch (responseException: ResponseException) {
-                    throw VotingConfigException(
-                        "Static voting config fetch failed: HTTP ${responseException.response.status.value}"
-                    )
-                }
-            StaticVotingConfig.decodeAndVerify(
-                data = bytes,
-                expectedSHA256 = source.sha256
+    private suspend fun fetchStaticConfig(sources: List<PinnedConfigSource>): StaticVotingConfig =
+        executeWithKtorTimeoutSupport { supportsKtorTimeouts ->
+            fetchStaticConfigWalk(sources, supportsKtorTimeouts)
+        }
+
+    /**
+     * Walks [sources] — the bundled trust anchor's mirror list, or a single-element list for a
+     * user override — deliberately WIDER than [fetchDynamicServiceConfigWalk]: since every
+     * mirror is independently checksum-gated, a transport failure, ANY non-200 response
+     * ([StaticVotingConfigFetchFailedException]), or a checksum mismatch
+     * ([StaticVotingConfigHashMismatchException]) is retryable, falling through to the next
+     * mirror. A decode or [StaticVotingConfig.validate] failure *after* the checksum matched is
+     * authoritative and thrown immediately — the pin guarantees identical bytes from every
+     * mirror, so no other mirror can do better. When every mirror fails, the first (canonical
+     * origin's) error is thrown.
+     */
+    private suspend fun HttpClient.fetchStaticConfigWalk(
+        sources: List<PinnedConfigSource>,
+        supportsKtorTimeouts: Boolean
+    ): StaticVotingConfig =
+        walkConfigSources(
+            sources = sources,
+            emptyMessage = "Static voting config source list is empty",
+            describe = { source -> source.url },
+            shouldTryNext = ::isRetryableStaticVotingConfigFailure
+        ) { source ->
+            val bytes = fetchStaticConfigBytes(source.url, supportsKtorTimeouts)
+            StaticVotingConfig.decodeAndVerify(data = bytes, expectedSHA256 = source.sha256)
+        }
+
+    private suspend fun HttpClient.fetchStaticConfigBytes(
+        url: String,
+        supportsKtorTimeouts: Boolean
+    ): ByteArray =
+        try {
+            get(url) {
+                noCache()
+                configRequestTimeout(supportsKtorTimeouts)
+            }.bodyAsBytes()
+        } catch (responseException: ResponseException) {
+            throw StaticVotingConfigFetchFailedException(
+                "Static voting config fetch failed: HTTP ${responseException.response.status.value}"
+            )
+        } catch (exception: Exception) {
+            exception.rethrowIfCancellation()
+            throw StaticVotingConfigFetchFailedException(
+                "Static voting config fetch failed: ${exception.message ?: exception::class.simpleName}"
             )
         }
 
-    private suspend fun fetchTrustedConfig(source: PinnedConfigSource): ResolvedVotingConfig {
-        val staticConfig = fetchStaticConfig(source)
-        val rawServiceConfig =
-            execute {
-                fetchDynamicServiceConfig(staticConfig.resolvedDynamicConfigUrls())
-            }
+    private suspend fun fetchTrustedConfig(sources: List<PinnedConfigSource>): ResolvedVotingConfig {
+        val staticConfig = fetchStaticConfig(sources)
+        val rawServiceConfig = fetchDynamicServiceConfig(staticConfig.resolvedDynamicConfigUrls())
         val serviceConfig = rawServiceConfig.retainingRoundsWithValidSignatures(staticConfig.trustedKeys)
 
         return ResolvedVotingConfig(
-            source = source,
+            sources = sources,
             staticConfig = staticConfig,
             rawServiceConfig = rawServiceConfig,
             serviceConfig = serviceConfig
         )
     }
 
+    private suspend fun fetchDynamicServiceConfig(urls: List<String>): VotingServiceConfig =
+        executeWithKtorTimeoutSupport { supportsKtorTimeouts ->
+            fetchDynamicServiceConfigWalk(urls, supportsKtorTimeouts)
+        }
+
     /**
      * Tries every configured dynamic-config URL in order (v2's fallback mirror alongside the
-     * primary valargroup.dev host — MOB-1806) and returns the first one that fetches, decodes,
-     * and validates successfully. Unlike [withVoteServerFailover]/[shouldTryNextVoteServer], a
-     * [VotingConfigException] from decode or validate is retryable here too — a malformed or
-     * unreachable mirror should not prevent falling through to the next URL. All URLs failing
-     * throws one [VotingConfigException] naming every URL's failure.
+     * primary valargroup.dev host — MOB-1806/MOB-1809) and returns the first one that fetches,
+     * decodes, and validates successfully. Unlike [fetchStaticConfigWalk], this walk is
+     * NARROWER: only a transport failure or an HTTP 5xx response
+     * ([DynamicVotingConfigTransientException]) is retryable. An HTTP 4xx response, and any
+     * decode or [VotingServiceConfig.validate] failure of successfully fetched bytes, is
+     * authoritative and thrown immediately — the README-normative semantics mirroring iOS's
+     * `fetchDynamicConfigData`. When every URL fails, the first (canonical origin's) error is
+     * thrown, not a joined list.
      */
-    private suspend fun HttpClient.fetchDynamicServiceConfig(urls: List<String>): VotingServiceConfig {
+    private suspend fun HttpClient.fetchDynamicServiceConfigWalk(
+        urls: List<String>,
+        supportsKtorTimeouts: Boolean
+    ): VotingServiceConfig {
         val normalizedUrls = urls.map(String::trim).filter(String::isNotEmpty).distinct()
-        if (normalizedUrls.isEmpty()) {
-            throw VotingConfigException("Static voting config does not list any dynamic_config_urls")
-        }
+        val cacheBustToken = UUID.randomUUID().toString()
 
-        val failures = mutableListOf<String>()
-        for (url in normalizedUrls) {
-            try {
-                return fetchSingleDynamicServiceConfig(url)
-            } catch (exception: Exception) {
-                exception.rethrowIfCancellation()
-                failures += "$url: ${exception.message ?: exception::class.simpleName}"
-            }
+        return walkConfigSources(
+            sources = normalizedUrls,
+            emptyMessage = "Static voting config does not list any dynamic_config_urls",
+            describe = { url -> url },
+            shouldTryNext = ::isRetryableDynamicVotingConfigFailure
+        ) { url ->
+            fetchSingleDynamicServiceConfig(url, cacheBustToken, supportsKtorTimeouts)
         }
-
-        throw VotingConfigException(
-            "Dynamic voting config fetch failed for all ${normalizedUrls.size} configured URL(s): " +
-                failures.joinToString("; ")
-        )
     }
 
-    private suspend fun HttpClient.fetchSingleDynamicServiceConfig(url: String): VotingServiceConfig {
-        val body =
-            try {
-                get(url) {
-                    noCache()
-                }.bodyAsText()
-            } catch (responseException: ResponseException) {
-                throw VotingConfigException(
-                    "Dynamic voting config fetch failed: HTTP ${responseException.response.status.value}"
-                )
-            }
+    private suspend fun HttpClient.fetchSingleDynamicServiceConfig(
+        url: String,
+        cacheBustToken: String,
+        supportsKtorTimeouts: Boolean
+    ): VotingServiceConfig {
+        val body = fetchDynamicConfigBody(url, cacheBustToken, supportsKtorTimeouts)
         return VotingServiceConfig.decode(body).also(VotingServiceConfig::validate)
     }
+
+    /**
+     * Fetches the raw body for one dynamic-config URL, cache-busting only requests to
+     * raw.githubusercontent.com (its branch paths are CDN-cached ~300s server-side and ignore
+     * request cache headers — a plain host-equality check, never contains/endsWith, so this
+     * never fires for the content-addressed static-config mirror). [cacheBustToken] is one
+     * random value per walk invocation, shared by every busted request in that walk; the
+     * cache-bust query parameter is applied to the request only — [url] itself, un-busted, is
+     * what the caller logs and reports as the serving origin.
+     */
+    private suspend fun HttpClient.fetchDynamicConfigBody(
+        url: String,
+        cacheBustToken: String,
+        supportsKtorTimeouts: Boolean
+    ): String =
+        try {
+            get(url.withCacheBustIfNeeded(cacheBustToken)) {
+                noCache()
+                configRequestTimeout(supportsKtorTimeouts)
+            }.bodyAsText()
+        } catch (responseException: ResponseException) {
+            throw responseException.toDynamicVotingConfigException()
+        } catch (exception: Exception) {
+            exception.rethrowIfCancellation()
+            throw DynamicVotingConfigTransientException(
+                "Dynamic voting config fetch failed: ${exception.message ?: exception::class.simpleName}"
+            )
+        }
 
     private suspend fun authenticateVotingSession(session: VotingSession): VotingSession {
         val resolvedConfig = getResolvedConfig()
@@ -714,11 +773,55 @@ private class VotingServerHealthTracker {
 }
 
 private data class ResolvedVotingConfig(
-    val source: PinnedConfigSource,
+    val sources: List<PinnedConfigSource>,
     val staticConfig: StaticVotingConfig,
     val rawServiceConfig: VotingServiceConfig,
     val serviceConfig: VotingServiceConfig,
 )
+
+/**
+ * Thrown only by the static-config walk's fetch step for a transport failure or ANY non-200
+ * response. Together with [StaticVotingConfigHashMismatchException], this is one of the two
+ * failure classes [isRetryableStaticVotingConfigFailure] treats as retryable. A decode or
+ * [StaticVotingConfig.validate] failure of successfully fetched, checksum-matched bytes is
+ * thrown as a plain [VotingConfigException] instead, so it is never retried.
+ */
+internal class StaticVotingConfigFetchFailedException(
+    message: String
+) : VotingConfigException(message)
+
+internal fun isRetryableStaticVotingConfigFailure(throwable: Throwable): Boolean =
+    throwable is StaticVotingConfigFetchFailedException || throwable is StaticVotingConfigHashMismatchException
+
+/**
+ * Thrown only by the dynamic-config walk's fetch step for a transport failure or an HTTP 5xx
+ * response — the two failure classes [isRetryableDynamicVotingConfigFailure] treats as
+ * retryable. An HTTP 4xx response, and a decode or `validate()` failure of successfully fetched
+ * bytes, are thrown as a plain [VotingConfigException] instead, so the walk's narrower predicate
+ * never lets them retry and they propagate as authoritative.
+ */
+internal class DynamicVotingConfigTransientException(
+    message: String
+) : VotingConfigException(message)
+
+internal fun isRetryableDynamicVotingConfigFailure(throwable: Throwable): Boolean =
+    throwable is DynamicVotingConfigTransientException
+
+/**
+ * Classifies a dynamic-config fetch's non-2xx response without throwing, so the single `throw`
+ * at the call site is the only throw statement this classification contributes to that
+ * function's count: an HTTP 5xx is [DynamicVotingConfigTransientException] (retryable), every
+ * other status is a plain [VotingConfigException] (authoritative).
+ */
+private fun ResponseException.toDynamicVotingConfigException(): VotingConfigException {
+    val statusValue = response.status.value
+    val message = "Dynamic voting config fetch failed: HTTP $statusValue"
+    return if (statusValue in TRANSIENT_HTTP_STATUS_MIN..TRANSIENT_HTTP_STATUS_MAX) {
+        DynamicVotingConfigTransientException(message)
+    } else {
+        VotingConfigException(message)
+    }
+}
 
 private fun HttpRequestBuilder.noCache() {
     header("Cache-Control", "no-cache")
@@ -735,6 +838,33 @@ private fun HttpRequestBuilder.helperRequestTimeout(supportsKtorTimeouts: Boolea
     }
 }
 
+private fun HttpRequestBuilder.configRequestTimeout(supportsKtorTimeouts: Boolean) {
+    if (supportsKtorTimeouts) {
+        timeout {
+            requestTimeoutMillis = StaticVotingConfig.CONFIG_REQUEST_TIMEOUT_MS
+            socketTimeoutMillis = StaticVotingConfig.CONFIG_REQUEST_TIMEOUT_MS
+            connectTimeoutMillis = StaticVotingConfig.CONFIG_REQUEST_TIMEOUT_MS
+        }
+    }
+}
+
+/**
+ * Appends a unique `zodl_cache_bust` query parameter when, and only when, this URL's host is
+ * exactly `raw.githubusercontent.com` (case-insensitive equality — never contains/endsWith, so
+ * an unrelated host that merely mentions it in a path or query is never matched). GitHub's raw
+ * CDN caches branch paths for roughly 300 seconds server-side and ignores request cache-control
+ * headers, which matters during round rollover; a content-addressed pin never needs this since
+ * its bytes are immutable by definition.
+ */
+private fun String.withCacheBustIfNeeded(token: String): String {
+    val host = runCatching { URI(this).host }.getOrNull()
+    if (!host.equals(RAW_GITHUBUSERCONTENT_HOST, ignoreCase = true)) {
+        return this
+    }
+    val separator = if (contains('?')) '&' else '?'
+    return "$this$separator$CACHE_BUST_QUERY_PARAM=$token"
+}
+
 private const val HELPER_REQUEST_TIMEOUT_MILLIS = 5_000L
 private const val HELPER_SOCKET_TIMEOUT_MILLIS = 10_000L
 private const val HELPER_CONNECT_TIMEOUT_MILLIS = 5_000L
@@ -744,6 +874,10 @@ private const val ROUNDS_PATH = "/shielded-vote/v1/rounds"
 private const val ENDORSED_ROUNDS_PATH = "/shielded-vote/v1/endorsed-rounds/zodl"
 private const val DELEGATE_VOTE_PATH = "/shielded-vote/v1/delegate-vote"
 private const val CAST_VOTE_PATH = "/shielded-vote/v1/cast-vote"
+private const val RAW_GITHUBUSERCONTENT_HOST = "raw.githubusercontent.com"
+private const val CACHE_BUST_QUERY_PARAM = "zodl_cache_bust"
+private const val TRANSIENT_HTTP_STATUS_MIN = 500
+private const val TRANSIENT_HTTP_STATUS_MAX = 599
 
 private fun List<String>.normalizeServerUrls(): List<String> =
     map(String::trim)
@@ -879,17 +1013,6 @@ private fun tallyResultsPath(roundIdHex: String): String =
 private fun txConfirmationPath(txHash: String): String =
     "/shielded-vote/v1/tx/$txHash"
 
-/**
- * Never swallow a coroutine cancellation while collecting per-URL failures — rethrowing it
- * here (instead of inline in [KtorVotingApiProvider.fetchDynamicServiceConfig]) keeps that
- * loop's own throw count within detekt's [ThrowsCount] budget.
- */
-private fun Throwable.rethrowIfCancellation() {
-    if (this is CancellationException) {
-        throw this
-    }
-}
-
 internal fun shouldTreatEndorsedRoundsStatusAsEmpty(status: HttpStatusCode): Boolean =
     status == HttpStatusCode.BadRequest || status == HttpStatusCode.NotFound
 
@@ -901,12 +1024,29 @@ internal fun shouldTreatEndorsedRoundsFailoverFailuresAsEmpty(
             status != null && shouldTreatEndorsedRoundsStatusAsEmpty(status)
         }
 
-internal fun resolvePinnedConfigSource(configUrl: String): PinnedConfigSource =
-    if (configUrl.isNotEmpty()) {
-        runCatching { PinnedConfigSource.parse(configUrl) }.getOrNull()
+/**
+ * Resolves an override URL (a custom chain's pinned source, or remote config's
+ * `voting_config_url`) to its source list. An override that fails to parse, or an empty URL
+ * (no override configured), resolves to the full bundled mirror list
+ * ([StaticVotingConfig.BUNDLED_PINNED_CONFIG_SOURCES]) — canonical origin first, so a saved
+ * copy of the default keeps its own mirror fallback. A valid override is a single-element list
+ * (no mirrors) UNLESS it is byte-equal (URL and checksum, i.e. [PinnedConfigSource] equality)
+ * to one of the bundled mirrors, in which case the full bundled list is used instead.
+ */
+internal fun resolvePinnedConfigSource(configUrl: String): List<PinnedConfigSource> {
+    val parsedOverride =
+        if (configUrl.isNotEmpty()) {
+            runCatching { PinnedConfigSource.parse(configUrl) }.getOrNull()
+        } else {
+            null
+        } ?: return StaticVotingConfig.BUNDLED_PINNED_CONFIG_SOURCES
+
+    return if (parsedOverride in StaticVotingConfig.BUNDLED_PINNED_CONFIG_SOURCES) {
+        StaticVotingConfig.BUNDLED_PINNED_CONFIG_SOURCES
     } else {
-        null
-    } ?: PinnedConfigSource.parse(StaticVotingConfig.BUNDLED_PINNED_SOURCE)
+        listOf(parsedOverride)
+    }
+}
 
 private suspend fun Throwable.isNoActiveRoundFailure(): Boolean =
     when (this) {

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -36,7 +36,9 @@ import co.electriccoin.zcash.ui.common.repository.VotingChainConfigRepository
 import co.electriccoin.zcash.ui.configuration.ConfigurationEntries
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.ResponseException
+import io.ktor.client.plugins.retry
 import io.ktor.client.plugins.timeout
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.get
@@ -51,12 +53,14 @@ import io.ktor.http.content.TextContent
 import io.ktor.http.contentType
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.json.JSONObject
 import java.net.URI
 import java.util.UUID
@@ -129,6 +133,15 @@ class KtorVotingApiProvider(
     private val configurationRepository: ConfigurationRepository,
     private val votingChainConfigRepository: VotingChainConfigRepository,
     private val votingCryptoClient: VotingCryptoClient,
+    /**
+     * Per-attempt timeout for both config-fetch legs (MOB-1809), defaulting to
+     * [StaticVotingConfig.CONFIG_REQUEST_TIMEOUT_MS]. Overridable only so tests can inject a
+     * short value when exercising the app-side [withConfigRequestTimeoutFallback] path — the
+     * production default never changes, and DI (see `featureVotingModule`) never passes an
+     * override, so every real caller gets the same 15s bound both the Ktor-level and app-side
+     * timeout mechanisms share.
+     */
+    private val configRequestTimeoutMillis: Long = StaticVotingConfig.CONFIG_REQUEST_TIMEOUT_MS,
 ) : VotingApiProvider {
     private var cachedResolvedConfig: ResolvedVotingConfig? = null
     private val configMutex = Mutex()
@@ -451,13 +464,20 @@ class KtorVotingApiProvider(
         supportsKtorTimeouts: Boolean
     ): ByteArray =
         try {
-            get(url) {
-                noCache()
-                configRequestTimeout(supportsKtorTimeouts)
-            }.bodyAsBytes()
+            withConfigRequestTimeoutFallback(supportsKtorTimeouts, configRequestTimeoutMillis) {
+                get(url) {
+                    noCache()
+                    configRequestTimeout(supportsKtorTimeouts, configRequestTimeoutMillis)
+                    excludeFromClientRetry()
+                }.bodyAsBytes()
+            }
         } catch (responseException: ResponseException) {
             throw StaticVotingConfigFetchFailedException(
                 "Static voting config fetch failed: HTTP ${responseException.response.status.value}"
+            )
+        } catch (_: TimeoutCancellationException) {
+            throw StaticVotingConfigFetchFailedException(
+                "Static voting config fetch failed: request timed out after ${configRequestTimeoutMillis}ms"
             )
         } catch (exception: Exception) {
             exception.rethrowIfCancellation()
@@ -529,6 +549,11 @@ class KtorVotingApiProvider(
      * random value per walk invocation, shared by every busted request in that walk; the
      * cache-bust query parameter is applied to the request only — [url] itself, un-busted, is
      * what the caller logs and reports as the serving origin.
+     *
+     * The generic transport-failure branch below builds its message from that clean [url] plus
+     * the exception's short class name — never from `exception.message` verbatim, since for a
+     * Ktor timeout/connect failure that message can contain the full busted request URL,
+     * including the cache-bust token.
      */
     private suspend fun HttpClient.fetchDynamicConfigBody(
         url: String,
@@ -536,16 +561,23 @@ class KtorVotingApiProvider(
         supportsKtorTimeouts: Boolean
     ): String =
         try {
-            get(url.withCacheBustIfNeeded(cacheBustToken)) {
-                noCache()
-                configRequestTimeout(supportsKtorTimeouts)
-            }.bodyAsText()
+            withConfigRequestTimeoutFallback(supportsKtorTimeouts, configRequestTimeoutMillis) {
+                get(url.withCacheBustIfNeeded(cacheBustToken)) {
+                    noCache()
+                    configRequestTimeout(supportsKtorTimeouts, configRequestTimeoutMillis)
+                    excludeFromClientRetry()
+                }.bodyAsText()
+            }
         } catch (responseException: ResponseException) {
             throw responseException.toDynamicVotingConfigException()
+        } catch (_: TimeoutCancellationException) {
+            throw DynamicVotingConfigTransientException(
+                "Dynamic voting config fetch failed for $url: request timed out after ${configRequestTimeoutMillis}ms"
+            )
         } catch (exception: Exception) {
             exception.rethrowIfCancellation()
             throw DynamicVotingConfigTransientException(
-                "Dynamic voting config fetch failed: ${exception.message ?: exception::class.simpleName}"
+                "Dynamic voting config fetch failed for $url: ${exception::class.simpleName ?: "unknown error"}"
             )
         }
 
@@ -838,14 +870,60 @@ private fun HttpRequestBuilder.helperRequestTimeout(supportsKtorTimeouts: Boolea
     }
 }
 
-private fun HttpRequestBuilder.configRequestTimeout(supportsKtorTimeouts: Boolean) {
+private fun HttpRequestBuilder.configRequestTimeout(
+    supportsKtorTimeouts: Boolean,
+    timeoutMillis: Long
+) {
     if (supportsKtorTimeouts) {
         timeout {
-            requestTimeoutMillis = StaticVotingConfig.CONFIG_REQUEST_TIMEOUT_MS
-            socketTimeoutMillis = StaticVotingConfig.CONFIG_REQUEST_TIMEOUT_MS
-            connectTimeoutMillis = StaticVotingConfig.CONFIG_REQUEST_TIMEOUT_MS
+            requestTimeoutMillis = timeoutMillis
+            socketTimeoutMillis = timeoutMillis
+            connectTimeoutMillis = timeoutMillis
         }
     }
+}
+
+/**
+ * Bounds a config-fetch attempt to [timeoutMillis] app-side when Ktor-level timeouts are
+ * unavailable ([supportsKtorTimeouts] == false — the Tor client is built with
+ * `installTimeouts = false`, so [configRequestTimeout] is a no-op there and a stalling origin
+ * would otherwise hang the attempt forever). When [supportsKtorTimeouts] is true, [block] runs
+ * unbounded here — Ktor's own per-request [io.ktor.client.plugins.HttpTimeout] already enforces
+ * the same bound.
+ *
+ * TRAP: [kotlinx.coroutines.TimeoutCancellationException] EXTENDS [CancellationException].
+ * kotlinx.coroutines guarantees it is delivered only to the [kotlinx.coroutines.withTimeout]
+ * frame whose own deadline actually expired; a genuine OUTER cancellation manifests as a
+ * *different* [CancellationException] and is never caught by a `catch (TimeoutCancellationException)`
+ * clause here. Every caller MUST catch [TimeoutCancellationException] explicitly and convert it to
+ * that leg's own retryable exception BEFORE any generic `catch (exception: Exception)` /
+ * [rethrowIfCancellation] handling runs — letting it fall through to that generic handling would
+ * rethrow it as a cancellation and abort the whole mirror walk instead of falling through to the
+ * next mirror.
+ */
+private suspend fun <T> withConfigRequestTimeoutFallback(
+    supportsKtorTimeouts: Boolean,
+    timeoutMillis: Long,
+    block: suspend () -> T
+): T =
+    if (supportsKtorTimeouts) {
+        block()
+    } else {
+        withTimeout(timeoutMillis) { block() }
+    }
+
+/**
+ * Marks a config-fetch request as exempt from the direct client's [HttpRequestRetry] policy
+ * (MOB-1809): retry policy for a config request belongs entirely to [walkConfigSources]'s mirror
+ * fallback, which classifies and fails fast per attempt. Left unmarked, the client's default
+ * policy (`~5` attempts with exponential backoff, roughly 90s) would internally exhaust itself
+ * against a single dead mirror before the walk's own classification — and
+ * [withConfigRequestTimeoutFallback]'s fail-fast bound — ever runs. Uses Ktor's own per-request
+ * retry configuration ([io.ktor.client.plugins.retry]); on a client where [HttpRequestRetry]
+ * isn't installed at all (the Tor client), this is a harmless no-op.
+ */
+private fun HttpRequestBuilder.excludeFromClientRetry() {
+    retry { noRetry() }
 }
 
 /**
@@ -855,14 +933,43 @@ private fun HttpRequestBuilder.configRequestTimeout(supportsKtorTimeouts: Boolea
  * CDN caches branch paths for roughly 300 seconds server-side and ignores request cache-control
  * headers, which matters during round rollover; a content-addressed pin never needs this since
  * its bytes are immutable by definition.
+ *
+ * This is only ever applied to the DYNAMIC config leg's URLs. The static leg's
+ * raw.githubusercontent.com mirror ([StaticVotingConfig.BUNDLED_PINNED_SOURCE_MIRROR]) is
+ * deliberately never cache-busted, matching iOS: that path is content-addressed (the checksum is
+ * in the filename itself), so its bytes are immutable by construction and a pin bump changes the
+ * URL rather than the content behind an existing one — there is nothing for a CDN cache to serve
+ * stale.
+ *
+ * Rebuilt via URI components (scheme/authority/path/query/fragment) rather than blind string
+ * concatenation, so the busted query parameter always lands before a fragment instead of being
+ * appended after one and silently becoming part of it. Config URLs are not expected to carry a
+ * fragment in practice, but this stays correct if one is ever present.
  */
 private fun String.withCacheBustIfNeeded(token: String): String {
-    val host = runCatching { URI(this).host }.getOrNull()
-    if (!host.equals(RAW_GITHUBUSERCONTENT_HOST, ignoreCase = true)) {
+    val uri = runCatching { URI(this) }.getOrNull()
+    if (uri == null || !uri.host.equals(RAW_GITHUBUSERCONTENT_HOST, ignoreCase = true)) {
         return this
     }
-    val separator = if (contains('?')) '&' else '?'
-    return "$this$separator$CACHE_BUST_QUERY_PARAM=$token"
+    val existingQuery = uri.rawQuery
+    val bustedQuery =
+        if (existingQuery.isNullOrEmpty()) {
+            "$CACHE_BUST_QUERY_PARAM=$token"
+        } else {
+            "$existingQuery&$CACHE_BUST_QUERY_PARAM=$token"
+        }
+    return buildString {
+        append(uri.scheme)
+        append("://")
+        append(uri.rawAuthority)
+        append(uri.rawPath.orEmpty())
+        append('?')
+        append(bustedQuery)
+        if (uri.rawFragment != null) {
+            append('#')
+            append(uri.rawFragment)
+        }
+    }
 }
 
 private const val HELPER_REQUEST_TIMEOUT_MILLIS = 5_000L

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -434,17 +434,8 @@ class KtorVotingApiProvider(
         val staticConfig = fetchStaticConfig(source)
         val rawServiceConfig =
             execute {
-                try {
-                    get(staticConfig.dynamicConfigURL) {
-                        noCache()
-                    }.bodyAsText()
-                } catch (responseException: ResponseException) {
-                    throw VotingConfigException(
-                        "Dynamic voting config fetch failed: HTTP ${responseException.response.status.value}"
-                    )
-                }
-            }.let(VotingServiceConfig::decode)
-                .also(VotingServiceConfig::validate)
+                fetchDynamicServiceConfig(staticConfig.resolvedDynamicConfigUrls())
+            }
         val serviceConfig = rawServiceConfig.retainingRoundsWithValidSignatures(staticConfig.trustedKeys)
 
         return ResolvedVotingConfig(
@@ -453,6 +444,50 @@ class KtorVotingApiProvider(
             rawServiceConfig = rawServiceConfig,
             serviceConfig = serviceConfig
         )
+    }
+
+    /**
+     * Tries every configured dynamic-config URL in order (v2's fallback mirror alongside the
+     * primary valargroup.dev host — MOB-1806) and returns the first one that fetches, decodes,
+     * and validates successfully. Unlike [withVoteServerFailover]/[shouldTryNextVoteServer], a
+     * [VotingConfigException] from decode or validate is retryable here too — a malformed or
+     * unreachable mirror should not prevent falling through to the next URL. All URLs failing
+     * throws one [VotingConfigException] naming every URL's failure.
+     */
+    private suspend fun HttpClient.fetchDynamicServiceConfig(urls: List<String>): VotingServiceConfig {
+        val normalizedUrls = urls.map(String::trim).filter(String::isNotEmpty).distinct()
+        if (normalizedUrls.isEmpty()) {
+            throw VotingConfigException("Static voting config does not list any dynamic_config_urls")
+        }
+
+        val failures = mutableListOf<String>()
+        for (url in normalizedUrls) {
+            try {
+                return fetchSingleDynamicServiceConfig(url)
+            } catch (exception: Exception) {
+                exception.rethrowIfCancellation()
+                failures += "$url: ${exception.message ?: exception::class.simpleName}"
+            }
+        }
+
+        throw VotingConfigException(
+            "Dynamic voting config fetch failed for all ${normalizedUrls.size} configured URL(s): " +
+                failures.joinToString("; ")
+        )
+    }
+
+    private suspend fun HttpClient.fetchSingleDynamicServiceConfig(url: String): VotingServiceConfig {
+        val body =
+            try {
+                get(url) {
+                    noCache()
+                }.bodyAsText()
+            } catch (responseException: ResponseException) {
+                throw VotingConfigException(
+                    "Dynamic voting config fetch failed: HTTP ${responseException.response.status.value}"
+                )
+            }
+        return VotingServiceConfig.decode(body).also(VotingServiceConfig::validate)
     }
 
     private suspend fun authenticateVotingSession(session: VotingSession): VotingSession {
@@ -843,6 +878,17 @@ private fun tallyResultsPath(roundIdHex: String): String =
 
 private fun txConfirmationPath(txHash: String): String =
     "/shielded-vote/v1/tx/$txHash"
+
+/**
+ * Never swallow a coroutine cancellation while collecting per-URL failures — rethrowing it
+ * here (instead of inline in [KtorVotingApiProvider.fetchDynamicServiceConfig]) keeps that
+ * loop's own throw count within detekt's [ThrowsCount] budget.
+ */
+private fun Throwable.rethrowIfCancellation() {
+    if (this is CancellationException) {
+        throw this
+    }
+}
 
 internal fun shouldTreatEndorsedRoundsStatusAsEmpty(status: HttpStatusCode): Boolean =
     status == HttpStatusCode.BadRequest || status == HttpStatusCode.NotFound

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingConfigMirrorWalk.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingConfigMirrorWalk.kt
@@ -1,0 +1,65 @@
+package co.electriccoin.zcash.ui.common.provider
+
+import co.electriccoin.zcash.spackle.Twig
+import co.electriccoin.zcash.ui.common.model.voting.VotingConfigException
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Generic mirror walk shared by the static and dynamic voting-config fetch legs (MOB-1809):
+ * tries [sources] in order and returns the first [operation] call that succeeds. [operation]
+ * must only ever fail with a [VotingConfigException] (its call sites wrap every transport and
+ * decode/validate failure into one) — a coroutine cancellation is never a [VotingConfigException]
+ * and so is never intercepted here, propagating untouched. [shouldTryNext] decides whether a
+ * given [VotingConfigException] is retryable (fall through to the next source) or authoritative
+ * (thrown immediately, no further sources tried) — the same shape as
+ * [shouldTryNextVoteServer]/[withVoteServerFailover] for the vote-server leg, but with a
+ * different exhaustion contract: when every source fails, the FIRST (canonical origin's) error
+ * is thrown verbatim, not wrapped in a joined/aggregate exception, since every mirror is
+ * expected to serve identical content and the canonical origin's own failure is the one worth
+ * reporting.
+ */
+internal suspend fun <TSource, T> walkConfigSources(
+    sources: List<TSource>,
+    emptyMessage: String,
+    describe: (TSource) -> String,
+    shouldTryNext: (Throwable) -> Boolean,
+    operation: suspend (TSource) -> T
+): T {
+    if (sources.isEmpty()) {
+        throw VotingConfigException(emptyMessage)
+    }
+
+    var firstError: VotingConfigException? = null
+    sources.forEachIndexed { index, source ->
+        try {
+            val result = operation(source)
+            if (index > 0) {
+                Twig.info { "Voting config resolved via ${describe(source)} (attempt ${index + 1})" }
+            }
+            return result
+        } catch (exception: VotingConfigException) {
+            exception.rethrowIfNotRetryable(shouldTryNext)
+            if (firstError == null) firstError = exception
+            Twig.warn(exception) { "Voting config mirror ${describe(source)} failed, trying next mirror" }
+        }
+    }
+
+    throw firstError ?: VotingConfigException(emptyMessage)
+}
+
+private fun VotingConfigException.rethrowIfNotRetryable(shouldTryNext: (Throwable) -> Boolean) {
+    if (!shouldTryNext(this)) {
+        throw this
+    }
+}
+
+/**
+ * Never swallow a coroutine cancellation while wrapping a config-fetch failure — rethrowing it
+ * here (instead of inline at every call site) keeps each call site's own throw count within
+ * detekt's ThrowsCount budget.
+ */
+internal fun Throwable.rethrowIfCancellation() {
+    if (this is CancellationException) {
+        throw this
+    }
+}

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingConfigMirrorWalk.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingConfigMirrorWalk.kt
@@ -35,6 +35,8 @@ internal suspend fun <TSource, T> walkConfigSources(
             val result = operation(source)
             if (index > 0) {
                 Twig.info { "Voting config resolved via ${describe(source)} (attempt ${index + 1})" }
+            } else {
+                Twig.debug { "Voting config resolved via ${describe(source)}" }
             }
             return result
         } catch (exception: VotingConfigException) {

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/chainconfig/VoteChainConfigVM.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/chainconfig/VoteChainConfigVM.kt
@@ -297,7 +297,7 @@ class VoteChainConfigVM(
         current: VotingChainConfigState,
         editingId: String?
     ): StringResource? {
-        if (parsedSource == PinnedConfigSource.parse(StaticVotingConfig.BUNDLED_PINNED_SOURCE)) {
+        if (parsedSource.isBundledDefaultUrl()) {
             return stringRes(R.string.vote_chain_config_error_duplicate_default)
         }
 
@@ -419,8 +419,14 @@ private fun compactSource(raw: String): String =
     runCatching { PinnedConfigSource.parse(raw).url }
         .getOrDefault(raw)
 
+/**
+ * A pinned source counts as the bundled default when it is byte-equal (URL and checksum) to
+ * any of [StaticVotingConfig.BUNDLED_PINNED_CONFIG_SOURCES] — canonical origin or mirror. A
+ * matching URL with a *different* checksum is a deliberately re-pinned custom source and must
+ * stay custom, not silently collapse to Default.
+ */
 private fun PinnedConfigSource.isBundledDefaultUrl(): Boolean =
-    url == PinnedConfigSource.parse(StaticVotingConfig.BUNDLED_PINNED_SOURCE).url
+    this in StaticVotingConfig.BUNDLED_PINNED_CONFIG_SOURCES
 
 private fun EditorDraft.canSave(): Boolean =
     name.trim().length <= MAX_CUSTOM_CHAIN_NAME_LENGTH &&

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/chainconfig/VoteChainConfigVM.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/chainconfig/VoteChainConfigVM.kt
@@ -425,7 +425,7 @@ private fun compactSource(raw: String): String =
  * matching URL with a *different* checksum is a deliberately re-pinned custom source and must
  * stay custom, not silently collapse to Default.
  */
-private fun PinnedConfigSource.isBundledDefaultUrl(): Boolean =
+internal fun PinnedConfigSource.isBundledDefaultUrl(): Boolean =
     this in StaticVotingConfig.BUNDLED_PINNED_CONFIG_SOURCES
 
 private fun EditorDraft.canSave(): Boolean =

--- a/feature-voting/src/main/java/co/electriccoin/zcash/voting/di/FeatureVotingModule.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/voting/di/FeatureVotingModule.kt
@@ -76,7 +76,14 @@ val featureVotingModule =
         // Providers
         singleOf(::VotingCryptoClientImpl) bind VotingCryptoClient::class
         singleOf(::VotingHotkeySeedProviderImpl) bind VotingHotkeySeedProvider::class
-        singleOf(::KtorVotingApiProvider) bind VotingApiProvider::class
+        single<VotingApiProvider> {
+            KtorVotingApiProvider(
+                httpClientProvider = get(),
+                configurationRepository = get(),
+                votingChainConfigRepository = get(),
+                votingCryptoClient = get()
+            )
+        }
         singleOf(::HttpPirSnapshotResolver) bind PirSnapshotResolver::class
         singleOf(::VotingShareTrackingScheduler)
 

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/model/voting/VotingServiceConfigTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/model/voting/VotingServiceConfigTest.kt
@@ -105,6 +105,36 @@ class StaticVotingConfigTest {
         }
     }
 
+    /**
+     * A hash mismatch must be distinguishable from a decode/validate failure — the mirror walk
+     * (`KtorVotingApiProvider.fetchStaticConfigWalk`) retries the next mirror only for the
+     * former.
+     */
+    @Test
+    fun staticConfigDecodeAndVerifyThrowsHashMismatchExceptionOnMismatch() {
+        val data = makeStaticConfigJson().toByteArray(Charsets.UTF_8)
+
+        assertFailsWith<StaticVotingConfigHashMismatchException> {
+            StaticVotingConfig.decodeAndVerify(data = data, expectedSHA256 = ByteArray(32))
+        }
+    }
+
+    /**
+     * A decode failure on bytes whose hash *does* match the pin must not be reported as a hash
+     * mismatch — the walk treats this case as authoritative, not retryable.
+     */
+    @Test
+    fun staticConfigDecodeAndVerifyDoesNotThrowHashMismatchExceptionOnDecodeFailure() {
+        val data = "not json".toByteArray(Charsets.UTF_8)
+        val sha256 = MessageDigest.getInstance("SHA-256").digest(data)
+
+        val exception =
+            assertFailsWith<VotingConfigException> {
+                StaticVotingConfig.decodeAndVerify(data = data, expectedSHA256 = sha256)
+            }
+        assertFalse(exception is StaticVotingConfigHashMismatchException)
+    }
+
     @Test
     fun staticConfigValidationRejectsShortTrustedKey() {
         val data =
@@ -176,6 +206,72 @@ class StaticVotingConfigTest {
         }
     }
 
+    /** A v2 payload carrying only the v1-shaped singular field must not satisfy v2's array requirement. */
+    @Test
+    fun staticConfigV2RejectsSingularUrlOnly() {
+        val data = makeStaticConfigJsonV2WithSingularUrlOnly().toByteArray(Charsets.UTF_8)
+
+        assertFailsWith<VotingConfigException> {
+            StaticVotingConfig.decodeAndVerify(data = data, expectedSHA256 = null)
+        }
+    }
+
+    /** A v1 payload carrying only the v2-shaped array must not satisfy v1's singular requirement. */
+    @Test
+    fun staticConfigV1RejectsPluralUrlOnly() {
+        val data = makeStaticConfigJsonV1WithPluralUrlOnly().toByteArray(Charsets.UTF_8)
+
+        assertFailsWith<VotingConfigException> {
+            StaticVotingConfig.decodeAndVerify(data = data, expectedSHA256 = null)
+        }
+    }
+
+    @Test
+    fun staticConfigRejectsMissingVersionField() {
+        val data = makeStaticConfigJsonWithoutVersion().toByteArray(Charsets.UTF_8)
+
+        assertFailsWith<VotingConfigException> {
+            StaticVotingConfig.decodeAndVerify(data = data, expectedSHA256 = null)
+        }
+    }
+
+    @Test
+    fun staticConfigV1RejectsNonHttpsDynamicConfigUrl() {
+        val data =
+            makeStaticConfigJson(dynamicConfigUrl = "http://example.com/dynamic-voting-config.json")
+                .toByteArray(Charsets.UTF_8)
+
+        val exception =
+            assertFailsWith<VotingConfigException> {
+                StaticVotingConfig.decodeAndVerify(data = data, expectedSHA256 = null)
+            }
+        assertEquals(
+            "dynamic_config_url must use https; got http://example.com/dynamic-voting-config.json",
+            exception.message
+        )
+    }
+
+    @Test
+    fun staticConfigV2RejectsNonHttpsDynamicConfigUrl() {
+        val data =
+            makeStaticConfigJsonV2(
+                dynamicConfigUrls =
+                    listOf(
+                        "https://example.com/dynamic-voting-config.json",
+                        "http://mirror.example.com/dynamic-voting-config.json"
+                    )
+            ).toByteArray(Charsets.UTF_8)
+
+        val exception =
+            assertFailsWith<VotingConfigException> {
+                StaticVotingConfig.decodeAndVerify(data = data, expectedSHA256 = null)
+            }
+        assertEquals(
+            "dynamic_config_urls must use https; got http://mirror.example.com/dynamic-voting-config.json",
+            exception.message
+        )
+    }
+
     @Test
     fun resolvedDynamicConfigUrlsUnifiesV1AndV2() {
         val v1Config =
@@ -203,13 +299,85 @@ class StaticVotingConfigTest {
         )
     }
 
+    /**
+     * Both bundled mirrors must carry the identical checksum in the path segment AND the query
+     * param, and parsing must strip the checksum from the fetched URL — the pin's trust is
+     * carried by the checksum alone, so both mirrors have to be pinned to the same bytes.
+     */
+    @Test
+    fun bundledPinnedSourcesShareChecksumInPathAndQuery() {
+        val bundledSources =
+            listOf(
+                StaticVotingConfig.BUNDLED_PINNED_SOURCE,
+                StaticVotingConfig.BUNDLED_PINNED_SOURCE_MIRROR
+            )
+
+        bundledSources.forEach { raw ->
+            assertTrue(raw.contains("/$BUNDLED_CHECKSUM_HEX/"), raw)
+            assertTrue(raw.contains("checksum=sha256:$BUNDLED_CHECKSUM_HEX"), raw)
+
+            val source = PinnedConfigSource.parse(raw)
+            assertEquals(BUNDLED_CHECKSUM_HEX, source.sha256?.toLowerHex())
+            assertFalse(source.url.contains("checksum="), source.url)
+        }
+    }
+
+    @Test
+    fun bundledPinnedSourcesListCanonicalOriginBeforeMirror() {
+        assertEquals(
+            listOf(StaticVotingConfig.BUNDLED_PINNED_SOURCE, StaticVotingConfig.BUNDLED_PINNED_SOURCE_MIRROR),
+            StaticVotingConfig.BUNDLED_PINNED_SOURCES
+        )
+        assertEquals(
+            listOf(
+                PinnedConfigSource.parse(StaticVotingConfig.BUNDLED_PINNED_SOURCE),
+                PinnedConfigSource.parse(StaticVotingConfig.BUNDLED_PINNED_SOURCE_MIRROR)
+            ),
+            StaticVotingConfig.BUNDLED_PINNED_CONFIG_SOURCES
+        )
+    }
+
     private fun makeStaticConfigJson(
+        pubkey: String = ADMIN_PUBKEY_BASE64,
+        dynamicConfigUrl: String = "https://example.com/dynamic-voting-config.json"
+    ): String =
+        """
+        {
+          "static_config_version": 1,
+          "dynamic_config_url": "$dynamicConfigUrl",
+          "trusted_keys": [
+            {
+              "key_id": "valar-test",
+              "alg": "ed25519",
+              "pubkey": "$pubkey"
+            }
+          ]
+        }
+        """.trimIndent()
+
+    private fun makeStaticConfigJsonWithoutVersion(
+        pubkey: String = ADMIN_PUBKEY_BASE64
+    ): String =
+        """
+        {
+          "dynamic_config_url": "https://example.com/dynamic-voting-config.json",
+          "trusted_keys": [
+            {
+              "key_id": "valar-test",
+              "alg": "ed25519",
+              "pubkey": "$pubkey"
+            }
+          ]
+        }
+        """.trimIndent()
+
+    private fun makeStaticConfigJsonV1WithPluralUrlOnly(
         pubkey: String = ADMIN_PUBKEY_BASE64
     ): String =
         """
         {
           "static_config_version": 1,
-          "dynamic_config_url": "https://example.com/dynamic-voting-config.json",
+          "dynamic_config_urls": [${V2_DYNAMIC_CONFIG_URLS.joinToString(",") { url -> "\"$url\"" }}],
           "trusted_keys": [
             {
               "key_id": "valar-test",
@@ -254,6 +422,23 @@ class StaticVotingConfigTest {
         }
         """.trimIndent()
 
+    private fun makeStaticConfigJsonV2WithSingularUrlOnly(
+        pubkey: String = ADMIN_PUBKEY_BASE64
+    ): String =
+        """
+        {
+          "static_config_version": 2,
+          "dynamic_config_url": "https://example.com/dynamic-voting-config.json",
+          "trusted_keys": [
+            {
+              "key_id": "valar-test",
+              "alg": "ed25519",
+              "pubkey": "$pubkey"
+            }
+          ]
+        }
+        """.trimIndent()
+
     private fun makeStaticConfigJsonV2WithoutDynamicConfigUrlsField(
         pubkey: String = ADMIN_PUBKEY_BASE64
     ): String =
@@ -271,6 +456,8 @@ class StaticVotingConfigTest {
         """.trimIndent()
 
     private companion object {
+        const val BUNDLED_CHECKSUM_HEX = "28fc9b631091ae8bc2f8635d8930489238ce144174cbd15a03efb0530b301ebe"
+
         val V2_DYNAMIC_CONFIG_URLS =
             listOf(
                 "https://voting.valargroup.dev/prod/dynamic-voting-config.json",

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/model/voting/VotingServiceConfigTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/model/voting/VotingServiceConfigTest.kt
@@ -184,6 +184,44 @@ class StaticVotingConfigTest {
     }
 
     @Test
+    fun unsupportedVersionExceptionMessageIsExact() {
+        val data =
+            makeStaticConfigJson()
+                .replace("\"static_config_version\": 1", "\"static_config_version\": 3")
+                .toByteArray(Charsets.UTF_8)
+
+        val exception =
+            assertFailsWith<VotingConfigException> {
+                StaticVotingConfig.decodeAndVerify(data = data, expectedSHA256 = null)
+            }
+
+        assertEquals("Unsupported static_config_version 3", exception.message)
+    }
+
+    /**
+     * The unsupported-version check must win over every field check: a v3 payload with neither
+     * `dynamic_config_url` nor `dynamic_config_urls` (nor even `trusted_keys`) must still report
+     * the version error, not a missing-field error.
+     */
+    @Test
+    fun unsupportedVersionWinsOverMissingDynamicUrlFields() {
+        val data =
+            """
+            {
+              "static_config_version": 3,
+              "trusted_keys": []
+            }
+            """.trimIndent().toByteArray(Charsets.UTF_8)
+
+        val exception =
+            assertFailsWith<VotingConfigException> {
+                StaticVotingConfig.decodeAndVerify(data = data, expectedSHA256 = null)
+            }
+
+        assertEquals("Unsupported static_config_version 3", exception.message)
+    }
+
+    @Test
     fun staticConfigV2RejectsMissingOrEmptyDynamicConfigUrls() {
         listOf(
             makeStaticConfigJsonV2(dynamicConfigUrls = emptyList()),

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/model/voting/VotingServiceConfigTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/model/voting/VotingServiceConfigTest.kt
@@ -117,6 +117,92 @@ class StaticVotingConfigTest {
         }
     }
 
+    @Test
+    fun staticConfigV1StillParses() {
+        val data = makeStaticConfigJson().toByteArray(Charsets.UTF_8)
+
+        val config = StaticVotingConfig.decodeAndVerify(data = data, expectedSHA256 = null)
+
+        assertEquals(1, config.staticConfigVersion)
+        assertEquals("https://example.com/dynamic-voting-config.json", config.dynamicConfigURL)
+        assertEquals(emptyList(), config.dynamicConfigURLs)
+    }
+
+    @Test
+    fun staticConfigV2ParsesAndValidates() {
+        val data = makeStaticConfigJsonV2().toByteArray(Charsets.UTF_8)
+        val sha256 = MessageDigest.getInstance("SHA-256").digest(data)
+
+        val config = StaticVotingConfig.decodeAndVerify(data = data, expectedSHA256 = sha256)
+
+        assertEquals(2, config.staticConfigVersion)
+        assertEquals(V2_DYNAMIC_CONFIG_URLS, config.dynamicConfigURLs)
+        assertEquals(null, config.dynamicConfigURL)
+        assertEquals(1, config.trustedKeys.size)
+    }
+
+    @Test
+    fun staticConfigRejectsUnsupportedVersion() {
+        val data =
+            makeStaticConfigJson()
+                .replace("\"static_config_version\": 1", "\"static_config_version\": 3")
+                .toByteArray(Charsets.UTF_8)
+
+        assertFailsWith<VotingConfigException> {
+            StaticVotingConfig.decodeAndVerify(data = data, expectedSHA256 = null)
+        }
+    }
+
+    @Test
+    fun staticConfigV2RejectsMissingOrEmptyDynamicConfigUrls() {
+        listOf(
+            makeStaticConfigJsonV2(dynamicConfigUrls = emptyList()),
+            makeStaticConfigJsonV2WithoutDynamicConfigUrlsField()
+        ).forEach { json ->
+            val data = json.toByteArray(Charsets.UTF_8)
+
+            assertFailsWith<VotingConfigException>(json) {
+                StaticVotingConfig.decodeAndVerify(data = data, expectedSHA256 = null)
+            }
+        }
+    }
+
+    @Test
+    fun staticConfigV1RejectsMissingDynamicConfigUrl() {
+        val data = makeStaticConfigJsonV1WithoutDynamicConfigUrl().toByteArray(Charsets.UTF_8)
+
+        assertFailsWith<VotingConfigException> {
+            StaticVotingConfig.decodeAndVerify(data = data, expectedSHA256 = null)
+        }
+    }
+
+    @Test
+    fun resolvedDynamicConfigUrlsUnifiesV1AndV2() {
+        val v1Config =
+            StaticVotingConfig.decodeAndVerify(
+                data = makeStaticConfigJson().toByteArray(Charsets.UTF_8),
+                expectedSHA256 = null
+            )
+        val v2Config =
+            StaticVotingConfig.decodeAndVerify(
+                data = makeStaticConfigJsonV2().toByteArray(Charsets.UTF_8),
+                expectedSHA256 = null
+            )
+
+        assertEquals(listOf("https://example.com/dynamic-voting-config.json"), v1Config.resolvedDynamicConfigUrls())
+        assertEquals(V2_DYNAMIC_CONFIG_URLS, v2Config.resolvedDynamicConfigUrls())
+    }
+
+    @Test
+    fun bundledPinnedSourceHasExpectedV2Sha256() {
+        val source = PinnedConfigSource.parse(StaticVotingConfig.BUNDLED_PINNED_SOURCE)
+
+        assertEquals(
+            "28fc9b631091ae8bc2f8635d8930489238ce144174cbd15a03efb0530b301ebe",
+            source.sha256?.toLowerHex()
+        )
+    }
+
     private fun makeStaticConfigJson(
         pubkey: String = ADMIN_PUBKEY_BASE64
     ): String =
@@ -133,6 +219,65 @@ class StaticVotingConfigTest {
           ]
         }
         """.trimIndent()
+
+    private fun makeStaticConfigJsonV1WithoutDynamicConfigUrl(
+        pubkey: String = ADMIN_PUBKEY_BASE64
+    ): String =
+        """
+        {
+          "static_config_version": 1,
+          "trusted_keys": [
+            {
+              "key_id": "valar-test",
+              "alg": "ed25519",
+              "pubkey": "$pubkey"
+            }
+          ]
+        }
+        """.trimIndent()
+
+    private fun makeStaticConfigJsonV2(
+        pubkey: String = ADMIN_PUBKEY_BASE64,
+        dynamicConfigUrls: List<String> = V2_DYNAMIC_CONFIG_URLS
+    ): String =
+        """
+        {
+          "static_config_version": 2,
+          "dynamic_config_urls": [${dynamicConfigUrls.joinToString(",") { url -> "\"$url\"" }}],
+          "trusted_keys": [
+            {
+              "key_id": "valar-test",
+              "alg": "ed25519",
+              "pubkey": "$pubkey"
+            }
+          ]
+        }
+        """.trimIndent()
+
+    private fun makeStaticConfigJsonV2WithoutDynamicConfigUrlsField(
+        pubkey: String = ADMIN_PUBKEY_BASE64
+    ): String =
+        """
+        {
+          "static_config_version": 2,
+          "trusted_keys": [
+            {
+              "key_id": "valar-test",
+              "alg": "ed25519",
+              "pubkey": "$pubkey"
+            }
+          ]
+        }
+        """.trimIndent()
+
+    private companion object {
+        val V2_DYNAMIC_CONFIG_URLS =
+            listOf(
+                "https://voting.valargroup.dev/prod/dynamic-voting-config.json",
+                "https://raw.githubusercontent.com/valargroup/token-holder-voting-config/main/prod/" +
+                    "dynamic-voting-config.json"
+            )
+    }
 }
 
 class ZodlEndorsedRoundsResponseTest {

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/KtorVotingApiProviderTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/KtorVotingApiProviderTest.kt
@@ -11,10 +11,17 @@ import co.electriccoin.zcash.ui.common.repository.VotingCustomChainConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.HttpTimeoutCapability
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking
@@ -184,6 +191,448 @@ class KtorVotingApiProviderTest {
             assertFalse(requestTimeoutCapabilities.single())
         }
 
+    // region config-request timeout capability (MOB-1809)
+
+    @Test
+    fun configRequestsCarryFifteenSecondTimeoutCapabilityWhenSupported() =
+        runBlocking {
+            val timeoutCapabilities = mutableListOf<Pair<String, Long?>>()
+            val provider = multiEndpointProvider(timeoutCapabilities = timeoutCapabilities)
+
+            provider.fetchServiceConfig()
+
+            val configPaths = setOf("/static-voting-config.json", "/dynamic-voting-config.json")
+            val configCapabilities = timeoutCapabilities.filter { (path, _) -> path in configPaths }
+            assertEquals(listOf(15_000L, 15_000L), configCapabilities.map { (_, millis) -> millis })
+        }
+
+    @Test
+    fun voteServerRequestDoesNotCarryConfigTimeoutCapability() =
+        runBlocking {
+            val timeoutCapabilities = mutableListOf<Pair<String, Long?>>()
+            val provider = multiEndpointProvider(timeoutCapabilities = timeoutCapabilities)
+
+            provider.fetchAllRounds()
+
+            val roundsCapability = timeoutCapabilities.first { (path, _) -> path == ROUNDS_TEST_PATH }.second
+            assertEquals(null, roundsCapability)
+        }
+
+    @Test
+    fun appSideTimeoutFallbackFallsThroughToNextMirrorWhenKtorTimeoutsUnsupported() =
+        runBlocking {
+            val requests = mutableListOf<String>()
+            val provider =
+                KtorVotingApiProvider(
+                    httpClientProvider =
+                        object : HttpClientProvider {
+                            override suspend fun supportsKtorTimeouts(): Boolean = false
+
+                            override suspend fun createTor(): HttpClient = create()
+
+                            override suspend fun create(): HttpClient =
+                                HttpClient(
+                                    MockEngine { request ->
+                                        val path = request.url.encodedPath
+                                        requests += path
+                                        when (path) {
+                                            "/static-voting-config.json" -> {
+                                                respond(
+                                                    content =
+                                                        staticConfigJsonV2(
+                                                            listOf(FIRST_DYNAMIC_CONFIG_URL, SECOND_DYNAMIC_CONFIG_URL)
+                                                        ),
+                                                    status = HttpStatusCode.OK,
+                                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                                )
+                                            }
+
+                                            "/first-dynamic-voting-config.json" -> {
+                                                awaitCancellation()
+                                            }
+
+                                            else -> {
+                                                respond(
+                                                    content = validDynamicServiceConfigJson(),
+                                                    status = HttpStatusCode.OK,
+                                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                                )
+                                            }
+                                        }
+                                    }
+                                ) { expectSuccess = true }
+                        },
+                    configurationRepository = TestConfigurationRepository(),
+                    votingChainConfigRepository = TestVotingChainConfigRepository(),
+                    votingCryptoClient = unusedVotingCryptoClient(),
+                    configRequestTimeoutMillis = TEST_TIMEOUT_MILLIS
+                )
+
+            val serviceConfig = provider.fetchServiceConfig()
+
+            assertEquals(
+                listOf(
+                    "/static-voting-config.json",
+                    "/first-dynamic-voting-config.json",
+                    "/second-dynamic-voting-config.json"
+                ),
+                requests
+            )
+            assertEquals(1, serviceConfig.voteServers.size)
+        }
+
+    // endregion
+
+    // region memoization (MOB-1809)
+
+    @Test
+    fun resolvedConfigIsMemoizedAcrossConsecutiveCalls() =
+        runBlocking {
+            val requestLog = mutableListOf<String>()
+            val provider = multiEndpointProvider(requestLog = requestLog)
+
+            provider.fetchAllRounds()
+            provider.fetchAllRounds()
+
+            assertEquals(1, requestLog.count { path -> path == "/static-voting-config.json" })
+            assertEquals(1, requestLog.count { path -> path == "/dynamic-voting-config.json" })
+            assertEquals(2, requestLog.count { path -> path == ROUNDS_TEST_PATH })
+        }
+
+    @Test
+    fun changingSelectedSourceRefetchesConfig() =
+        runBlocking {
+            val requestLog = mutableListOf<String>()
+            val sourceUrlA = "https://example.com/static-config-a.json"
+            val sourceUrlB = "https://example.com/static-config-b.json"
+            val repository = SwitchableVotingChainConfigRepository(initialPinnedSource = sourceUrlA)
+            val provider =
+                KtorVotingApiProvider(
+                    httpClientProvider =
+                        object : HttpClientProvider {
+                            override suspend fun supportsKtorTimeouts(): Boolean = true
+
+                            override suspend fun createTor(): HttpClient = create()
+
+                            override suspend fun create(): HttpClient =
+                                HttpClient(
+                                    MockEngine { request ->
+                                        val path = request.url.encodedPath
+                                        requestLog += path
+                                        when (path) {
+                                            "/static-config-a.json", "/static-config-b.json" -> {
+                                                respond(
+                                                    content = staticConfigJson(dynamicConfigUrl = DYNAMIC_CONFIG_URL),
+                                                    status = HttpStatusCode.OK,
+                                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                                )
+                                            }
+
+                                            "/dynamic-voting-config.json" -> {
+                                                respond(
+                                                    content = validDynamicServiceConfigJson(),
+                                                    status = HttpStatusCode.OK,
+                                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                                )
+                                            }
+
+                                            ROUNDS_TEST_PATH -> {
+                                                respond(
+                                                    content = """{"rounds": []}""",
+                                                    status = HttpStatusCode.OK,
+                                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                                )
+                                            }
+
+                                            else -> {
+                                                respond(content = "not found", status = HttpStatusCode.NotFound)
+                                            }
+                                        }
+                                    }
+                                ) {
+                                    expectSuccess = true
+                                    install(ContentNegotiation) { json() }
+                                }
+                        },
+                    configurationRepository = TestConfigurationRepository(),
+                    votingChainConfigRepository = repository,
+                    votingCryptoClient = unusedVotingCryptoClient()
+                )
+
+            provider.fetchAllRounds()
+            repository.switchTo(sourceUrlB)
+            provider.fetchAllRounds()
+
+            assertEquals(1, requestLog.count { path -> path == "/static-config-a.json" })
+            assertEquals(1, requestLog.count { path -> path == "/static-config-b.json" })
+        }
+
+    @Test
+    fun invalidateConfigCacheForcesRefetch() =
+        runBlocking {
+            val requestLog = mutableListOf<String>()
+            val provider = multiEndpointProvider(requestLog = requestLog)
+
+            provider.fetchAllRounds()
+            provider.invalidateConfigCache()
+            provider.fetchAllRounds()
+
+            assertEquals(2, requestLog.count { path -> path == "/static-voting-config.json" })
+            assertEquals(2, requestLog.count { path -> path == "/dynamic-voting-config.json" })
+        }
+
+    // endregion
+
+    // region cancellation propagation with the app-side timeout fallback in place (MOB-1809)
+
+    @Test
+    fun genuineCancellationDuringAppSideTimeoutWrappedAttemptIsNotConvertedToRetryableFailure() =
+        runBlocking {
+            val requests = mutableListOf<String>()
+            val provider =
+                KtorVotingApiProvider(
+                    httpClientProvider =
+                        object : HttpClientProvider {
+                            override suspend fun supportsKtorTimeouts(): Boolean = false
+
+                            override suspend fun createTor(): HttpClient = create()
+
+                            override suspend fun create(): HttpClient =
+                                HttpClient(
+                                    MockEngine { request ->
+                                        val path = request.url.encodedPath
+                                        requests += path
+                                        when (path) {
+                                            "/static-voting-config.json" -> {
+                                                respond(
+                                                    content =
+                                                        staticConfigJsonV2(
+                                                            listOf(FIRST_DYNAMIC_CONFIG_URL, SECOND_DYNAMIC_CONFIG_URL)
+                                                        ),
+                                                    status = HttpStatusCode.OK,
+                                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                                )
+                                            }
+
+                                            else -> {
+                                                awaitCancellation()
+                                            }
+                                        }
+                                    }
+                                ) { expectSuccess = true }
+                        },
+                    configurationRepository = TestConfigurationRepository(),
+                    votingChainConfigRepository = TestVotingChainConfigRepository(),
+                    votingCryptoClient = unusedVotingCryptoClient(),
+                    configRequestTimeoutMillis = TEST_TIMEOUT_MILLIS
+                )
+
+            val job = async { provider.fetchServiceConfig() }
+            delay(CANCELLATION_DELAY_MILLIS)
+            job.cancel()
+
+            assertFailsWith<CancellationException> { job.await() }
+            assertEquals(listOf("/static-voting-config.json", "/first-dynamic-voting-config.json"), requests)
+        }
+
+    // endregion
+
+    // region client-level retry exclusion for config requests (MOB-1809)
+
+    @Test
+    fun configLegRequestIsNotRetriedByTheClientLevelRetryPolicy() =
+        runBlocking {
+            val attemptsByPath = mutableMapOf<String, Int>()
+            val provider =
+                KtorVotingApiProvider(
+                    httpClientProvider = retryingHttpClientProvider(attemptsByPath),
+                    configurationRepository = TestConfigurationRepository(),
+                    votingChainConfigRepository = TestVotingChainConfigRepository(),
+                    votingCryptoClient = unusedVotingCryptoClient()
+                )
+
+            assertFailsWith<VotingConfigException> { provider.fetchServiceConfig() }
+
+            assertEquals(1, attemptsByPath["/dynamic-voting-config.json"])
+        }
+
+    @Test
+    fun voteServerRequestIsRetriedByTheClientLevelRetryPolicy() =
+        runBlocking {
+            val attemptsByPath = mutableMapOf<String, Int>()
+            val provider =
+                KtorVotingApiProvider(
+                    httpClientProvider = retryingHttpClientProvider(attemptsByPath, dynamicConfigFails = false),
+                    configurationRepository = TestConfigurationRepository(),
+                    votingChainConfigRepository = TestVotingChainConfigRepository(),
+                    votingCryptoClient = unusedVotingCryptoClient()
+                )
+
+            runCatching { provider.fetchAllRounds() }
+
+            assertEquals(CLIENT_RETRY_MAX_RETRIES + 1, attemptsByPath[ROUNDS_TEST_PATH])
+        }
+
+    // endregion
+
+    private fun retryingHttpClientProvider(
+        attemptsByPath: MutableMap<String, Int>,
+        dynamicConfigFails: Boolean = true
+    ): HttpClientProvider =
+        object : HttpClientProvider {
+            override suspend fun supportsKtorTimeouts(): Boolean = true
+
+            override suspend fun createTor(): HttpClient = create()
+
+            override suspend fun create(): HttpClient =
+                HttpClient(
+                    MockEngine { request ->
+                        val path = request.url.encodedPath
+                        attemptsByPath[path] = (attemptsByPath[path] ?: 0) + 1
+                        when (path) {
+                            "/static-voting-config.json" -> {
+                                respond(
+                                    content = staticConfigJson(dynamicConfigUrl = DYNAMIC_CONFIG_URL),
+                                    status = HttpStatusCode.OK,
+                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                )
+                            }
+
+                            "/dynamic-voting-config.json" -> {
+                                if (dynamicConfigFails) {
+                                    respond(content = "boom", status = HttpStatusCode.InternalServerError)
+                                } else {
+                                    respond(
+                                        content = validDynamicServiceConfigJson(),
+                                        status = HttpStatusCode.OK,
+                                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                    )
+                                }
+                            }
+
+                            ROUNDS_TEST_PATH -> {
+                                respond(content = "boom", status = HttpStatusCode.InternalServerError)
+                            }
+
+                            else -> {
+                                respond(content = "not found", status = HttpStatusCode.NotFound)
+                            }
+                        }
+                    }
+                ) {
+                    expectSuccess = true
+                    install(ContentNegotiation) { json() }
+                    install(HttpRequestRetry) {
+                        maxRetries = CLIENT_RETRY_MAX_RETRIES
+                        retryIf { _, response -> response.status.value in 500..599 }
+                        retryOnExceptionIf { _, _ -> true }
+                        constantDelay(millis = 1, randomizationMs = 0)
+                    }
+                }
+        }
+
+    private fun multiEndpointProvider(
+        requestLog: MutableList<String> = mutableListOf(),
+        timeoutCapabilities: MutableList<Pair<String, Long?>> = mutableListOf()
+    ): KtorVotingApiProvider =
+        KtorVotingApiProvider(
+            httpClientProvider =
+                object : HttpClientProvider {
+                    override suspend fun supportsKtorTimeouts(): Boolean = true
+
+                    override suspend fun createTor(): HttpClient = create()
+
+                    override suspend fun create(): HttpClient =
+                        HttpClient(
+                            MockEngine { request ->
+                                val path = request.url.encodedPath
+                                requestLog += path
+                                val requestTimeoutMillis =
+                                    request.getCapabilityOrNull(HttpTimeoutCapability)?.requestTimeoutMillis
+                                timeoutCapabilities += path to requestTimeoutMillis
+                                when (path) {
+                                    "/static-voting-config.json" -> {
+                                        respond(
+                                            content = staticConfigJson(dynamicConfigUrl = DYNAMIC_CONFIG_URL),
+                                            status = HttpStatusCode.OK,
+                                            headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                        )
+                                    }
+
+                                    "/dynamic-voting-config.json" -> {
+                                        respond(
+                                            content = validDynamicServiceConfigJson(),
+                                            status = HttpStatusCode.OK,
+                                            headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                        )
+                                    }
+
+                                    ROUNDS_TEST_PATH -> {
+                                        respond(
+                                            content = """{"rounds": []}""",
+                                            status = HttpStatusCode.OK,
+                                            headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                        )
+                                    }
+
+                                    else -> {
+                                        respond(content = "not found", status = HttpStatusCode.NotFound)
+                                    }
+                                }
+                            }
+                        ) {
+                            expectSuccess = true
+                            install(ContentNegotiation) { json() }
+                        }
+                },
+            configurationRepository = TestConfigurationRepository(),
+            votingChainConfigRepository = TestVotingChainConfigRepository(),
+            votingCryptoClient = unusedVotingCryptoClient()
+        )
+
+    private class SwitchableVotingChainConfigRepository(
+        initialPinnedSource: String
+    ) : VotingChainConfigRepository {
+        private var currentState =
+            VotingChainConfigState(
+                selected = VotingChainConfigSelection.Custom(SWITCHABLE_CHAIN_ID),
+                customChains = listOf(switchableChain(initialPinnedSource))
+            )
+
+        override val state: StateFlow<VotingChainConfigState>
+            get() = MutableStateFlow(currentState)
+
+        fun switchTo(pinnedSource: String) {
+            currentState = currentState.copy(customChains = listOf(switchableChain(pinnedSource)))
+        }
+
+        override suspend fun get(): VotingChainConfigState = currentState
+
+        override suspend fun selectDefault() = Unit
+
+        override suspend fun selectCustom(id: String) = Unit
+
+        override suspend fun addCustom(
+            name: String,
+            pinnedSource: String
+        ): VotingCustomChainConfig = error("unused")
+
+        override suspend fun updateCustom(
+            id: String,
+            name: String,
+            pinnedSource: String
+        ) = Unit
+
+        override suspend fun deleteCustom(id: String) = Unit
+
+        private fun switchableChain(pinnedSource: String) =
+            VotingCustomChainConfig(id = SWITCHABLE_CHAIN_ID, name = "Switchable", pinnedSource = pinnedSource)
+
+        private companion object {
+            const val SWITCHABLE_CHAIN_ID = "switchable-chain"
+        }
+    }
+
     private fun newProvider(
         requests: MutableList<String>,
         supportsKtorTimeouts: Boolean = true,
@@ -323,6 +772,10 @@ class KtorVotingApiProviderTest {
         const val DYNAMIC_CONFIG_URL = "https://example.com/dynamic-voting-config.json"
         const val FIRST_DYNAMIC_CONFIG_URL = "https://example.com/first-dynamic-voting-config.json"
         const val SECOND_DYNAMIC_CONFIG_URL = "https://example.com/second-dynamic-voting-config.json"
+        const val ROUNDS_TEST_PATH = "/shielded-vote/v1/rounds"
+        const val TEST_TIMEOUT_MILLIS = 100L
+        const val CANCELLATION_DELAY_MILLIS = 50L
+        const val CLIENT_RETRY_MAX_RETRIES = 4
         val TEST_CHAIN_CONFIG_STATE =
             VotingChainConfigState(
                 selected = VotingChainConfigSelection.Custom("test-chain"),

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/KtorVotingApiProviderTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/KtorVotingApiProviderTest.kt
@@ -50,6 +50,92 @@ class KtorVotingApiProviderTest {
         }
 
     @Test
+    fun fetchServiceConfigFallsBackToSecondDynamicConfigUrlWhenFirstFails() =
+        runBlocking {
+            val requests = mutableListOf<String>()
+            val provider =
+                newProviderWithResponses(
+                    requests = requests,
+                    responses =
+                        mapOf(
+                            "/static-voting-config.json" to
+                                MockResponse(
+                                    content =
+                                        staticConfigJsonV2(
+                                            dynamicConfigUrls =
+                                                listOf(FIRST_DYNAMIC_CONFIG_URL, SECOND_DYNAMIC_CONFIG_URL)
+                                        ),
+                                    status = HttpStatusCode.OK
+                                ),
+                            "/first-dynamic-voting-config.json" to
+                                MockResponse(
+                                    content = "temporary dynamic config failure",
+                                    status = HttpStatusCode.InternalServerError
+                                ),
+                            "/second-dynamic-voting-config.json" to
+                                MockResponse(content = validDynamicServiceConfigJson(), status = HttpStatusCode.OK)
+                        )
+                )
+
+            val serviceConfig = provider.fetchServiceConfig()
+
+            assertEquals(
+                listOf(
+                    "/static-voting-config.json",
+                    "/first-dynamic-voting-config.json",
+                    "/second-dynamic-voting-config.json"
+                ),
+                requests
+            )
+            assertEquals(1, serviceConfig.voteServers.size)
+        }
+
+    @Test
+    fun fetchServiceConfigThrowsWhenAllDynamicConfigUrlsFail() =
+        runBlocking {
+            val requests = mutableListOf<String>()
+            val provider =
+                newProviderWithResponses(
+                    requests = requests,
+                    responses =
+                        mapOf(
+                            "/static-voting-config.json" to
+                                MockResponse(
+                                    content =
+                                        staticConfigJsonV2(
+                                            dynamicConfigUrls =
+                                                listOf(FIRST_DYNAMIC_CONFIG_URL, SECOND_DYNAMIC_CONFIG_URL)
+                                        ),
+                                    status = HttpStatusCode.OK
+                                ),
+                            "/first-dynamic-voting-config.json" to
+                                MockResponse(
+                                    content = "temporary dynamic config failure",
+                                    status = HttpStatusCode.InternalServerError
+                                ),
+                            "/second-dynamic-voting-config.json" to
+                                MockResponse(
+                                    content = "temporary dynamic config failure",
+                                    status = HttpStatusCode.InternalServerError
+                                )
+                        )
+                )
+
+            assertFailsWith<VotingConfigException> {
+                provider.fetchServiceConfig()
+            }
+
+            assertEquals(
+                listOf(
+                    "/static-voting-config.json",
+                    "/first-dynamic-voting-config.json",
+                    "/second-dynamic-voting-config.json"
+                ),
+                requests
+            )
+        }
+
+    @Test
     fun fetchShareStatusUsesHelperTimeoutWhenSupported() =
         runBlocking {
             val requests = mutableListOf<String>()
@@ -110,6 +196,16 @@ class KtorVotingApiProviderTest {
             votingCryptoClient = unusedVotingCryptoClient()
         )
 
+    private fun newProviderWithResponses(
+        requests: MutableList<String>,
+        responses: Map<String, MockResponse>
+    ) = KtorVotingApiProvider(
+        httpClientProvider = ResponseMapHttpClientProvider(requests, responses),
+        configurationRepository = TestConfigurationRepository(),
+        votingChainConfigRepository = TestVotingChainConfigRepository(),
+        votingCryptoClient = unusedVotingCryptoClient()
+    )
+
     private class TestHttpClientProvider(
         private val requests: MutableList<String>,
         private val supportsKtorTimeouts: Boolean,
@@ -158,6 +254,40 @@ class KtorVotingApiProviderTest {
             }
     }
 
+    private class ResponseMapHttpClientProvider(
+        private val requests: MutableList<String>,
+        private val responses: Map<String, MockResponse>
+    ) : HttpClientProvider {
+        override suspend fun supportsKtorTimeouts(): Boolean = true
+
+        override suspend fun createTor(): HttpClient = create()
+
+        override suspend fun create(): HttpClient =
+            HttpClient(
+                MockEngine { request ->
+                    val path = request.url.encodedPath
+                    requests += path
+                    val response = responses[path]
+                    if (response == null) {
+                        respond(content = "not found", status = HttpStatusCode.NotFound)
+                    } else {
+                        respond(
+                            content = response.content,
+                            status = response.status,
+                            headers =
+                                if (response.status == HttpStatusCode.OK) {
+                                    headersOf(HttpHeaders.ContentType, "application/json")
+                                } else {
+                                    headersOf()
+                                }
+                        )
+                    }
+                }
+            ) {
+                expectSuccess = true
+            }
+    }
+
     private class TestConfigurationRepository : ConfigurationRepository {
         override val configurationFlow: StateFlow<Configuration?> = MutableStateFlow(null)
         override val isFlexaAvailable: StateFlow<Boolean?> = MutableStateFlow(false)
@@ -191,6 +321,8 @@ class KtorVotingApiProviderTest {
     private companion object {
         const val STATIC_CONFIG_URL = "https://example.com/static-voting-config.json"
         const val DYNAMIC_CONFIG_URL = "https://example.com/dynamic-voting-config.json"
+        const val FIRST_DYNAMIC_CONFIG_URL = "https://example.com/first-dynamic-voting-config.json"
+        const val SECOND_DYNAMIC_CONFIG_URL = "https://example.com/second-dynamic-voting-config.json"
         val TEST_CHAIN_CONFIG_STATE =
             VotingChainConfigState(
                 selected = VotingChainConfigSelection.Custom("test-chain"),
@@ -222,6 +354,42 @@ private fun staticConfigJson(dynamicConfigUrl: String): String =
       ]
     }
     """.trimIndent()
+
+private fun staticConfigJsonV2(dynamicConfigUrls: List<String>): String =
+    """
+    {
+      "static_config_version": 2,
+      "dynamic_config_urls": [${dynamicConfigUrls.joinToString(",") { url -> "\"$url\"" }}],
+      "trusted_keys": [
+        {
+          "key_id": "valar-test",
+          "alg": "ed25519",
+          "pubkey": "$ADMIN_PUBKEY_BASE64"
+        }
+      ]
+    }
+    """.trimIndent()
+
+private fun validDynamicServiceConfigJson(): String =
+    """
+    {
+      "config_version": 1,
+      "vote_servers": [{"url": "https://vote.example.com", "label": "vote"}],
+      "pir_endpoints": [{"url": "https://pir.example.com", "label": "pir"}],
+      "supported_versions": {
+        "pir": ["v0"],
+        "vote_protocol": "v0",
+        "tally": "v0",
+        "vote_server": "v1"
+      },
+      "rounds": {}
+    }
+    """.trimIndent()
+
+private data class MockResponse(
+    val content: String,
+    val status: HttpStatusCode
+)
 
 private fun unusedVotingCryptoClient(): VotingCryptoClient =
     Proxy.newProxyInstance(

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/VoteServerFailoverTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/VoteServerFailoverTest.kt
@@ -2,6 +2,7 @@ package co.electriccoin.zcash.ui.common.provider
 
 import co.electriccoin.zcash.ui.common.model.voting.StaticVotingConfig
 import co.electriccoin.zcash.ui.common.model.voting.VotingConfigException
+import co.electriccoin.zcash.ui.common.model.voting.toLowerHex
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
@@ -108,18 +109,44 @@ class VoteServerFailoverTest {
     }
 
     @Test
-    fun invalidConfiguredSourceFallsBackToBundledPinnedSource() {
-        val source = resolvePinnedConfigSource("not a url")
-        val bundled = resolvePinnedConfigSource(StaticVotingConfig.BUNDLED_PINNED_SOURCE)
+    fun invalidConfiguredSourceFallsBackToBundledPinnedSources() {
+        val sources = resolvePinnedConfigSource("not a url")
 
-        assertEquals(bundled, source)
+        assertEquals(StaticVotingConfig.BUNDLED_PINNED_CONFIG_SOURCES, sources)
+    }
+
+    @Test
+    fun emptyConfiguredSourceFallsBackToBundledPinnedSources() {
+        val sources = resolvePinnedConfigSource("")
+
+        assertEquals(StaticVotingConfig.BUNDLED_PINNED_CONFIG_SOURCES, sources)
     }
 
     @Test
     fun validConfiguredSourceCanBeUnpinned() {
-        val source = resolvePinnedConfigSource("https://override.example.com/static-voting-config.json?foo=bar")
+        val sources = resolvePinnedConfigSource("https://override.example.com/static-voting-config.json?foo=bar")
 
-        assertEquals("https://override.example.com/static-voting-config.json?foo=bar", source.url)
-        assertEquals(null, source.sha256)
+        assertEquals(1, sources.size)
+        assertEquals("https://override.example.com/static-voting-config.json?foo=bar", sources.single().url)
+        assertEquals(null, sources.single().sha256)
+    }
+
+    @Test
+    fun bundledMirrorEqualOverrideResolvesToFullBundledWalk() {
+        val sources = resolvePinnedConfigSource(StaticVotingConfig.BUNDLED_PINNED_SOURCE_MIRROR)
+
+        assertEquals(StaticVotingConfig.BUNDLED_PINNED_CONFIG_SOURCES, sources)
+    }
+
+    @Test
+    fun bundledUrlWithDifferentChecksumStaysSingleSource() {
+        val differentChecksum = "0a".repeat(32)
+        val overrideUrl =
+            StaticVotingConfig.BUNDLED_PINNED_SOURCE.substringBefore("checksum=") + "checksum=sha256:$differentChecksum"
+
+        val sources = resolvePinnedConfigSource(overrideUrl)
+
+        assertEquals(1, sources.size)
+        assertEquals(differentChecksum, sources.single().sha256?.toLowerHex())
     }
 }

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/VotingConfigWalkTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/VotingConfigWalkTest.kt
@@ -1,0 +1,512 @@
+package co.electriccoin.zcash.ui.common.provider
+
+import co.electriccoin.zcash.configuration.model.map.Configuration
+import co.electriccoin.zcash.ui.common.model.voting.StaticVotingConfigHashMismatchException
+import co.electriccoin.zcash.ui.common.model.voting.VotingConfigException
+import co.electriccoin.zcash.ui.common.repository.ConfigurationRepository
+import co.electriccoin.zcash.ui.common.repository.VotingChainConfigRepository
+import co.electriccoin.zcash.ui.common.repository.VotingChainConfigSelection
+import co.electriccoin.zcash.ui.common.repository.VotingChainConfigState
+import co.electriccoin.zcash.ui.common.repository.VotingCustomChainConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpResponseData
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
+import java.lang.reflect.Proxy
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Covers the MOB-1809 mirror-failover machinery: the generic [walkConfigSources] algorithm
+ * shared by the static and dynamic config legs, the static/dynamic failure classification
+ * predicates, and the dynamic walk's end-to-end behavior through [KtorVotingApiProvider]
+ * (order, 4xx/5xx handling, decode-failure handling, first-error retention, and
+ * raw.githubusercontent.com cache-busting).
+ *
+ * The static walk's end-to-end mirror behavior is deliberately NOT re-exercised here through
+ * [KtorVotingApiProvider.fetchServiceConfig] against the real bundled sources: those sources'
+ * checksums are fixed, real SHA-256 pins, so a test cannot fabricate mismatched-then-matching
+ * mock bytes for them without a SHA-256 preimage. Instead, [walkConfigSources] (the exact
+ * mechanism [KtorVotingApiProvider] composes for both legs) and
+ * [isRetryableStaticVotingConfigFailure] are tested directly below, together with
+ * [co.electriccoin.zcash.ui.common.model.voting.StaticVotingConfigTest]'s direct coverage of
+ * [co.electriccoin.zcash.ui.common.model.voting.StaticVotingConfig.decodeAndVerify]'s hash-vs-decode
+ * exception typing — the same combination [KtorVotingApiProvider.fetchStaticConfigWalk] relies on.
+ */
+class VotingConfigWalkTest {
+    // region generic walkConfigSources
+
+    @Test
+    fun walkShortCircuitsOnFirstHealthySource() =
+        runBlocking {
+            val attempted = mutableListOf<String>()
+
+            val result =
+                walkConfigSources(
+                    sources = listOf("a", "b"),
+                    emptyMessage = "empty",
+                    describe = { it },
+                    shouldTryNext = { true }
+                ) { source ->
+                    attempted += source
+                    "ok-$source"
+                }
+
+            assertEquals("ok-a", result)
+            assertEquals(listOf("a"), attempted)
+        }
+
+    @Test
+    fun walkFallsThroughRetryableFailureToNextSource() =
+        runBlocking {
+            val attempted = mutableListOf<String>()
+
+            val result =
+                walkConfigSources(
+                    sources = listOf("a", "b"),
+                    emptyMessage = "empty",
+                    describe = { it },
+                    shouldTryNext = { true }
+                ) { source ->
+                    attempted += source
+                    if (source == "a") throw VotingConfigException("a unreachable")
+                    "ok-$source"
+                }
+
+            assertEquals("ok-b", result)
+            assertEquals(listOf("a", "b"), attempted)
+        }
+
+    @Test
+    fun walkStopsImmediatelyOnAuthoritativeFailure() {
+        val attempted = mutableListOf<String>()
+        val authoritative = VotingConfigException("authoritative failure")
+
+        val exception =
+            assertFailsWith<VotingConfigException> {
+                runBlocking {
+                    walkConfigSources(
+                        sources = listOf("a", "b"),
+                        emptyMessage = "empty",
+                        describe = { it },
+                        shouldTryNext = { false }
+                    ) { source ->
+                        attempted += source
+                        throw authoritative
+                    }
+                }
+            }
+
+        assertSame(authoritative, exception)
+        assertEquals(listOf("a"), attempted)
+    }
+
+    @Test
+    fun walkThrowsFirstErrorWhenEverySourceFails() {
+        val firstError = VotingConfigException("first mirror: 503")
+        val secondError = VotingConfigException("second mirror: 502")
+
+        val exception =
+            assertFailsWith<VotingConfigException> {
+                runBlocking {
+                    var attempt = 0
+                    walkConfigSources(
+                        sources = listOf("a", "b"),
+                        emptyMessage = "empty",
+                        describe = { it },
+                        shouldTryNext = { true }
+                    ) {
+                        attempt += 1
+                        throw if (attempt == 1) firstError else secondError
+                    }
+                }
+            }
+
+        assertSame(firstError, exception)
+        assertEquals("first mirror: 503", exception.message)
+    }
+
+    @Test
+    fun walkThrowsEmptyMessageForEmptySourceList() {
+        val exception =
+            assertFailsWith<VotingConfigException> {
+                runBlocking {
+                    walkConfigSources<String, String>(
+                        sources = emptyList(),
+                        emptyMessage = "no sources configured",
+                        describe = { it },
+                        shouldTryNext = { true }
+                    ) { "unused" }
+                }
+            }
+
+        assertEquals("no sources configured", exception.message)
+    }
+
+    // endregion
+
+    // region failure classification
+
+    @Test
+    fun staticFailureClassificationTreatsFetchFailureAndHashMismatchAsRetryable() {
+        assertTrue(isRetryableStaticVotingConfigFailure(StaticVotingConfigFetchFailedException("HTTP 503")))
+        assertTrue(isRetryableStaticVotingConfigFailure(StaticVotingConfigHashMismatchException("mismatch")))
+    }
+
+    @Test
+    fun staticFailureClassificationTreatsDecodeOrValidateFailureAsAuthoritative() {
+        assertFalse(isRetryableStaticVotingConfigFailure(VotingConfigException("decode failed")))
+    }
+
+    @Test
+    fun dynamicFailureClassificationTreatsTransientFailureAsRetryable() {
+        assertTrue(isRetryableDynamicVotingConfigFailure(DynamicVotingConfigTransientException("HTTP 503")))
+    }
+
+    @Test
+    fun dynamicFailureClassificationTreatsPlainVotingConfigExceptionAsAuthoritative() {
+        assertFalse(isRetryableDynamicVotingConfigFailure(VotingConfigException("HTTP 404")))
+    }
+
+    // endregion
+
+    // region dynamic walk integration (through KtorVotingApiProvider)
+
+    @Test
+    fun dynamicWalkTriesUrlsInOrder() =
+        runBlocking {
+            val requestedUrls = mutableListOf<String>()
+            val provider =
+                newProvider(
+                    dynamicConfigUrls = listOf(FIRST_URL, SECOND_URL, THIRD_URL),
+                    responses =
+                        mapOf(
+                            FIRST_URL to WalkMockResponse(HttpStatusCode.InternalServerError, "boom"),
+                            SECOND_URL to WalkMockResponse(HttpStatusCode.InternalServerError, "boom"),
+                            THIRD_URL to WalkMockResponse(HttpStatusCode.OK, validDynamicServiceConfigJson())
+                        ),
+                    requestedUrls = requestedUrls
+                )
+
+            provider.fetchServiceConfig()
+
+            assertEquals(listOf(FIRST_URL, SECOND_URL, THIRD_URL), requestedUrls.map { it.substringBefore('?') })
+        }
+
+    @Test
+    fun dynamicWalkDoesNotFallThroughOn404() =
+        runBlocking {
+            val requestedUrls = mutableListOf<String>()
+            val provider =
+                newProvider(
+                    dynamicConfigUrls = listOf(FIRST_URL, SECOND_URL),
+                    responses =
+                        mapOf(
+                            FIRST_URL to WalkMockResponse(HttpStatusCode.NotFound, "not found"),
+                            SECOND_URL to WalkMockResponse(HttpStatusCode.OK, validDynamicServiceConfigJson())
+                        ),
+                    requestedUrls = requestedUrls
+                )
+
+            assertFailsWith<VotingConfigException> {
+                provider.fetchServiceConfig()
+            }
+
+            assertEquals(listOf(FIRST_URL), requestedUrls.map { it.substringBefore('?') })
+        }
+
+    @Test
+    fun dynamicWalkDoesNotFallThroughOnDecodeFailure() =
+        runBlocking {
+            val requestedUrls = mutableListOf<String>()
+            val provider =
+                newProvider(
+                    dynamicConfigUrls = listOf(FIRST_URL, SECOND_URL),
+                    responses =
+                        mapOf(
+                            FIRST_URL to WalkMockResponse(HttpStatusCode.OK, "not json"),
+                            SECOND_URL to WalkMockResponse(HttpStatusCode.OK, validDynamicServiceConfigJson())
+                        ),
+                    requestedUrls = requestedUrls
+                )
+
+            assertFailsWith<VotingConfigException> {
+                provider.fetchServiceConfig()
+            }
+
+            assertEquals(listOf(FIRST_URL), requestedUrls.map { it.substringBefore('?') })
+        }
+
+    @Test
+    fun dynamicWalkRetainsFirstErrorWithDistinguishablePayloads() =
+        runBlocking {
+            val requestedUrls = mutableListOf<String>()
+            val provider =
+                newProvider(
+                    dynamicConfigUrls = listOf(FIRST_URL, SECOND_URL),
+                    responses =
+                        mapOf(
+                            FIRST_URL to WalkMockResponse(HttpStatusCode.ServiceUnavailable, "first-mirror-payload"),
+                            SECOND_URL to WalkMockResponse(HttpStatusCode.BadGateway, "second-mirror-payload")
+                        ),
+                    requestedUrls = requestedUrls
+                )
+
+            val exception =
+                assertFailsWith<VotingConfigException> {
+                    provider.fetchServiceConfig()
+                }
+
+            assertTrue(exception.message.orEmpty().contains("503"), exception.message.orEmpty())
+            assertFalse(exception.message.orEmpty().contains("502"), exception.message.orEmpty())
+            assertEquals(listOf(FIRST_URL, SECOND_URL), requestedUrls.map { it.substringBefore('?') })
+        }
+
+    @Test
+    fun dynamicWalkCacheBustsOnlyRawGithubusercontentAndKeepsErrorMessageClean() =
+        runBlocking {
+            val requestedUrls = mutableListOf<String>()
+            val provider =
+                newProvider(
+                    dynamicConfigUrls = listOf(RAW_GITHUB_URL, FIRST_URL),
+                    responses =
+                        mapOf(
+                            RAW_GITHUB_URL to WalkMockResponse(HttpStatusCode.InternalServerError, "boom"),
+                            FIRST_URL to WalkMockResponse(HttpStatusCode.InternalServerError, "boom")
+                        ),
+                    requestedUrls = requestedUrls
+                )
+
+            val exception =
+                assertFailsWith<VotingConfigException> {
+                    provider.fetchServiceConfig()
+                }
+
+            assertEquals(2, requestedUrls.size)
+            assertTrue(requestedUrls[0].contains("zodl_cache_bust="), requestedUrls[0])
+            assertFalse(requestedUrls[1].contains("zodl_cache_bust="), requestedUrls[1])
+            assertFalse(exception.message.orEmpty().contains("zodl_cache_bust"), exception.message.orEmpty())
+        }
+
+    @Test
+    fun dynamicWalkSendsNoCacheHeadersPerAttempt() =
+        runBlocking {
+            val noCacheHeaderSeen = mutableListOf<Boolean>()
+            val provider =
+                newProviderCapturingHeaders(
+                    dynamicConfigUrls = listOf(FIRST_URL, SECOND_URL),
+                    responses =
+                        mapOf(
+                            FIRST_URL to WalkMockResponse(HttpStatusCode.InternalServerError, "boom"),
+                            SECOND_URL to WalkMockResponse(HttpStatusCode.OK, validDynamicServiceConfigJson())
+                        ),
+                    noCacheHeaderSeen = noCacheHeaderSeen
+                )
+
+            provider.fetchServiceConfig()
+
+            assertEquals(listOf(true, true), noCacheHeaderSeen)
+        }
+
+    // endregion
+
+    private fun newProvider(
+        dynamicConfigUrls: List<String>,
+        responses: Map<String, WalkMockResponse>,
+        requestedUrls: MutableList<String>
+    ): KtorVotingApiProvider =
+        KtorVotingApiProvider(
+            httpClientProvider =
+                object : HttpClientProvider {
+                    override suspend fun supportsKtorTimeouts(): Boolean = true
+
+                    override suspend fun createTor(): HttpClient = create()
+
+                    override suspend fun create(): HttpClient =
+                        HttpClient(
+                            MockEngine { request ->
+                                val fullUrl = request.url.toString()
+                                if (fullUrl.startsWith(STATIC_CONFIG_URL)) {
+                                    respond(
+                                        content = staticConfigJson(dynamicConfigUrls),
+                                        status = HttpStatusCode.OK,
+                                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                    )
+                                } else {
+                                    requestedUrls += fullUrl
+                                    respondFor(fullUrl, responses)
+                                }
+                            }
+                        ) {
+                            expectSuccess = true
+                        }
+                },
+            configurationRepository = TestConfigurationRepository(),
+            votingChainConfigRepository = TestVotingChainConfigRepository(),
+            votingCryptoClient = unusedVotingCryptoClient()
+        )
+
+    private fun newProviderCapturingHeaders(
+        dynamicConfigUrls: List<String>,
+        responses: Map<String, WalkMockResponse>,
+        noCacheHeaderSeen: MutableList<Boolean>
+    ): KtorVotingApiProvider =
+        KtorVotingApiProvider(
+            httpClientProvider =
+                object : HttpClientProvider {
+                    override suspend fun supportsKtorTimeouts(): Boolean = true
+
+                    override suspend fun createTor(): HttpClient = create()
+
+                    override suspend fun create(): HttpClient =
+                        HttpClient(
+                            MockEngine { request ->
+                                val fullUrl = request.url.toString()
+                                if (fullUrl.startsWith(STATIC_CONFIG_URL)) {
+                                    respond(
+                                        content = staticConfigJson(dynamicConfigUrls),
+                                        status = HttpStatusCode.OK,
+                                        headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                    )
+                                } else {
+                                    noCacheHeaderSeen += (request.headers[HttpHeaders.CacheControl] == "no-cache")
+                                    respondFor(fullUrl, responses)
+                                }
+                            }
+                        ) {
+                            expectSuccess = true
+                        }
+                },
+            configurationRepository = TestConfigurationRepository(),
+            votingChainConfigRepository = TestVotingChainConfigRepository(),
+            votingCryptoClient = unusedVotingCryptoClient()
+        )
+
+    private class TestConfigurationRepository : ConfigurationRepository {
+        override val configurationFlow: StateFlow<Configuration?> = MutableStateFlow(null)
+        override val isFlexaAvailable: StateFlow<Boolean?> = MutableStateFlow(false)
+
+        override suspend fun isFlexaAvailable(): Boolean = false
+    }
+
+    private class TestVotingChainConfigRepository : VotingChainConfigRepository {
+        override val state: StateFlow<VotingChainConfigState> = MutableStateFlow(TEST_CHAIN_CONFIG_STATE)
+
+        override suspend fun get(): VotingChainConfigState = TEST_CHAIN_CONFIG_STATE
+
+        override suspend fun selectDefault() = Unit
+
+        override suspend fun selectCustom(id: String) = Unit
+
+        override suspend fun addCustom(
+            name: String,
+            pinnedSource: String
+        ): VotingCustomChainConfig = error("unused")
+
+        override suspend fun updateCustom(
+            id: String,
+            name: String,
+            pinnedSource: String
+        ) = Unit
+
+        override suspend fun deleteCustom(id: String) = Unit
+    }
+
+    private companion object {
+        const val STATIC_CONFIG_URL = "https://example.com/static-voting-config.json"
+        const val FIRST_URL = "https://example.com/first-dynamic-voting-config.json"
+        const val SECOND_URL = "https://example.com/second-dynamic-voting-config.json"
+        const val THIRD_URL = "https://example.com/third-dynamic-voting-config.json"
+        const val RAW_GITHUB_URL =
+            "https://raw.githubusercontent.com/valargroup/token-holder-voting-config/main/dynamic-voting-config.json"
+
+        val TEST_CHAIN_CONFIG_STATE =
+            VotingChainConfigState(
+                selected = VotingChainConfigSelection.Custom("test-chain"),
+                customChains =
+                    listOf(
+                        VotingCustomChainConfig(
+                            id = "test-chain",
+                            name = "Test Chain",
+                            pinnedSource = STATIC_CONFIG_URL
+                        )
+                    )
+            )
+    }
+}
+
+private data class WalkMockResponse(
+    val status: HttpStatusCode,
+    val content: String
+)
+
+private fun MockRequestHandleScope.respondFor(
+    fullUrl: String,
+    responses: Map<String, WalkMockResponse>
+): HttpResponseData {
+    val response = responses[fullUrl.substringBefore('?')]
+    return if (response == null) {
+        respond(content = "not found", status = HttpStatusCode.NotFound)
+    } else {
+        respond(
+            content = response.content,
+            status = response.status,
+            headers =
+                if (response.status == HttpStatusCode.OK) {
+                    headersOf(HttpHeaders.ContentType, "application/json")
+                } else {
+                    headersOf()
+                }
+        )
+    }
+}
+
+private fun staticConfigJson(dynamicConfigUrls: List<String>): String =
+    """
+    {
+      "static_config_version": 2,
+      "dynamic_config_urls": [${dynamicConfigUrls.joinToString(",") { url -> "\"$url\"" }}],
+      "trusted_keys": [
+        {
+          "key_id": "valar-test",
+          "alg": "ed25519",
+          "pubkey": "rKDbmhkoW9ja7dMiCV+1uTao7wXWV6xN/57erkrOuiQ="
+        }
+      ]
+    }
+    """.trimIndent()
+
+private fun validDynamicServiceConfigJson(): String =
+    """
+    {
+      "config_version": 1,
+      "vote_servers": [{"url": "https://vote.example.com", "label": "vote"}],
+      "pir_endpoints": [{"url": "https://pir.example.com", "label": "pir"}],
+      "supported_versions": {
+        "pir": ["v0"],
+        "vote_protocol": "v0",
+        "tally": "v0",
+        "vote_server": "v1"
+      },
+      "rounds": {}
+    }
+    """.trimIndent()
+
+private fun unusedVotingCryptoClient(): VotingCryptoClient =
+    Proxy.newProxyInstance(
+        VotingCryptoClient::class.java.classLoader,
+        arrayOf(VotingCryptoClient::class.java)
+    ) { _, method, _ ->
+        error("Unexpected VotingCryptoClient call: ${method.name}")
+    } as VotingCryptoClient

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/VotingConfigWalkTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/VotingConfigWalkTest.kt
@@ -1,6 +1,8 @@
 package co.electriccoin.zcash.ui.common.provider
 
 import co.electriccoin.zcash.configuration.model.map.Configuration
+import co.electriccoin.zcash.ui.common.model.voting.PinnedConfigSource
+import co.electriccoin.zcash.ui.common.model.voting.StaticVotingConfig
 import co.electriccoin.zcash.ui.common.model.voting.StaticVotingConfigHashMismatchException
 import co.electriccoin.zcash.ui.common.model.voting.VotingConfigException
 import co.electriccoin.zcash.ui.common.repository.ConfigurationRepository
@@ -12,37 +14,48 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.MockRequestHandleScope
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.ResponseException
 import io.ktor.client.request.HttpResponseData
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsBytes
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking
+import java.io.IOException
 import java.lang.reflect.Proxy
+import java.security.MessageDigest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
  * Covers the MOB-1809 mirror-failover machinery: the generic [walkConfigSources] algorithm
  * shared by the static and dynamic config legs, the static/dynamic failure classification
- * predicates, and the dynamic walk's end-to-end behavior through [KtorVotingApiProvider]
- * (order, 4xx/5xx handling, decode-failure handling, first-error retention, and
- * raw.githubusercontent.com cache-busting).
+ * predicates, the dynamic walk's end-to-end behavior through [KtorVotingApiProvider] (order,
+ * 4xx/5xx handling, decode-failure handling, first-error retention, cache-bust token scoping,
+ * and raw.githubusercontent.com near-miss negatives), cancellation propagation, and the static
+ * walk's end-to-end behavior.
  *
- * The static walk's end-to-end mirror behavior is deliberately NOT re-exercised here through
- * [KtorVotingApiProvider.fetchServiceConfig] against the real bundled sources: those sources'
- * checksums are fixed, real SHA-256 pins, so a test cannot fabricate mismatched-then-matching
- * mock bytes for them without a SHA-256 preimage. Instead, [walkConfigSources] (the exact
- * mechanism [KtorVotingApiProvider] composes for both legs) and
- * [isRetryableStaticVotingConfigFailure] are tested directly below, together with
- * [co.electriccoin.zcash.ui.common.model.voting.StaticVotingConfigTest]'s direct coverage of
- * [co.electriccoin.zcash.ui.common.model.voting.StaticVotingConfig.decodeAndVerify]'s hash-vs-decode
- * exception typing — the same combination [KtorVotingApiProvider.fetchStaticConfigWalk] relies on.
+ * The static walk's success/hash-mismatch/decode-failure scenarios are exercised against
+ * FABRICATED sources rather than through [KtorVotingApiProvider.fetchServiceConfig] against the
+ * real bundled sources: those sources' checksums are fixed, real SHA-256 pins, so a test cannot
+ * fabricate hash-matching mock bytes for them without a SHA-256 preimage. The fabricated-source
+ * tests below compose the exact same pieces the real fetch leg does — [walkConfigSources],
+ * [isRetryableStaticVotingConfigFailure], and
+ * [co.electriccoin.zcash.ui.common.model.voting.StaticVotingConfig.decodeAndVerify] (whose own
+ * hash-vs-decode exception typing is covered directly by
+ * [co.electriccoin.zcash.ui.common.model.voting.StaticVotingConfigTest]) — while a separate test
+ * against the real bundled two-URL list confirms the one property that's testable without a
+ * preimage: both real sources are requested, in order, with the first (canonical) error retained
+ * when both fail.
  */
 class VotingConfigWalkTest {
     // region generic walkConfigSources
@@ -321,6 +334,371 @@ class VotingConfigWalkTest {
 
     // endregion
 
+    // region cache-bust near-miss negatives and per-walk token behavior
+
+    @Test
+    fun cacheBustDoesNotFireForRawGithubusercontentSubdomain() =
+        runBlocking {
+            val requestedUrls = mutableListOf<String>()
+            val subdomainUrl = "https://evil.raw.githubusercontent.com/config.json"
+            val provider =
+                newProvider(
+                    dynamicConfigUrls = listOf(subdomainUrl),
+                    responses =
+                        mapOf(subdomainUrl to WalkMockResponse(HttpStatusCode.OK, validDynamicServiceConfigJson())),
+                    requestedUrls = requestedUrls
+                )
+
+            provider.fetchServiceConfig()
+
+            assertEquals(1, requestedUrls.size)
+            assertFalse(requestedUrls[0].contains("zodl_cache_bust="), requestedUrls[0])
+        }
+
+    @Test
+    fun cacheBustDoesNotFireForPathMerelyContainingRawGithubusercontent() =
+        runBlocking {
+            val requestedUrls = mutableListOf<String>()
+            val pathLookalikeUrl = "https://example.com/raw.githubusercontent.com/config.json"
+            val provider =
+                newProvider(
+                    dynamicConfigUrls = listOf(pathLookalikeUrl),
+                    responses =
+                        mapOf(pathLookalikeUrl to WalkMockResponse(HttpStatusCode.OK, validDynamicServiceConfigJson())),
+                    requestedUrls = requestedUrls
+                )
+
+            provider.fetchServiceConfig()
+
+            assertEquals(1, requestedUrls.size)
+            assertFalse(requestedUrls[0].contains("zodl_cache_bust="), requestedUrls[0])
+        }
+
+    @Test
+    fun cacheBustUsesTheSameTokenForTwoRawGithubusercontentUrlsInOneWalk() =
+        runBlocking {
+            val requestedUrls = mutableListOf<String>()
+            val first = "https://raw.githubusercontent.com/org/repo/main/first.json"
+            val second = "https://raw.githubusercontent.com/org/repo/main/second.json"
+            val provider =
+                newProvider(
+                    dynamicConfigUrls = listOf(first, second),
+                    responses =
+                        mapOf(
+                            first to WalkMockResponse(HttpStatusCode.InternalServerError, "boom"),
+                            second to WalkMockResponse(HttpStatusCode.OK, validDynamicServiceConfigJson())
+                        ),
+                    requestedUrls = requestedUrls
+                )
+
+            provider.fetchServiceConfig()
+
+            assertEquals(2, requestedUrls.size)
+            val firstToken = requestedUrls[0].substringAfter("zodl_cache_bust=")
+            val secondToken = requestedUrls[1].substringAfter("zodl_cache_bust=")
+            assertEquals(firstToken, secondToken)
+        }
+
+    @Test
+    fun cacheBustTokenDiffersAcrossWalkInvocations() =
+        runBlocking {
+            val requestedUrls = mutableListOf<String>()
+            val provider =
+                newProvider(
+                    dynamicConfigUrls = listOf(RAW_GITHUB_URL),
+                    responses =
+                        mapOf(RAW_GITHUB_URL to WalkMockResponse(HttpStatusCode.OK, validDynamicServiceConfigJson())),
+                    requestedUrls = requestedUrls
+                )
+
+            provider.fetchServiceConfig()
+            provider.fetchServiceConfig()
+
+            assertEquals(2, requestedUrls.size)
+            val firstToken = requestedUrls[0].substringAfter("zodl_cache_bust=")
+            val secondToken = requestedUrls[1].substringAfter("zodl_cache_bust=")
+            assertNotEquals(firstToken, secondToken)
+        }
+
+    // endregion
+
+    // region cancellation propagation
+
+    @Test
+    fun cancellationPropagatesImmediatelyWithoutTryingFurtherSources() {
+        val attempted = mutableListOf<String>()
+
+        assertFailsWith<CancellationException> {
+            runBlocking {
+                walkConfigSources(
+                    sources = listOf("a", "b"),
+                    emptyMessage = "empty",
+                    describe = { it },
+                    shouldTryNext = { true }
+                ) { source ->
+                    attempted += source
+                    throw CancellationException("cancelled")
+                }
+            }
+        }
+
+        assertEquals(listOf("a"), attempted)
+    }
+
+    // endregion
+
+    // region static walk end-to-end: real decode/hash/classification machinery, fabricated sources
+
+    @Test
+    fun staticWalkSucceedsViaMirrorWhenCanonicalFailsAndMirrorBytesHashMatch() =
+        runBlocking {
+            val validBytes = staticConfigJson(listOf("https://dynamic.example.com/config.json")).toByteArray()
+            val matchingHash = validBytes.sha256()
+            val canonical = staticSource("https://canonical.example.com/static.json", matchingHash)
+            val mirror = staticSource("https://mirror.example.com/static.json", matchingHash)
+            val requestedUrls = mutableListOf<String>()
+            val client =
+                HttpClient(
+                    MockEngine { request ->
+                        val url = request.url.toString()
+                        requestedUrls += url
+                        if (url.startsWith(canonical.url)) {
+                            respond(content = "canonical missing", status = HttpStatusCode.NotFound)
+                        } else {
+                            respond(content = validBytes, status = HttpStatusCode.OK)
+                        }
+                    }
+                ) { expectSuccess = true }
+
+            val result =
+                walkConfigSources(
+                    sources = listOf(canonical, mirror),
+                    emptyMessage = "empty",
+                    describe = { source -> source.url },
+                    shouldTryNext = ::isRetryableStaticVotingConfigFailure
+                ) { source ->
+                    val bytes = client.fetchStaticBytesOrThrow(source.url)
+                    StaticVotingConfig.decodeAndVerify(data = bytes, expectedSHA256 = source.sha256)
+                }
+
+            assertEquals(listOf(canonical.url, mirror.url), requestedUrls)
+            assertEquals(StaticVotingConfig.STATIC_CONFIG_VERSION_V2, result.staticConfigVersion)
+        }
+
+    @Test
+    fun staticWalkRetainsCanonicalErrorWhenMirrorBytesHashMismatch() =
+        runBlocking {
+            val validBytes = staticConfigJson(listOf("https://dynamic.example.com/config.json")).toByteArray()
+            val matchingHash = validBytes.sha256()
+            val wrongBytes = "wrong mirror content".toByteArray()
+            val canonical = staticSource("https://canonical.example.com/static.json", matchingHash)
+            val mirror = staticSource("https://mirror.example.com/static.json", matchingHash)
+            val requestedUrls = mutableListOf<String>()
+            val client =
+                HttpClient(
+                    MockEngine { request ->
+                        val url = request.url.toString()
+                        requestedUrls += url
+                        if (url.startsWith(canonical.url)) {
+                            respond(content = "canonical missing", status = HttpStatusCode.NotFound)
+                        } else {
+                            respond(content = wrongBytes, status = HttpStatusCode.OK)
+                        }
+                    }
+                ) { expectSuccess = true }
+
+            val exception =
+                assertFailsWith<StaticVotingConfigFetchFailedException> {
+                    walkConfigSources(
+                        sources = listOf(canonical, mirror),
+                        emptyMessage = "empty",
+                        describe = { source -> source.url },
+                        shouldTryNext = ::isRetryableStaticVotingConfigFailure
+                    ) { source ->
+                        val bytes = client.fetchStaticBytesOrThrow(source.url)
+                        StaticVotingConfig.decodeAndVerify(data = bytes, expectedSHA256 = source.sha256)
+                    }
+                }
+
+            assertTrue(exception.message.orEmpty().contains("404"), exception.message.orEmpty())
+            assertEquals(listOf(canonical.url, mirror.url), requestedUrls)
+        }
+
+    @Test
+    fun staticWalkFailsImmediatelyOnHashMatchedMalformedCanonicalBytesAndNeverRequestsMirror() =
+        runBlocking {
+            val malformedBytes = "not json at all".toByteArray()
+            val matchingHash = malformedBytes.sha256()
+            val canonical = staticSource("https://canonical.example.com/static.json", matchingHash)
+            val mirror = staticSource("https://mirror.example.com/static.json", matchingHash)
+            val requestedUrls = mutableListOf<String>()
+            val client =
+                HttpClient(
+                    MockEngine { request ->
+                        requestedUrls += request.url.toString()
+                        respond(content = malformedBytes, status = HttpStatusCode.OK)
+                    }
+                ) { expectSuccess = true }
+
+            assertFailsWith<VotingConfigException> {
+                walkConfigSources(
+                    sources = listOf(canonical, mirror),
+                    emptyMessage = "empty",
+                    describe = { source -> source.url },
+                    shouldTryNext = ::isRetryableStaticVotingConfigFailure
+                ) { source ->
+                    val bytes = client.fetchStaticBytesOrThrow(source.url)
+                    StaticVotingConfig.decodeAndVerify(data = bytes, expectedSHA256 = source.sha256)
+                }
+            }
+
+            assertEquals(listOf(canonical.url), requestedUrls)
+        }
+
+    /**
+     * Exercises the real [KtorVotingApiProvider]'s default source resolution (its private
+     * `resolveConfigSources`, unreachable directly from a test): no override configured resolves
+     * to [StaticVotingConfig.BUNDLED_PINNED_CONFIG_SOURCES] verbatim, so both real,
+     * checksum-pinned URLs get requested in order. The three scenarios above cover the
+     * hash-match/decode-failure/first-error-retention mechanics with fabricated sources instead,
+     * since the real bundled checksums are fixed SHA-256 pins with no available preimage — no
+     * test can fabricate bytes that hash-match them, only bytes that are guaranteed NOT to (as
+     * used here).
+     */
+    @Test
+    fun realBundledStaticSourcesAreRequestedInOrderAndCanonicalErrorIsRetainedWhenBothMirrorsFail() =
+        runBlocking {
+            val requestedUrls = mutableListOf<String>()
+            val provider =
+                KtorVotingApiProvider(
+                    httpClientProvider =
+                        object : HttpClientProvider {
+                            override suspend fun supportsKtorTimeouts(): Boolean = true
+
+                            override suspend fun createTor(): HttpClient = create()
+
+                            override suspend fun create(): HttpClient =
+                                HttpClient(
+                                    MockEngine { request ->
+                                        requestedUrls += request.url.toString()
+                                        respond(
+                                            content = "definitely not the pinned bytes",
+                                            status = HttpStatusCode.OK,
+                                            headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                        )
+                                    }
+                                ) { expectSuccess = true }
+                        },
+                    configurationRepository = TestConfigurationRepository(),
+                    votingChainConfigRepository = DefaultVotingChainConfigRepository(),
+                    votingCryptoClient = unusedVotingCryptoClient()
+                )
+
+            val exception =
+                assertFailsWith<StaticVotingConfigHashMismatchException> {
+                    provider.fetchServiceConfig()
+                }
+
+            assertEquals(
+                listOf(StaticVotingConfig.BUNDLED_PINNED_SOURCE, StaticVotingConfig.BUNDLED_PINNED_SOURCE_MIRROR)
+                    .map { source -> source.substringBefore('?') },
+                requestedUrls.map { url -> url.substringBefore('?') }
+            )
+            assertEquals(
+                "Static voting config hash mismatch",
+                exception.message.orEmpty().substringBefore(':')
+            )
+        }
+
+    // endregion
+
+    // region transport exception (thrown, not an HTTP status) falls through on both walks
+
+    @Test
+    fun staticWalkFallsThroughOnThrownTransportException() =
+        runBlocking {
+            val validBytes = staticConfigJson(listOf("https://dynamic.example.com/config.json")).toByteArray()
+            val matchingHash = validBytes.sha256()
+            val canonical = staticSource("https://canonical.example.com/static.json", matchingHash)
+            val mirror = staticSource("https://mirror.example.com/static.json", matchingHash)
+            val requestedUrls = mutableListOf<String>()
+            val client =
+                HttpClient(
+                    MockEngine { request ->
+                        val url = request.url.toString()
+                        requestedUrls += url
+                        if (url.startsWith(canonical.url)) {
+                            throw IOException("simulated transport failure")
+                        } else {
+                            respond(content = validBytes, status = HttpStatusCode.OK)
+                        }
+                    }
+                ) { expectSuccess = true }
+
+            val result =
+                walkConfigSources(
+                    sources = listOf(canonical, mirror),
+                    emptyMessage = "empty",
+                    describe = { source -> source.url },
+                    shouldTryNext = ::isRetryableStaticVotingConfigFailure
+                ) { source ->
+                    val bytes = client.fetchStaticBytesOrThrow(source.url)
+                    StaticVotingConfig.decodeAndVerify(data = bytes, expectedSHA256 = source.sha256)
+                }
+
+            assertEquals(listOf(canonical.url, mirror.url), requestedUrls)
+            assertEquals(StaticVotingConfig.STATIC_CONFIG_VERSION_V2, result.staticConfigVersion)
+        }
+
+    @Test
+    fun dynamicWalkFallsThroughOnThrownTransportException() =
+        runBlocking {
+            val requestedUrls = mutableListOf<String>()
+            val provider =
+                KtorVotingApiProvider(
+                    httpClientProvider =
+                        object : HttpClientProvider {
+                            override suspend fun supportsKtorTimeouts(): Boolean = true
+
+                            override suspend fun createTor(): HttpClient = create()
+
+                            override suspend fun create(): HttpClient =
+                                HttpClient(
+                                    MockEngine { request ->
+                                        val fullUrl = request.url.toString()
+                                        if (fullUrl.startsWith(STATIC_CONFIG_URL)) {
+                                            respond(
+                                                content = staticConfigJson(listOf(FIRST_URL, SECOND_URL)),
+                                                status = HttpStatusCode.OK,
+                                                headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                            )
+                                        } else {
+                                            requestedUrls += fullUrl
+                                            if (fullUrl.startsWith(FIRST_URL)) {
+                                                throw IOException("simulated transport failure")
+                                            } else {
+                                                respond(
+                                                    content = validDynamicServiceConfigJson(),
+                                                    status = HttpStatusCode.OK,
+                                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                                )
+                                            }
+                                        }
+                                    }
+                                ) { expectSuccess = true }
+                        },
+                    configurationRepository = TestConfigurationRepository(),
+                    votingChainConfigRepository = TestVotingChainConfigRepository(),
+                    votingCryptoClient = unusedVotingCryptoClient()
+                )
+
+            provider.fetchServiceConfig()
+
+            assertEquals(listOf(FIRST_URL, SECOND_URL), requestedUrls.map { url -> url.substringBefore('?') })
+        }
+
+    // endregion
+
     private fun newProvider(
         dynamicConfigUrls: List<String>,
         responses: Map<String, WalkMockResponse>,
@@ -404,6 +782,33 @@ class VotingConfigWalkTest {
         override val state: StateFlow<VotingChainConfigState> = MutableStateFlow(TEST_CHAIN_CONFIG_STATE)
 
         override suspend fun get(): VotingChainConfigState = TEST_CHAIN_CONFIG_STATE
+
+        override suspend fun selectDefault() = Unit
+
+        override suspend fun selectCustom(id: String) = Unit
+
+        override suspend fun addCustom(
+            name: String,
+            pinnedSource: String
+        ): VotingCustomChainConfig = error("unused")
+
+        override suspend fun updateCustom(
+            id: String,
+            name: String,
+            pinnedSource: String
+        ) = Unit
+
+        override suspend fun deleteCustom(id: String) = Unit
+    }
+
+    /**
+     * No selection, no custom chains — [KtorVotingApiProvider]'s private `resolveConfigSources`'s
+     * "no override configured" path.
+     */
+    private class DefaultVotingChainConfigRepository : VotingChainConfigRepository {
+        override val state: StateFlow<VotingChainConfigState> = MutableStateFlow(VotingChainConfigState())
+
+        override suspend fun get(): VotingChainConfigState = VotingChainConfigState()
 
         override suspend fun selectDefault() = Unit
 
@@ -510,3 +915,33 @@ private fun unusedVotingCryptoClient(): VotingCryptoClient =
     ) { _, method, _ ->
         error("Unexpected VotingCryptoClient call: ${method.name}")
     } as VotingCryptoClient
+
+private fun ByteArray.sha256(): ByteArray = MessageDigest.getInstance("SHA-256").digest(this)
+
+private fun staticSource(
+    url: String,
+    sha256: ByteArray
+): PinnedConfigSource = PinnedConfigSource.parse("$url?checksum=sha256:${sha256.toHexString()}")
+
+private fun ByteArray.toHexString(): String = joinToString(separator = "") { byte -> "%02x".format(byte) }
+
+/**
+ * Mirrors [KtorVotingApiProvider]'s private `fetchStaticConfigBytes` classification (fetch
+ * failure and non-200 wrapped as the retryable [StaticVotingConfigFetchFailedException]) so the
+ * static-walk end-to-end tests above exercise the exact same [walkConfigSources] +
+ * [isRetryableStaticVotingConfigFailure] + [StaticVotingConfig.decodeAndVerify] composition the
+ * real fetch leg does, without needing a handle on that private method.
+ */
+private suspend fun HttpClient.fetchStaticBytesOrThrow(url: String): ByteArray =
+    try {
+        get(url).bodyAsBytes()
+    } catch (responseException: ResponseException) {
+        throw StaticVotingConfigFetchFailedException(
+            "Static voting config fetch failed: HTTP ${responseException.response.status.value}"
+        ).apply { initCause(responseException) }
+    } catch (exception: Exception) {
+        exception.rethrowIfCancellation()
+        throw StaticVotingConfigFetchFailedException(
+            "Static voting config fetch failed: ${exception.message ?: exception::class.simpleName}"
+        )
+    }

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/screen/voting/chainconfig/VoteChainConfigVMTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/screen/voting/chainconfig/VoteChainConfigVMTest.kt
@@ -1,0 +1,258 @@
+package co.electriccoin.zcash.ui.screen.voting.chainconfig
+
+import co.electriccoin.zcash.ui.NavigationRouter
+import co.electriccoin.zcash.ui.R
+import co.electriccoin.zcash.ui.common.model.voting.PinnedConfigSource
+import co.electriccoin.zcash.ui.common.model.voting.StaticVotingConfig
+import co.electriccoin.zcash.ui.common.provider.VotingApiProvider
+import co.electriccoin.zcash.ui.common.repository.VotingChainConfigRepository
+import co.electriccoin.zcash.ui.common.repository.VotingChainConfigSelection
+import co.electriccoin.zcash.ui.common.repository.VotingChainConfigState
+import co.electriccoin.zcash.ui.common.repository.VotingCustomChainConfig
+import co.electriccoin.zcash.ui.common.usecase.CopyToClipboardUseCase
+import co.electriccoin.zcash.ui.design.util.stringRes
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Covers MOB-1809's default-detection fix: [isBundledDefaultUrl] directly (a bundled mirror URL
+ * with a matching checksum counts as the default; the same URL re-pinned with a different
+ * checksum must stay custom), plus the two VM flows that observably depend on it —
+ * [VoteChainConfigVM]'s duplicate-of-default save error and its default-collapse on selecting an
+ * existing custom chain that already matches a bundled source.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class VoteChainConfigVMTest {
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // region isBundledDefaultUrl
+
+    @Test
+    fun bundledMirrorUrlWithMatchingChecksumIsBundledDefault() {
+        val source = PinnedConfigSource.parse(StaticVotingConfig.BUNDLED_PINNED_SOURCE_MIRROR)
+
+        assertTrue(source.isBundledDefaultUrl())
+    }
+
+    @Test
+    fun bundledUrlWithDifferentChecksumIsNotBundledDefault() {
+        val source = PinnedConfigSource.parse(rePinnedBundledMirrorUrl())
+
+        assertFalse(source.isBundledDefaultUrl())
+    }
+
+    // endregion
+
+    // region VM: selecting an existing custom chain that already matches a bundled source
+
+    @Test
+    fun selectingCustomChainMatchingBundledMirrorCollapsesToDefault() =
+        runTest {
+            val repository =
+                FakeVotingChainConfigRepository(
+                    VotingChainConfigState(
+                        selected = VotingChainConfigSelection.Default,
+                        customChains =
+                            listOf(
+                                VotingCustomChainConfig(
+                                    id = CUSTOM_CHAIN_ID,
+                                    name = "Bundled mirror copy",
+                                    pinnedSource = StaticVotingConfig.BUNDLED_PINNED_SOURCE_MIRROR
+                                )
+                            )
+                    )
+                )
+            val vm = vm(repository = repository)
+            val collectJob = launch { vm.state.collect {} }
+            advanceUntilIdle()
+
+            val customItem =
+                vm.state.value
+                    ?.chains
+                    ?.first { item -> item.id == CUSTOM_CHAIN_ID }
+            customItem?.radioButtonState?.onClick?.invoke()
+            advanceUntilIdle()
+
+            assertEquals(1, repository.selectDefaultCalls)
+            assertTrue(repository.selectCustomCalls.isEmpty())
+            collectJob.cancel()
+        }
+
+    @Test
+    fun selectingCustomChainWithRePinnedBundledUrlStaysCustom() =
+        runTest {
+            val repository =
+                FakeVotingChainConfigRepository(
+                    VotingChainConfigState(
+                        selected = VotingChainConfigSelection.Default,
+                        customChains =
+                            listOf(
+                                VotingCustomChainConfig(
+                                    id = CUSTOM_CHAIN_ID,
+                                    name = "Re-pinned mirror",
+                                    pinnedSource = rePinnedBundledMirrorUrl()
+                                )
+                            )
+                    )
+                )
+            val vm = vm(repository = repository)
+            val collectJob = launch { vm.state.collect {} }
+            advanceUntilIdle()
+
+            val customItem =
+                vm.state.value
+                    ?.chains
+                    ?.first { item -> item.id == CUSTOM_CHAIN_ID }
+            customItem?.radioButtonState?.onClick?.invoke()
+            advanceUntilIdle()
+
+            assertEquals(listOf(CUSTOM_CHAIN_ID), repository.selectCustomCalls)
+            assertEquals(0, repository.selectDefaultCalls)
+            collectJob.cancel()
+        }
+
+    // endregion
+
+    // region VM: saving a new custom source that duplicates the bundled default
+
+    @Test
+    fun savingNewSourceMatchingBundledMirrorShowsDuplicateDefaultError() =
+        runTest {
+            val repository = FakeVotingChainConfigRepository(VotingChainConfigState())
+            val vm = vm(repository = repository)
+            val collectJob = launch { vm.state.collect {} }
+            advanceUntilIdle()
+
+            vm.state.value
+                ?.onAddCustom
+                ?.invoke()
+            advanceUntilIdle()
+            vm.state.value
+                ?.editor
+                ?.url
+                ?.onValueChange
+                ?.invoke(StaticVotingConfig.BUNDLED_PINNED_SOURCE_MIRROR)
+            advanceUntilIdle()
+            vm.state.value
+                ?.editor
+                ?.saveButton
+                ?.onClick
+                ?.invoke()
+            advanceUntilIdle()
+
+            assertEquals(
+                stringRes(R.string.vote_chain_config_error_duplicate_default),
+                vm.state.value
+                    ?.errorSheet
+                    ?.message
+            )
+            assertTrue(repository.addCustomCalls.isEmpty())
+            assertEquals(0, repository.selectDefaultCalls)
+            collectJob.cancel()
+        }
+
+    // endregion
+
+    private fun vm(
+        repository: VotingChainConfigRepository,
+        votingApiProvider: VotingApiProvider = mockk { coEvery { validateConfigSource(any()) } just Runs },
+        navigationRouter: NavigationRouter = mockk(relaxed = true),
+        copyToClipboard: CopyToClipboardUseCase = mockk(relaxed = true),
+    ) = VoteChainConfigVM(
+        votingChainConfigRepository = repository,
+        votingApiProvider = votingApiProvider,
+        navigationRouter = navigationRouter,
+        copyToClipboard = copyToClipboard,
+    )
+
+    private fun rePinnedBundledMirrorUrl(): String =
+        StaticVotingConfig.BUNDLED_PINNED_SOURCE_MIRROR.substringBeforeLast("checksum=sha256:") +
+            "checksum=sha256:" +
+            DIFFERENT_CHECKSUM_HEX
+
+    private companion object {
+        const val CUSTOM_CHAIN_ID = "custom-chain"
+        val DIFFERENT_CHECKSUM_HEX = "0".repeat(64)
+    }
+}
+
+private class FakeVotingChainConfigRepository(
+    initial: VotingChainConfigState
+) : VotingChainConfigRepository {
+    private val mutableState = MutableStateFlow(initial)
+    override val state: StateFlow<VotingChainConfigState> = mutableState
+
+    var selectDefaultCalls = 0
+        private set
+    val selectCustomCalls = mutableListOf<String>()
+    val addCustomCalls = mutableListOf<Pair<String, String>>()
+
+    override suspend fun get(): VotingChainConfigState = mutableState.value
+
+    override suspend fun selectDefault() {
+        selectDefaultCalls += 1
+        mutableState.value = mutableState.value.copy(selected = VotingChainConfigSelection.Default)
+    }
+
+    override suspend fun selectCustom(id: String) {
+        selectCustomCalls += id
+        mutableState.value = mutableState.value.copy(selected = VotingChainConfigSelection.Custom(id))
+    }
+
+    override suspend fun addCustom(
+        name: String,
+        pinnedSource: String
+    ): VotingCustomChainConfig {
+        addCustomCalls += name to pinnedSource
+        val chain = VotingCustomChainConfig(id = "new-chain", name = name, pinnedSource = pinnedSource)
+        mutableState.value = mutableState.value.copy(customChains = mutableState.value.customChains + chain)
+        return chain
+    }
+
+    override suspend fun updateCustom(
+        id: String,
+        name: String,
+        pinnedSource: String
+    ) {
+        mutableState.value =
+            mutableState.value.copy(
+                customChains =
+                    mutableState.value.customChains.map { chain ->
+                        if (chain.id == id) chain.copy(name = name, pinnedSource = pinnedSource) else chain
+                    }
+            )
+    }
+
+    override suspend fun deleteCustom(id: String) {
+        mutableState.value =
+            mutableState.value.copy(
+                customChains = mutableState.value.customChains.filterNot { chain -> chain.id == id }
+            )
+    }
+}


### PR DESCRIPTION
## Summary

Adopts Valar's static voting config **version 2** with full **mirror failover** on both configuration legs — the defense against ISPs blocking `voting.valargroup.dev` ([context thread](https://zodl.slack.com/archives/C0A8RHV7KEW/p1787694873005729?thread_ts=1787671580.949409&channel=C0A8RHV7KEW&message_ts=1787694873.005729)). Android counterpart of iOS [zodl-inc/zodl-ios#2012](https://github.com/zodl-inc/zodl-ios/pull/2012); implements [MOB-1806](https://linear.app/zodl/issue/MOB-1806/need-to-add-fallback-to-improve-server-side-issues) / [MOB-1809](https://linear.app/zodl/issue/MOB-1809/adopt-static-voting-config-v2-with-config-mirror-failover-android) (the hand-off carrying the authoritative spec — the `valargroup/token-holder-voting-config` README). Targets `maint/v3.10.x` (fix for the live NU7 CHP round; forward to `main` via the usual cascade). Three commits: v2 schema support → alignment with the iOS mirror-failover semantics → retry/timeout ownership + test hardening.

**Model** (`StaticVotingConfig`)
- Accepts `static_config_version` 1 **and** 2; the field is now required. v2 introduces the `dynamic_config_urls` array; v1's singular `dynamic_config_url` keeps working (users saved v1 custom sources during the NU7 incident). Unknown versions fail with a precise `Unsupported static_config_version N`, not a decode error.
- Every dynamic-config URL must be HTTPS (a static-config rotation can't downgrade voting to plaintext).
- The bundled trust anchor is now a **mirror list**: the canonical gateway pin plus a byte-identical `raw.githubusercontent.com` pin (same checksum `28fc9b63…` in path and query) — trust is carried by the checksum, not the origin.

**Static anchor walk** — deliberately wide: falls through to the next mirror on transport failure, any non-200, or checksum mismatch (each mirror is independently hash-gated, so fall-through is availability-only); a decode/validation failure *after* the hash matched is authoritative for every mirror and stops immediately. All-fail reports the canonical origin's error.

**Dynamic config walk** — README-normative (narrow): falls through only on transport failure or HTTP 5xx; 4xx and decode/validation failures are authoritative. First error reported; serving origin logged.

**Hardening**
- Config requests own their retry policy: they're exempted from the direct client's `HttpRequestRetry` (per-request `retry { noRetry() }`), so a dead mirror fails once in ≤15 s and the walk moves on — instead of the plugin internally retrying it ~5× (~90 s) first.
- 15 s per-attempt timeout on both config legs — Ktor-level where available, with an app-side `withTimeout` fallback on the Tor path (which previously had no bound at all).
- `zodl_cache_bust=<token>` query param on requests to exactly `raw.githubusercontent.com` (its CDN caches branch paths ~300 s and ignores request cache headers — matters during round rollover); the clean URL is what's logged and used in error messages (the token never leaks). The static-leg mirror is content-addressed and deliberately not busted.
- A custom source byte-equal (URL + checksum) to a bundled mirror uses the full bundled walk; settings' "Default" detection now requires URL **and** checksum to match a bundled mirror, so a same-URL/different-checksum custom source stays custom (fixes a pre-existing silent-collapse quirk).

No stored-data migration needed; v1 custom overrides keep working unchanged.

## Test plan

- Model: v1/v2 decode, singular/plural cross-rejection, missing version, non-HTTPS entries, precise unsupported-version message (wins over field errors), bundled-mirror invariants (both pins parse, same 64-hex checksum in path + query, checksum stripped from the fetched URL).
- Static walk: first-healthy-mirror short-circuit; fall-through on transport/non-200/hash-mismatch; authoritative stop on hash-matched-but-malformed bytes; first-error retention with distinguishable payloads; ordered requests over the real bundled two-URL list; empty source list.
- Dynamic walk: order respected; transport + 5xx fall through; **404 does not** fall through; decode/validate failures do not fall through; first-error retention; cache-bust applied only to exact-host `raw.githubusercontent.com` (subdomain/path near-misses stay clean), same token within a walk, fresh token across walks.
- Timeouts & retry: 15 s timeout capability asserted on config requests and absent from vote-server requests; app-side fallback converts a stalling attempt into mirror fall-through; with a real `HttpRequestRetry` plugin installed, a config request makes exactly one attempt while vote-server requests still retry.
- Memoization (same source → one fetch; source change / `invalidateConfigCache` → refetch), cancellation propagation, and `VoteChainConfigVM` default-collapse/duplicate detection.
- `./gradlew :feature-voting:test` — BUILD SUCCESSFUL, all variants (implementation + independent verification passes). `./gradlew :app:assembleZcashmainnetStoreDebug` — BUILD SUCCESSFUL. ktlint and `detektAll` fully clean on the `maint/v3.10.x` base.
- Reviewed by a multi-critic adversarial pass (spec compliance, Ktor correctness, test coverage, regressions); all confirmed findings addressed in the third commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)