### PR TITLE
Recover Base64-decoded voting leaf indexes

### DIFF
--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCase.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCase.kt
@@ -1667,8 +1667,22 @@ internal fun TxConfirmation.delegateVoteVanPosition(bundleIndex: Int): Int {
             ?.attribute("leaf_index")
             ?: throw unexpectedSdkResponse("Missing delegate_vote leaf_index for bundle $bundleIndex")
 
-    return rawLeafIndex.toIntOrNull()
-        ?: throw unexpectedSdkResponse("Malformed delegate_vote leaf_index for bundle $bundleIndex: $rawLeafIndex")
+    val normalizedLeafIndex = rawLeafIndex.trim()
+    normalizedLeafIndex.toIntOrNull()?.let { return it }
+
+    // Some compatibility clients opportunistically Base64-decode CometBFT event text.
+    // Re-encoding a resulting non-ASCII value restores the original decimal position.
+    if (normalizedLeafIndex.any { character -> character.code > ASCII_MAX_CODE_POINT }) {
+        Base64
+            .getEncoder()
+            .encodeToString(normalizedLeafIndex.toByteArray(Charsets.UTF_8))
+            .toIntOrNull()
+            ?.let { return it }
+    }
+
+    throw unexpectedSdkResponse(
+        "Malformed delegate_vote leaf_index for bundle $bundleIndex: $rawLeafIndex"
+    )
 }
 
 internal fun TxConfirmation.castVoteLeafPositions(): Pair<Int, Long> {
@@ -1687,6 +1701,8 @@ internal fun TxConfirmation.castVoteLeafPositions(): Pair<Int, Long> {
 
 private fun unexpectedSdkResponse(message: String) =
     VotingSubmissionRecoverableException(VotingErrors.UnexpectedSdkResponse(message))
+
+private const val ASCII_MAX_CODE_POINT = 0x7F
 
 internal fun calculateSubmittingBundleProgress(
     proposalIndex: Int,

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCase.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCase.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import java.io.File
 import java.time.Instant
+import java.util.Base64
 
 class VotingAuthorizationException(
     cause: Exception

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCaseProgressTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCaseProgressTest.kt
@@ -623,6 +623,35 @@ class SubmitVotesUseCaseProgressTest {
     }
 
     @Test
+    fun delegateVoteVanPositionRecoversLegacyBase64DecodedLeafIndex() {
+        val decodedLeafIndex =
+            String(
+                Base64.getDecoder().decode("3753"),
+                Charsets.UTF_8
+            )
+        val confirmation =
+            TxConfirmation(
+                height = 1,
+                code = 0,
+                events =
+                    listOf(
+                        TxEvent(
+                            type = "delegate_vote",
+                            attributes =
+                                listOf(
+                                    TxEventAttribute(
+                                        key = "leaf_index",
+                                        value = decodedLeafIndex
+                                    )
+                                )
+                        )
+                    )
+            )
+
+        assertEquals(3753, confirmation.delegateVoteVanPosition(bundleIndex = 0))
+    }
+
+    @Test
     fun castVoteLeafPositionsParseRecoveredConfirmation() {
         val confirmation =
             TxConfirmation(


### PR DESCRIPTION
## Summary
- recover delegation leaf indexes that compatibility clients mistakenly Base64-decode
- preserve strict failure handling for genuinely malformed event values
- add regression coverage for the observed `3753` → `߾w` transformation

## Motivation / Why
Mainnet voting submissions can fail after delegation confirmation when a numeric CometBFT event attribute is opportunistically Base64-decoded into non-ASCII text. Re-encoding that value restores the original decimal tree position and lets recovery continue.

## Tests
- `:feature-voting:testZcashmainnetFossDebugUnitTest --tests 'co.electriccoin.zcash.ui.common.usecase.SubmitVotesUseCaseProgressTest'`
- `:app:assembleZcashmainnetFossDebug`
- installed and launched the updated APK on a Pixel 10a

## Author checklist
- [ ] Self-review in GitHub
- [x] Added automated regression coverage
- [x] Ran the app on a physical device
- [ ] Checked code coverage report