### PR TITLE
Voting speed investigation (MOB-1808): fix redundant/duplicate CHP backend requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added:
+
+- Coinholder Polling now shows a pull-to-refresh indicator on the poll list, so you can manually refresh it on demand.
+
+### Changed:
+
+- Coinholder Polling's poll list no longer refreshes itself in the background while you're just browsing it; it now updates when you open the screen, return to it, or pull to refresh.
+- Vote submission is faster and more reliable over Tor: a slow or unresponsive vote-helper server no longer stalls the whole submission.
+
 ## [3.10.1 (2512)] - 2026-08-25
 
 ### Added:

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/PirSnapshotResolver.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/PirSnapshotResolver.kt
@@ -36,14 +36,22 @@ class HttpPirSnapshotResolver(
             throw PirSnapshotResolverException.NoEndpointsConfigured
         }
 
+        // MOB-1808: probes used to fan out concurrently but all through ONE shared/isolated Tor
+        // HttpClient (built once outside the loop). Confirmed live (via the identical pattern in
+        // VotingApiProvider.delegateShares) that the native Tor engine serializes concurrent
+        // requests on a single isolated client/stream regardless of Kotlin-level concurrency —
+        // so this fan-out was likely no faster than probing endpoints one at a time. Fix: give
+        // each concurrent probe its own freshly-built isolated Tor client instead.
         val outcomes =
-            httpClientProvider.create().use { client ->
-                coroutineScope {
-                    normalizedEndpoints
-                        .map { url ->
-                            async { probe(client, url, expectedSnapshotHeight) }
-                        }.awaitAll()
-                }
+            coroutineScope {
+                normalizedEndpoints
+                    .map { url ->
+                        async {
+                            httpClientProvider.create().use { client ->
+                                probe(client, url, expectedSnapshotHeight)
+                            }
+                        }
+                    }.awaitAll()
             }
 
         return outcomes

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -63,7 +63,9 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import org.json.JSONObject
@@ -157,11 +159,16 @@ class KtorVotingApiProvider(
     private val configRequestTimeoutMillis: Long = StaticVotingConfig.CONFIG_REQUEST_TIMEOUT_MS,
 ) : VotingApiProvider {
     private var cachedResolvedConfig: ResolvedVotingConfig? = null
+    private var cachedResolvedConfigFetchedAtMs: Long? = null
     private val configMutex = Mutex()
     private val serverHealthTracker = VotingServerHealthTracker()
     private val httpClientMutex = Mutex()
     private var cachedHttpClient: HttpClient? = null
     private var cachedHttpClientSupportsKtorTimeouts: Boolean? = null
+
+    // Bounds how many isolated Tor clients delegateShares() builds at once (MOB-1808) — see the
+    // comment at its call site for why an uncapped fan-out is a real client- and server-side risk.
+    private val shareDelegationSemaphore = Semaphore(MAX_CONCURRENT_SHARE_DELEGATIONS)
 
     override suspend fun validateConfigSource(source: PinnedConfigSource) {
         fetchStaticConfig(listOf(source))
@@ -170,11 +177,26 @@ class KtorVotingApiProvider(
     override suspend fun invalidateConfigCache() {
         configMutex.withLock {
             cachedResolvedConfig = null
+            cachedResolvedConfigFetchedAtMs = null
         }
     }
 
+    // MOB-1808: fetchServiceConfig() used to force-refresh unconditionally on every call. With
+    // the CHP round list open during an active round, at least 3 independent loops call this
+    // path — the 5s round-status auto-refresh, the 15s+ foreground share-rediscovery driver, and
+    // ad-hoc tally/tx-confirmation polling — each re-fetching the full static+dynamic config over
+    // Tor from scratch, never reusing what a sibling loop fetched moments earlier ("CHP is
+    // actually firing a lot of requests on its own from its screens" per the team's own Slack
+    // report). getResolvedConfig()'s cache was already source-aware (a config-source change
+    // still forces a real refetch) but forceRefresh=true bypassed it entirely regardless of age.
+    // Switching to TTL-bounded reuse (getResolvedConfigWithTtl) keeps every one of those loops
+    // fed from one shared fetch instead of each paying its own round trip, while still bounding
+    // how stale the served config can get. Callers that need a guaranteed-fresh fetch (e.g. a
+    // config-source change, or the submit flow, which already calls invalidateConfigCache()
+    // explicitly before it enters) go through that explicit invalidation instead of relying on
+    // this method to force one.
     override suspend fun fetchServiceConfig(): VotingServiceConfig =
-        getResolvedConfig(forceRefresh = true).serviceConfig
+        getResolvedConfigWithTtl().serviceConfig
 
     override suspend fun fetchActiveVotingSession(): VotingSession? =
         try {
@@ -283,40 +305,83 @@ class KtorVotingApiProvider(
 
                 serverHealthTracker.remember(serverUrls)
 
-                buildList {
-                    for (share in shares) {
-                        val body = share.toApiBody()
-                        val healthyServers = serverHealthTracker.healthyServers(serverUrls)
-                        val quorum = max(1, (healthyServers.size + 1) / 2)
-                        val targets = healthyServers.shuffled().take(quorum)
-                        val acceptedByServers =
-                            postShareToTargets(targets, body, supportsKtorTimeouts).toMutableList()
-                        if (acceptedByServers.isEmpty()) {
-                            val fallbackTargets =
-                                serverHealthTracker
-                                    .healthyServers(serverUrls)
-                                    .filterNot { serverUrl -> serverUrl in targets }
-                                    .shuffled()
-                            for (fallbackTarget in fallbackTargets) {
-                                if (postShare(fallbackTarget, body, supportsKtorTimeouts)) {
-                                    acceptedByServers += fallbackTarget
-                                    break
+                // MOB-1808: shares within one bundle used to be POSTed one at a time — each
+                // share awaited its own postShareToTargets() before the next share started.
+                // Measured live: ~1-1.3s/share over Tor, so a 16-share bundle took 16-22s
+                // sequentially — ~73% of a full vote submission's wall time across the ~12
+                // bundles in a 6-proposal round.
+                //
+                // First attempt: run the shares concurrently but still through the single
+                // cached HttpClient from sharedHttpClient() (see execute()/
+                // executeWithKtorTimeoutSupport below). That barely helped (16-22s -> 13-14.5s)
+                // — live Tor logs showed every "Connecting through Tor" firing exactly when the
+                // previous request's "Response status code" landed, back-to-back with no
+                // overlap, proving the *native* Tor engine serializes concurrent requests on one
+                // isolated client/stream regardless of Kotlin-level concurrency.
+                //
+                // Fix: give each concurrent share its own freshly-built isolated Tor client
+                // (httpClientProvider.create(), not the shared one) instead. Confirmed live:
+                // all 16 "Connecting through Tor" lines now fire within ~15ms of each other and
+                // circuit builds themselves parallelize fine (~300-700ms each even 16-at-once),
+                // collapsing the share-POST phase to a consistent ~1.5-2.5s per bundle — a
+                // ~7-10x win on the true bottleneck, not just the ~10-20% a same-client fan-out
+                // gets. The cached/shared client (sharedHttpClient) remains the right choice for
+                // every OTHER call site here (fetchAllRounds, fetchServiceConfig, delegation/
+                // commitment submission, tx confirmation) since those are one-shot, not an
+                // internal concurrent fan-out — reuse still saves them a redundant circuit build
+                // per call without hitting this serialization.
+                //
+                // Trade-off: serverHealthTracker.healthyServers() is now read once per share
+                // concurrently off the same starting snapshot rather than adapting share-by-share
+                // within the batch — recordSuccess/recordFailure inside postShare still updates
+                // the tracker for the *next* bundle, so this only affects in-flight target
+                // selection within a single batch, not longer-term health tracking.
+                //
+                // shareDelegationSemaphore bounds how many isolated Tor clients get built at
+                // once: uncapped, a wallet with far more shares than our ~16-share test batch
+                // would fan out proportionally more simultaneous Tor circuits with no limit —
+                // client-side resource/thread pressure, and server-side it's exactly the kind of
+                // burst (N distinctly-circuited requests for the same round within milliseconds
+                // of each other) that can look like an anomaly or trip rate-limiting.
+                coroutineScope {
+                    shares
+                        .map { share ->
+                            async {
+                                shareDelegationSemaphore.withPermit {
+                                    httpClientProvider.create().use { client ->
+                                        val body = share.toApiBody()
+                                        val healthyServers = serverHealthTracker.healthyServers(serverUrls)
+                                        val quorum = max(1, (healthyServers.size + 1) / 2)
+                                        val targets = healthyServers.shuffled().take(quorum)
+                                        val acceptedByServers =
+                                            client.postShareToTargets(targets, body, supportsKtorTimeouts).toMutableList()
+                                        if (acceptedByServers.isEmpty()) {
+                                            val fallbackTargets =
+                                                serverHealthTracker
+                                                    .healthyServers(serverUrls)
+                                                    .filterNot { serverUrl -> serverUrl in targets }
+                                                    .shuffled()
+                                            for (fallbackTarget in fallbackTargets) {
+                                                if (client.postShare(fallbackTarget, body, supportsKtorTimeouts)) {
+                                                    acceptedByServers += fallbackTarget
+                                                    break
+                                                }
+                                            }
+                                        }
+
+                                        if (acceptedByServers.isEmpty()) {
+                                            error("No voting server accepted share ${share.encShare.shareIndex}")
+                                        }
+
+                                        DelegatedShareInfo(
+                                            shareIndex = share.encShare.shareIndex,
+                                            proposalId = share.proposalId,
+                                            acceptedByServers = acceptedByServers
+                                        )
+                                    }
                                 }
                             }
-                        }
-
-                        if (acceptedByServers.isEmpty()) {
-                            error("No voting server accepted share ${share.encShare.shareIndex}")
-                        }
-
-                        add(
-                            DelegatedShareInfo(
-                                shareIndex = share.encShare.shareIndex,
-                                proposalId = share.proposalId,
-                                acceptedByServers = acceptedByServers
-                            )
-                        )
-                    }
+                        }.awaitAll()
                 }
             }
         } finally {
@@ -465,9 +530,34 @@ class KtorVotingApiProvider(
             } else {
                 fetchTrustedConfig(sources).also { resolved ->
                     cachedResolvedConfig = resolved
+                    cachedResolvedConfigFetchedAtMs = System.currentTimeMillis()
                 }
             }
         }
+
+    /**
+     * Like [getResolvedConfig] but additionally reuses a source-matching cache entry younger
+     * than [CONFIG_CACHE_TTL_MS] instead of always trusting whatever [getResolvedConfig] would
+     * otherwise decide — used by [fetchServiceConfig], the entry point several independent
+     * polling loops call on their own short cadence (see the call site's comment for why this
+     * matters). A cache miss, a source change, or an expired entry falls through to a real fetch
+     * exactly like [getResolvedConfig] would.
+     */
+    private suspend fun getResolvedConfigWithTtl(): ResolvedVotingConfig {
+        val sources = resolveConfigSources()
+        configMutex.withLock {
+            val cached = cachedResolvedConfig
+            val fetchedAtMs = cachedResolvedConfigFetchedAtMs
+            if (cached != null &&
+                fetchedAtMs != null &&
+                cached.sources == sources &&
+                System.currentTimeMillis() - fetchedAtMs < CONFIG_CACHE_TTL_MS
+            ) {
+                return cached
+            }
+        }
+        return getResolvedConfig()
+    }
 
     private suspend fun resolveConfigSources(): List<PinnedConfigSource> {
         val selectedPinnedSource = votingChainConfigRepository.get().selectedPinnedSource
@@ -769,7 +859,17 @@ class KtorVotingApiProvider(
             }
             serverHealthTracker.recordSuccess(serverUrl)
             true
-        } catch (_: Throwable) {
+        } catch (throwable: Throwable) {
+            // MOB-1808: delegateShares() now cancels sibling shares via coroutineScope on the
+            // first failing share. Without this rethrow, a cancelled share's suspended post()
+            // call would swallow its own CancellationException here, fall through to the
+            // fallback-target loop, and fire MORE requests after the batch already failed —
+            // plus wrongly recordFailure() a server that was never actually rejected, risking
+            // tripping its circuit breaker. Matches the same rethrow already used correctly in
+            // this file's fetchTxConfirmation.
+            if (throwable is CancellationException) {
+                throw throwable
+            }
             serverHealthTracker.recordFailure(serverUrl)
             false
         }
@@ -1060,6 +1160,20 @@ private const val RAW_GITHUBUSERCONTENT_HOST = "raw.githubusercontent.com"
 private const val CACHE_BUST_QUERY_PARAM = "zodl_cache_bust"
 private const val TRANSIENT_HTTP_STATUS_MIN = 500
 private const val TRANSIENT_HTTP_STATUS_MAX = 599
+
+// MOB-1808: cap on simultaneously in-flight isolated Tor clients within one delegateShares()
+// fan-out. Comfortably above our observed 16-share test batches while still bounding a much
+// larger wallet's fan-out to something that won't look like an anomalous multi-circuit burst to
+// the vote servers or exhaust local Tor/thread resources.
+private const val MAX_CONCURRENT_SHARE_DELEGATIONS = 16
+
+// MOB-1808: how long fetchServiceConfig() reuses a source-matching cached config before treating
+// it as stale — well above the CHP round list's fastest polling loop (5s round-status
+// auto-refresh) and the foreground share-rediscovery driver (15s), so those loops collapse onto
+// one shared fetch instead of each re-fetching from scratch, while still keeping served config
+// close to real-time for anything that isn't already forcing a fresh fetch via
+// invalidateConfigCache() (e.g. the submit flow, or a config-source change).
+private const val CONFIG_CACHE_TTL_MS = 60_000L
 
 private fun List<String>.normalizeServerUrls(): List<String> =
     map(String::trim)

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -1195,13 +1195,18 @@ private const val MAX_CONCURRENT_SHARE_DELEGATIONS = 16
 // connection doesn't dominate a batch's wall time the way we observed (up to 60s on one attempt).
 private const val SHARE_REQUEST_TIMEOUT_MILLIS = 15_000L
 
-// MOB-1808: how long fetchServiceConfig() reuses a source-matching cached config before treating
-// it as stale — well above the CHP round list's fastest polling loop (5s round-status
-// auto-refresh) and the foreground share-rediscovery driver (15s), so those loops collapse onto
-// one shared fetch instead of each re-fetching from scratch, while still keeping served config
-// close to real-time for anything that isn't already forcing a fresh fetch via
-// invalidateConfigCache() (e.g. the submit flow, or a config-source change).
-private const val CONFIG_CACHE_TTL_MS = 60_000L
+// MOB-1808: how long fetchServiceConfig() reuses a source-matching cached config (both the
+// static AND dynamic legs — fetchTrustedConfig() fetches them together as one unit, cached
+// together as one ResolvedVotingConfig) before treating it as stale. Well above the CHP round
+// list's fastest polling loop (5s round-status auto-refresh) and the foreground
+// share-rediscovery driver (15s), so those loops collapse onto one shared fetch instead of each
+// re-fetching from scratch. 10 minutes rather than something tighter: this config changes rarely
+// (trusted_keys rotation, server list changes) and nothing in the app already guarantees
+// real-time propagation of those changes, so a 10-minute-stale worst case is an acceptable
+// trade for cutting request volume much further — anything that genuinely needs a guaranteed
+// fresh fetch already bypasses this TTL via invalidateConfigCache() (the submit flow, or a
+// config-source change).
+private const val CONFIG_CACHE_TTL_MS = 600_000L
 
 private fun List<String>.normalizeServerUrls(): List<String> =
     map(String::trim)

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -723,6 +723,14 @@ class KtorVotingApiProvider(
                 // HttpClientProviderImpl) — recreate rather than keep serving a client built for the
                 // stale preference, and close the stale one so it isn't leaked.
                 existing?.close()
+                // Invalidate the cache BEFORE attempting the rebuild. If httpClientProvider.create()
+                // throws below, existing is already closed — leaving cachedHttpClient /
+                // cachedHttpClientSupportsKtorTimeouts pointing at it would risk a later call (e.g.
+                // after the user toggles Tor back to its original state) matching the stale cache
+                // entry and handing out an already-closed HttpClient. Clearing first forces the next
+                // call to attempt a fresh rebuild instead.
+                cachedHttpClient = null
+                cachedHttpClientSupportsKtorTimeouts = null
                 val fresh = httpClientProvider.create()
                 cachedHttpClient = fresh
                 cachedHttpClientSupportsKtorTimeouts = supportsKtorTimeouts

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -37,6 +37,7 @@ import co.electriccoin.zcash.ui.common.model.voting.toTallyResults
 import co.electriccoin.zcash.ui.common.model.voting.withSubmitAt
 import co.electriccoin.zcash.ui.common.repository.ConfigurationRepository
 import co.electriccoin.zcash.ui.common.repository.VotingChainConfigRepository
+import co.electriccoin.zcash.ui.common.repository.votingLog
 import co.electriccoin.zcash.ui.configuration.ConfigurationEntries
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -158,6 +159,9 @@ class KtorVotingApiProvider(
     private var cachedResolvedConfig: ResolvedVotingConfig? = null
     private val configMutex = Mutex()
     private val serverHealthTracker = VotingServerHealthTracker()
+    private val httpClientMutex = Mutex()
+    private var cachedHttpClient: HttpClient? = null
+    private var cachedHttpClientSupportsKtorTimeouts: Boolean? = null
 
     override suspend fun validateConfigSource(source: PinnedConfigSource) {
         fetchStaticConfig(listOf(source))
@@ -258,60 +262,70 @@ class KtorVotingApiProvider(
         }
     }
 
-    override suspend fun delegateShares(shares: List<SharePayload>): List<DelegatedShareInfo> =
-        executeWithKtorTimeoutSupport delegateShares@{ supportsKtorTimeouts ->
-            if (shares.isEmpty()) {
-                return@delegateShares emptyList()
-            }
+    override suspend fun delegateShares(shares: List<SharePayload>): List<DelegatedShareInfo> {
+        val startMs = System.currentTimeMillis()
+        votingLog("delegateShares START shares=${shares.size}")
+        return try {
+            executeWithKtorTimeoutSupport delegateShares@{ supportsKtorTimeouts ->
+                if (shares.isEmpty()) {
+                    return@delegateShares emptyList()
+                }
 
-            val config = getResolvedConfig().serviceConfig
-            val serverUrls =
-                config.voteServers
-                    .map { endpoint -> endpoint.url.trimEnd('/') }
-                    .distinct()
+                val config = getResolvedConfig().serviceConfig
+                val serverUrls =
+                    config.voteServers
+                        .map { endpoint -> endpoint.url.trimEnd('/') }
+                        .distinct()
 
-            if (serverUrls.isEmpty()) {
-                error("Voting server URL is not configured")
-            }
+                if (serverUrls.isEmpty()) {
+                    error("Voting server URL is not configured")
+                }
 
-            serverHealthTracker.remember(serverUrls)
+                serverHealthTracker.remember(serverUrls)
 
-            buildList {
-                for (share in shares) {
-                    val body = share.toApiBody()
-                    val healthyServers = serverHealthTracker.healthyServers(serverUrls)
-                    val quorum = max(1, (healthyServers.size + 1) / 2)
-                    val targets = healthyServers.shuffled().take(quorum)
-                    val acceptedByServers =
-                        postShareToTargets(targets, body, supportsKtorTimeouts).toMutableList()
-                    if (acceptedByServers.isEmpty()) {
-                        val fallbackTargets =
-                            serverHealthTracker
-                                .healthyServers(serverUrls)
-                                .filterNot { serverUrl -> serverUrl in targets }
-                                .shuffled()
-                        for (fallbackTarget in fallbackTargets) {
-                            if (postShare(fallbackTarget, body, supportsKtorTimeouts)) {
-                                acceptedByServers += fallbackTarget
-                                break
+                buildList {
+                    for (share in shares) {
+                        val body = share.toApiBody()
+                        val healthyServers = serverHealthTracker.healthyServers(serverUrls)
+                        val quorum = max(1, (healthyServers.size + 1) / 2)
+                        val targets = healthyServers.shuffled().take(quorum)
+                        val acceptedByServers =
+                            postShareToTargets(targets, body, supportsKtorTimeouts).toMutableList()
+                        if (acceptedByServers.isEmpty()) {
+                            val fallbackTargets =
+                                serverHealthTracker
+                                    .healthyServers(serverUrls)
+                                    .filterNot { serverUrl -> serverUrl in targets }
+                                    .shuffled()
+                            for (fallbackTarget in fallbackTargets) {
+                                if (postShare(fallbackTarget, body, supportsKtorTimeouts)) {
+                                    acceptedByServers += fallbackTarget
+                                    break
+                                }
                             }
                         }
-                    }
 
-                    if (acceptedByServers.isEmpty()) {
-                        error("No voting server accepted share ${share.encShare.shareIndex}")
-                    }
+                        if (acceptedByServers.isEmpty()) {
+                            error("No voting server accepted share ${share.encShare.shareIndex}")
+                        }
 
-                    add(
-                        DelegatedShareInfo(
-                            shareIndex = share.encShare.shareIndex,
-                            proposalId = share.proposalId,
-                            acceptedByServers = acceptedByServers
+                        add(
+                            DelegatedShareInfo(
+                                shareIndex = share.encShare.shareIndex,
+                                proposalId = share.proposalId,
+                                acceptedByServers = acceptedByServers
+                            )
                         )
-                    )
+                    }
                 }
             }
+        } finally {
+            votingLog(
+                "delegateShares END shares=${shares.size} " +
+                    "elapsed=${System.currentTimeMillis() - startMs}ms"
+            )
         }
+    }
 
     override suspend fun fetchShareStatus(
         helperBaseUrl: String,
@@ -694,9 +708,25 @@ class KtorVotingApiProvider(
         crossinline block: suspend HttpClient.(Boolean) -> T
     ): T =
         withContext(Dispatchers.IO) {
+            val (httpClient, supportsKtorTimeouts) = sharedHttpClient()
+            block(httpClient, supportsKtorTimeouts)
+        }
+
+    private suspend fun sharedHttpClient(): Pair<HttpClient, Boolean> =
+        httpClientMutex.withLock {
             val supportsKtorTimeouts = httpClientProvider.supportsKtorTimeouts()
-            httpClientProvider.create().use { httpClient ->
-                block(httpClient, supportsKtorTimeouts)
+            val existing = cachedHttpClient
+            if (existing != null && cachedHttpClientSupportsKtorTimeouts == supportsKtorTimeouts) {
+                existing to supportsKtorTimeouts
+            } else {
+                // supportsKtorTimeouts() flips exactly when the user's Tor preference flips (see
+                // HttpClientProviderImpl) — recreate rather than keep serving a client built for the
+                // stale preference, and close the stale one so it isn't leaked.
+                existing?.close()
+                val fresh = httpClientProvider.create()
+                cachedHttpClient = fresh
+                cachedHttpClientSupportsKtorTimeouts = supportsKtorTimeouts
+                fresh to supportsKtorTimeouts
             }
         }
 

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -356,7 +356,9 @@ class KtorVotingApiProvider(
                                         val quorum = max(1, (healthyServers.size + 1) / 2)
                                         val targets = healthyServers.shuffled().take(quorum)
                                         val acceptedByServers =
-                                            client.postShareToTargets(targets, body, supportsKtorTimeouts).toMutableList()
+                                            client
+                                                .postShareToTargets(targets, body, supportsKtorTimeouts)
+                                                .toMutableList()
                                         if (acceptedByServers.isEmpty()) {
                                             val fallbackTargets =
                                                 serverHealthTracker
@@ -880,21 +882,26 @@ class KtorVotingApiProvider(
         } catch (_: TimeoutCancellationException) {
             // Our own withTorRequestTimeoutFallback deadline firing, NOT a genuine outer
             // cancellation (see that function's TRAP doc) — treat exactly like any other failed
-            // attempt so the caller's fallback-target loop still runs, instead of the rethrow
-            // below misidentifying it as delegateShares' sibling-cancellation signal.
+            // attempt so the caller's fallback-target loop still runs, instead of the catch
+            // below misidentifying it as delegateShares' sibling-cancellation signal. This catch
+            // clause MUST stay ordered before the plain CancellationException one below —
+            // TimeoutCancellationException extends it, so Kotlin's first-match catch ordering
+            // requires the more specific type first.
             serverHealthTracker.recordFailure(serverUrl)
             false
-        } catch (throwable: Throwable) {
+        } catch (cancellation: CancellationException) {
             // MOB-1808: delegateShares() now cancels sibling shares via coroutineScope on the
             // first failing share. Without this rethrow, a cancelled share's suspended post()
             // call would swallow its own CancellationException here, fall through to the
             // fallback-target loop, and fire MORE requests after the batch already failed —
             // plus wrongly recordFailure() a server that was never actually rejected, risking
             // tripping its circuit breaker. Matches the same rethrow already used correctly in
-            // this file's fetchTxConfirmation.
-            if (throwable is CancellationException) {
-                throw throwable
-            }
+            // this file's fetchTxConfirmation. A dedicated catch clause (rather than an `is`
+            // check inside a broader Throwable catch) so detekt's InstanceOfCheckForException
+            // rule doesn't flag it.
+            throw cancellation
+        } catch (throwable: Throwable) {
+            votingLog("postShare FAILED server=$serverUrl", throwable)
             serverHealthTracker.recordFailure(serverUrl)
             false
         }

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -157,6 +157,14 @@ class KtorVotingApiProvider(
      * timeout mechanisms share.
      */
     private val configRequestTimeoutMillis: Long = StaticVotingConfig.CONFIG_REQUEST_TIMEOUT_MS,
+    /**
+     * Per-attempt timeout for [postShare] (MOB-1808), defaulting to
+     * [SHARE_REQUEST_TIMEOUT_MILLIS]. Overridable only so tests can inject a short value when
+     * exercising the app-side [withTorRequestTimeoutFallback] path for share posting, mirroring
+     * [configRequestTimeoutMillis] above — production callers (DI, see `featureVotingModule`)
+     * never pass an override.
+     */
+    private val shareRequestTimeoutMillis: Long = SHARE_REQUEST_TIMEOUT_MILLIS,
 ) : VotingApiProvider {
     private var cachedResolvedConfig: ResolvedVotingConfig? = null
     private var cachedResolvedConfigFetchedAtMs: Long? = null
@@ -871,7 +879,7 @@ class KtorVotingApiProvider(
             // supportsKtorTimeouts is false. Wrapping in withTorRequestTimeoutFallback fails this
             // one attempt fast instead of stalling the whole delegateShares() batch (awaitAll())
             // on its slowest share.
-            withTorRequestTimeoutFallback(supportsKtorTimeouts, SHARE_REQUEST_TIMEOUT_MILLIS) {
+            withTorRequestTimeoutFallback(supportsKtorTimeouts, shareRequestTimeoutMillis) {
                 post("$serverUrl/shielded-vote/v1/shares") {
                     setBody(TextContent(body, ContentType.Application.Json))
                     helperRequestTimeout(supportsKtorTimeouts)

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -151,7 +151,7 @@ class KtorVotingApiProvider(
     /**
      * Per-attempt timeout for both config-fetch legs (MOB-1809), defaulting to
      * [StaticVotingConfig.CONFIG_REQUEST_TIMEOUT_MS]. Overridable only so tests can inject a
-     * short value when exercising the app-side [withConfigRequestTimeoutFallback] path — the
+     * short value when exercising the app-side [withTorRequestTimeoutFallback] path — the
      * production default never changes, and DI (see `featureVotingModule`) never passes an
      * override, so every real caller gets the same 15s bound both the Ktor-level and app-side
      * timeout mechanisms share.
@@ -605,7 +605,7 @@ class KtorVotingApiProvider(
         supportsKtorTimeouts: Boolean
     ): ByteArray =
         try {
-            withConfigRequestTimeoutFallback(supportsKtorTimeouts, configRequestTimeoutMillis) {
+            withTorRequestTimeoutFallback(supportsKtorTimeouts, configRequestTimeoutMillis) {
                 get(url) {
                     noCache()
                     configRequestTimeout(supportsKtorTimeouts, configRequestTimeoutMillis)
@@ -702,7 +702,7 @@ class KtorVotingApiProvider(
         supportsKtorTimeouts: Boolean
     ): String =
         try {
-            withConfigRequestTimeoutFallback(supportsKtorTimeouts, configRequestTimeoutMillis) {
+            withTorRequestTimeoutFallback(supportsKtorTimeouts, configRequestTimeoutMillis) {
                 get(url.withCacheBustIfNeeded(cacheBustToken)) {
                     noCache()
                     configRequestTimeout(supportsKtorTimeouts, configRequestTimeoutMillis)
@@ -853,12 +853,29 @@ class KtorVotingApiProvider(
         supportsKtorTimeouts: Boolean
     ): Boolean =
         try {
-            post("$serverUrl/shielded-vote/v1/shares") {
-                setBody(TextContent(body, ContentType.Application.Json))
-                helperRequestTimeout(supportsKtorTimeouts)
+            // MOB-1808: observed live (see the "slow window" trace) that a single share hitting a
+            // vote server with a flaky/dropping Tor connection could hang far past every other
+            // share's latency — helperRequestTimeout() is a Ktor-level timeout that's a no-op
+            // under Tor (installTimeouts = false, same blind spot MOB-1809 already fixed for the
+            // config-fetch legs), so nothing was actually bounding this attempt when
+            // supportsKtorTimeouts is false. Wrapping in withTorRequestTimeoutFallback fails this
+            // one attempt fast instead of stalling the whole delegateShares() batch (awaitAll())
+            // on its slowest share.
+            withTorRequestTimeoutFallback(supportsKtorTimeouts, SHARE_REQUEST_TIMEOUT_MILLIS) {
+                post("$serverUrl/shielded-vote/v1/shares") {
+                    setBody(TextContent(body, ContentType.Application.Json))
+                    helperRequestTimeout(supportsKtorTimeouts)
+                }
             }
             serverHealthTracker.recordSuccess(serverUrl)
             true
+        } catch (_: TimeoutCancellationException) {
+            // Our own withTorRequestTimeoutFallback deadline firing, NOT a genuine outer
+            // cancellation (see that function's TRAP doc) — treat exactly like any other failed
+            // attempt so the caller's fallback-target loop still runs, instead of the rethrow
+            // below misidentifying it as delegateShares' sibling-cancellation signal.
+            serverHealthTracker.recordFailure(serverUrl)
+            false
         } catch (throwable: Throwable) {
             // MOB-1808: delegateShares() now cancels sibling shares via coroutineScope on the
             // first failing share. Without this rethrow, a cancelled share's suspended post()
@@ -1059,24 +1076,26 @@ private fun HttpRequestBuilder.configRequestTimeout(
 }
 
 /**
- * Bounds a config-fetch attempt to [timeoutMillis] app-side when Ktor-level timeouts are
- * unavailable ([supportsKtorTimeouts] == false — the Tor client is built with
- * `installTimeouts = false`, so [configRequestTimeout] is a no-op there and a stalling origin
- * would otherwise hang the attempt forever). When [supportsKtorTimeouts] is true, [block] runs
- * unbounded here — Ktor's own per-request [io.ktor.client.plugins.HttpTimeout] already enforces
- * the same bound.
+ * Bounds a request attempt to [timeoutMillis] app-side when Ktor-level timeouts are unavailable
+ * ([supportsKtorTimeouts] == false — every Tor-routed client is built with
+ * `installTimeouts = false`, so a Ktor-level `timeout { }` block is a no-op there and a stalling
+ * origin would otherwise hang the attempt forever). When [supportsKtorTimeouts] is true, [block]
+ * runs unbounded here — Ktor's own per-request [io.ktor.client.plugins.HttpTimeout] already
+ * enforces the same bound. Originally written for the config-fetch legs (MOB-1809); reused as-is
+ * for delegateShares()'s per-share POST (MOB-1808) — same blind spot, same fix, different caller.
  *
  * TRAP: [kotlinx.coroutines.TimeoutCancellationException] EXTENDS [CancellationException].
  * kotlinx.coroutines guarantees it is delivered only to the [kotlinx.coroutines.withTimeout]
  * frame whose own deadline actually expired; a genuine OUTER cancellation manifests as a
  * *different* [CancellationException] and is never caught by a `catch (TimeoutCancellationException)`
  * clause here. Every caller MUST catch [TimeoutCancellationException] explicitly and convert it to
- * that leg's own retryable exception BEFORE any generic `catch (exception: Exception)` /
+ * that leg's own retryable/failed outcome BEFORE any generic `catch (exception: Exception)` /
  * [rethrowIfCancellation] handling runs — letting it fall through to that generic handling would
- * rethrow it as a cancellation and abort the whole mirror walk instead of falling through to the
- * next mirror.
+ * rethrow it as a genuine cancellation instead of a per-attempt timeout (aborting a whole mirror
+ * walk, or in postShare's case wrongly killing sibling shares via structured concurrency, instead
+ * of just trying the next mirror/fallback server).
  */
-private suspend fun <T> withConfigRequestTimeoutFallback(
+private suspend fun <T> withTorRequestTimeoutFallback(
     supportsKtorTimeouts: Boolean,
     timeoutMillis: Long,
     block: suspend () -> T
@@ -1093,7 +1112,7 @@ private suspend fun <T> withConfigRequestTimeoutFallback(
  * fallback, which classifies and fails fast per attempt. Left unmarked, the client's default
  * policy (`~5` attempts with exponential backoff, roughly 90s) would internally exhaust itself
  * against a single dead mirror before the walk's own classification — and
- * [withConfigRequestTimeoutFallback]'s fail-fast bound — ever runs. Uses Ktor's own per-request
+ * [withTorRequestTimeoutFallback]'s fail-fast bound — ever runs. Uses Ktor's own per-request
  * retry configuration ([io.ktor.client.plugins.retry]); on a client where [HttpRequestRetry]
  * isn't installed at all (the Tor client), this is a harmless no-op.
  */
@@ -1166,6 +1185,15 @@ private const val TRANSIENT_HTTP_STATUS_MAX = 599
 // larger wallet's fan-out to something that won't look like an anomalous multi-circuit burst to
 // the vote servers or exhaust local Tor/thread resources.
 private const val MAX_CONCURRENT_SHARE_DELEGATIONS = 16
+
+// MOB-1808: per-attempt app-side timeout for a single share POST under Tor (see postShare's
+// withTorRequestTimeoutFallback usage) — bounds how long one flaky/dropping vote-server
+// connection can stall delegateShares()'s awaitAll() before that attempt fails fast and the
+// caller's fallback-target loop tries a different server. Matches StaticVotingConfig's
+// CONFIG_REQUEST_TIMEOUT_MS convention (15s): comfortably above the ~0.3-2s a healthy share POST
+// (including circuit build) took in live measurement, short enough that one dead operator
+// connection doesn't dominate a batch's wall time the way we observed (up to 60s on one attempt).
+private const val SHARE_REQUEST_TIMEOUT_MILLIS = 15_000L
 
 // MOB-1808: how long fetchServiceConfig() reuses a source-matching cached config before treating
 // it as stale — well above the CHP round list's fastest polling loop (5s round-status

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -191,10 +191,12 @@ class KtorVotingApiProvider(
     // still forces a real refetch) but forceRefresh=true bypassed it entirely regardless of age.
     // Switching to TTL-bounded reuse (getResolvedConfigWithTtl) keeps every one of those loops
     // fed from one shared fetch instead of each paying its own round trip, while still bounding
-    // how stale the served config can get. Callers that need a guaranteed-fresh fetch (e.g. a
-    // config-source change, or the submit flow, which already calls invalidateConfigCache()
-    // explicitly before it enters) go through that explicit invalidation instead of relying on
-    // this method to force one.
+    // how stale the served config can get. A guaranteed-fresh fetch still goes through the
+    // explicit invalidateConfigCache() path instead of relying on this method to force one — its
+    // sole caller today is VoteCoinholderPollingVM's refreshVotingDataInternal(), invoked on
+    // screen entry, pull-to-refresh, and a config-source change, so the submit flow's own config
+    // reads are only as fresh as whatever that screen-level invalidation + this TTL last left
+    // cached, not independently guaranteed fresh by the submit flow itself.
     override suspend fun fetchServiceConfig(): VotingServiceConfig =
         getResolvedConfigWithTtl().serviceConfig
 
@@ -522,10 +524,40 @@ class KtorVotingApiProvider(
     }
 
     private suspend fun getResolvedConfig(forceRefresh: Boolean = false): ResolvedVotingConfig =
+        resolveConfigCached(useTtl = false, forceRefresh = forceRefresh)
+
+    /**
+     * Like [getResolvedConfig] but additionally requires a source-matching cache entry to be
+     * younger than [CONFIG_CACHE_TTL_MS] to be reused — used by [fetchServiceConfig], the entry
+     * point several independent polling loops call on their own short cadence (see that call
+     * site's comment for why this matters). A cache miss, a source change, or an expired entry
+     * all fall through to a real fetch.
+     */
+    private suspend fun getResolvedConfigWithTtl(): ResolvedVotingConfig =
+        resolveConfigCached(useTtl = true, forceRefresh = false)
+
+    /**
+     * Single mutex-guarded decision point shared by [getResolvedConfig] and
+     * [getResolvedConfigWithTtl] — folding both into one critical section (rather than the TTL
+     * variant checking freshness outside the lock and then calling the non-TTL variant, which is
+     * what an earlier version of this code did) closes two problems at once: (1) it avoids two
+     * callers racing to independently decide "expired" and both firing a real fetch, and (2) it
+     * avoids the non-TTL variant's own cache check — source-match only, no age check — silently
+     * re-serving a [useTtl]-expired entry right back out because from *its* perspective the cache
+     * looked perfectly valid.
+     */
+    private suspend fun resolveConfigCached(
+        useTtl: Boolean,
+        forceRefresh: Boolean
+    ): ResolvedVotingConfig =
         configMutex.withLock {
             val sources = resolveConfigSources()
             val cached = cachedResolvedConfig
-            if (!forceRefresh && cached?.sources == sources) {
+            val fetchedAtMs = cachedResolvedConfigFetchedAtMs
+            val sourcesMatch = cached != null && cached.sources == sources
+            val withinTtl =
+                !useTtl || (fetchedAtMs != null && System.currentTimeMillis() - fetchedAtMs < CONFIG_CACHE_TTL_MS)
+            if (!forceRefresh && sourcesMatch && withinTtl) {
                 cached
             } else {
                 fetchTrustedConfig(sources).also { resolved ->
@@ -534,30 +566,6 @@ class KtorVotingApiProvider(
                 }
             }
         }
-
-    /**
-     * Like [getResolvedConfig] but additionally reuses a source-matching cache entry younger
-     * than [CONFIG_CACHE_TTL_MS] instead of always trusting whatever [getResolvedConfig] would
-     * otherwise decide — used by [fetchServiceConfig], the entry point several independent
-     * polling loops call on their own short cadence (see the call site's comment for why this
-     * matters). A cache miss, a source change, or an expired entry falls through to a real fetch
-     * exactly like [getResolvedConfig] would.
-     */
-    private suspend fun getResolvedConfigWithTtl(): ResolvedVotingConfig {
-        val sources = resolveConfigSources()
-        configMutex.withLock {
-            val cached = cachedResolvedConfig
-            val fetchedAtMs = cachedResolvedConfigFetchedAtMs
-            if (cached != null &&
-                fetchedAtMs != null &&
-                cached.sources == sources &&
-                System.currentTimeMillis() - fetchedAtMs < CONFIG_CACHE_TTL_MS
-            ) {
-                return cached
-            }
-        }
-        return getResolvedConfig()
-    }
 
     private suspend fun resolveConfigSources(): List<PinnedConfigSource> {
         val selectedPinnedSource = votingChainConfigRepository.get().selectedPinnedSource

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -165,6 +165,15 @@ class KtorVotingApiProvider(
      * never pass an override.
      */
     private val shareRequestTimeoutMillis: Long = SHARE_REQUEST_TIMEOUT_MILLIS,
+    /**
+     * TTL for the resolved-config cache (MOB-1808), defaulting to [CONFIG_CACHE_TTL_MS].
+     * Overridable only so tests can inject a short value to actually exercise the expiry
+     * fallthrough branch of [resolveConfigCached] (a real elapsed-time wait past a tiny TTL,
+     * as opposed to [invalidateConfigCache]'s null-out, which only exercises the cache-miss
+     * branch and cannot distinguish "never cached" from "expired") — mirrors
+     * [configRequestTimeoutMillis] above; production callers never pass an override.
+     */
+    private val configCacheTtlMillis: Long = CONFIG_CACHE_TTL_MS,
 ) : VotingApiProvider {
     private var cachedResolvedConfig: ResolvedVotingConfig? = null
     private var cachedResolvedConfigFetchedAtMs: Long? = null
@@ -566,7 +575,7 @@ class KtorVotingApiProvider(
             val fetchedAtMs = cachedResolvedConfigFetchedAtMs
             val sourcesMatch = cached != null && cached.sources == sources
             val withinTtl =
-                !useTtl || (fetchedAtMs != null && System.currentTimeMillis() - fetchedAtMs < CONFIG_CACHE_TTL_MS)
+                !useTtl || (fetchedAtMs != null && System.currentTimeMillis() - fetchedAtMs < configCacheTtlMillis)
             if (!forceRefresh && sourcesMatch && withinTtl) {
                 cached
             } else {

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/repository/VotingLogger.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/repository/VotingLogger.kt
@@ -7,4 +7,6 @@ import co.electriccoin.zcash.ui.util.loggable
  * Mirrors `feature-migration`'s MigrationLogger: one plain tag, no unrelated noise, no-op in
  * release builds (see `loggable`'s `BuildConfig.DEBUG` gate).
  */
-val votingLog = co.electriccoin.zcash.ui.util.loggable("VOTING")
+val votingLog =
+    co.electriccoin.zcash.ui.util
+        .loggable("VOTING")

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/repository/VotingLogger.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/repository/VotingLogger.kt
@@ -1,0 +1,10 @@
+package co.electriccoin.zcash.ui.common.repository
+
+import co.electriccoin.zcash.ui.util.loggable
+
+/**
+ * Single-tag debug logger for CHP voting timing/diagnostics. Watch with `adb logcat -s VOTING`.
+ * Mirrors `feature-migration`'s MigrationLogger: one plain tag, no unrelated noise, no-op in
+ * release builds (see `loggable`'s `BuildConfig.DEBUG` gate).
+ */
+val votingLog = co.electriccoin.zcash.ui.util.loggable("VOTING")

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/repository/VotingLogger.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/repository/VotingLogger.kt
@@ -1,12 +1,28 @@
 package co.electriccoin.zcash.ui.common.repository
 
-import co.electriccoin.zcash.ui.util.loggable
+import co.electriccoin.zcash.voting.BuildConfig
 
 /**
  * Single-tag debug logger for CHP voting timing/diagnostics. Watch with `adb logcat -s VOTING`.
- * Mirrors `feature-migration`'s MigrationLogger: one plain tag, no unrelated noise, no-op in
- * release builds (see `loggable`'s `BuildConfig.DEBUG` gate).
+ *
+ * Implemented locally (not via `co.electriccoin.zcash.ui.util.loggable`, which is forbidden
+ * outside ui-lib by the repo's detekt config - module boundary, feature-voting doesn't depend
+ * on ui-lib internals for this) but behaviorally identical: mirrors `feature-migration`'s
+ * MigrationLogger, one plain tag, no-op in release builds.
  */
+interface VotingLogger {
+    operator fun invoke(message: String, exception: Throwable? = null)
+}
+
 val votingLog =
-    co.electriccoin.zcash.ui.util
-        .loggable("VOTING")
+    object : VotingLogger {
+        override fun invoke(message: String, exception: Throwable?) {
+            if (BuildConfig.DEBUG) {
+                if (exception != null) {
+                    android.util.Log.e("VOTING", message, exception)
+                } else {
+                    android.util.Log.d("VOTING", message)
+                }
+            }
+        }
+    }

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/usecase/RefreshVotingServiceConfigUseCase.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/usecase/RefreshVotingServiceConfigUseCase.kt
@@ -1,0 +1,33 @@
+package co.electriccoin.zcash.ui.common.usecase
+
+import co.electriccoin.zcash.ui.common.provider.VotingApiProvider
+import co.electriccoin.zcash.ui.common.repository.VotingConfigRepository
+import co.electriccoin.zcash.ui.common.repository.VotingConfigSnapshot
+import co.electriccoin.zcash.ui.common.repository.VotingConfigSource
+
+/**
+ * Fetches and stores the resolved voting service config, without also fetching and storing the
+ * round list (MOB-1808). [RefreshActiveVotingSessionUseCase] does both — needed as-is by
+ * [co.electriccoin.zcash.voting.VotingHomeHooksImpl]'s pending-Keystone-request recovery check,
+ * which genuinely wants the round list populated as a side effect. But
+ * `VoteCoinholderPollingVM.refreshVotingDataInternal()` calls `RefreshVotingRoundsUseCase` (which
+ * already fetches config + the full round list + endorsed round ids) immediately before this —
+ * using `RefreshActiveVotingSessionUseCase` there too, just to surface a [VotingConfigException]
+ * the config fetch might throw, was re-fetching the entire round list a second time for no reason
+ * every single auto-refresh tick (confirmed live: two `/shielded-vote/v1/rounds` requests per
+ * cycle, ~1.3s apart). This use case is that same config-fetch-and-store step on its own.
+ */
+class RefreshVotingServiceConfigUseCase(
+    private val votingApiProvider: VotingApiProvider,
+    private val votingConfigRepository: VotingConfigRepository,
+) {
+    suspend operator fun invoke() {
+        val serviceConfig = votingApiProvider.fetchServiceConfig()
+        votingConfigRepository.store(
+            VotingConfigSnapshot(
+                serviceConfig = serviceConfig,
+                source = VotingConfigSource.REMOTE
+            )
+        )
+    }
+}

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingScreen.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingScreen.kt
@@ -1,8 +1,6 @@
 package co.electriccoin.zcash.ui.screen.voting.coinholderpolling
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.Lifecycle
@@ -12,7 +10,6 @@ import co.electriccoin.zcash.ui.screen.common.LceRenderer
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun VoteCoinholderPollingScreen() {
     val vm = koinViewModel<VoteCoinholderPollingVM>()
@@ -32,12 +29,9 @@ fun VoteCoinholderPollingScreen() {
         } else {
             // Cache-and-fresh (MOB-1808): rounds render immediately from the repository cache
             // while a refresh runs in the background (see VoteCoinholderPollingVM's `rounds`
-            // derivation). `isLoading` no longer needs to block content behind a full-screen
-            // shimmer for this case, so it drives the pull-to-refresh spinner instead — the
-            // background refresh becomes visible feedback rather than a silent, unbounded wait.
-            PullToRefreshBox(isRefreshing = state.isLoading, onRefresh = it.onRefresh) {
-                VoteCoinholderPollingView(it)
-            }
+            // derivation). The pull-to-refresh indicator (wired inside VoteCoinholderPollingView,
+            // below its own top bar) surfaces that background refresh instead of a silent wait.
+            VoteCoinholderPollingView(it, isRefreshing = state.isLoading)
         }
     }
 }

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingScreen.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingScreen.kt
@@ -1,6 +1,8 @@
 package co.electriccoin.zcash.ui.screen.voting.coinholderpolling
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.Lifecycle
@@ -10,6 +12,7 @@ import co.electriccoin.zcash.ui.screen.common.LceRenderer
 import kotlinx.serialization.Serializable
 import org.koin.androidx.compose.koinViewModel
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun VoteCoinholderPollingScreen() {
     val vm = koinViewModel<VoteCoinholderPollingVM>()
@@ -24,10 +27,17 @@ fun VoteCoinholderPollingScreen() {
     val state by vm.state.collectAsStateWithLifecycle()
     LceRenderer(state = state) {
         BackHandler { it.onBack() }
-        if (state.isLoading && it.activeRounds == null && it.pastRounds == null) {
+        if (it.isInitialLoading) {
             VoteCoinholderPollingLoadingView(it)
         } else {
-            VoteCoinholderPollingView(it)
+            // Cache-and-fresh (MOB-1808): rounds render immediately from the repository cache
+            // while a refresh runs in the background (see VoteCoinholderPollingVM's `rounds`
+            // derivation). `isLoading` no longer needs to block content behind a full-screen
+            // shimmer for this case, so it drives the pull-to-refresh spinner instead — the
+            // background refresh becomes visible feedback rather than a silent, unbounded wait.
+            PullToRefreshBox(isRefreshing = state.isLoading, onRefresh = it.onRefresh) {
+                VoteCoinholderPollingView(it)
+            }
         }
     }
 }

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingState.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingState.kt
@@ -17,6 +17,11 @@ data class VoteCoinholderPollingState(
     val configErrorSheet: ZashiConfirmationState? = null,
     val unverifiedPollWarningSheet: ZashiConfirmationState? = null,
     val noRoundsSheet: ZashiConfirmationState? = null,
+    // Set once by the VM (VoteCoinholderPollingVM's `rounds == null` check) rather than
+    // re-derived in the Screen composable from activeRounds/pastRounds nullness — the VM already
+    // knows exactly why there's no content yet (cold start vs. cache-and-fresh); the View should
+    // just trust this one flag instead of reconstructing the same decision from raw fields.
+    val isInitialLoading: Boolean = false,
 ) {
     companion object {
         val preview =

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingVM.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingVM.kt
@@ -539,24 +539,48 @@ class VoteCoinholderPollingVM(
             votingApiProvider.invalidateConfigCache()
         }
 
-        refreshVotingRounds()
         var nextConfigIssue: VotingConfigException? = null
-        runCatching {
-            // MOB-1808: this used to be RefreshActiveVotingSessionUseCase, which — despite its
-            // name — fetches the service config AND the entire round list, redundantly re-doing
-            // the fetchAllRounds() that refreshVotingRounds() (above) just did. Its only real job
-            // here is to re-probe fetchServiceConfig() so a VotingConfigException surfaces as
-            // configIssue below; RefreshVotingServiceConfigUseCase does just that, without the
-            // second round-list fetch (confirmed live: this was doubling every /rounds request
-            // during the CHP screen's auto-refresh). RefreshActiveVotingSessionUseCase itself is
-            // unchanged and still used as-is by VotingHomeHooksImpl, which genuinely wants its
-            // round-list side effect for pending-Keystone-request recovery.
-            refreshVotingServiceConfig()
-        }.onFailure { throwable ->
-            if (throwable is VotingConfigException) {
-                nextConfigIssue = throwable
-            } else {
-                Log.w(TAG, "Voting service config refresh failed", throwable)
+        try {
+            // refreshVotingRounds() -> RefreshVotingRoundsUseCase calls fetchServiceConfig()
+            // before fetchAllRounds(), and fetchServiceConfig() is the ONLY source of
+            // VotingConfigException on this path: it never touches round authentication
+            // (that lives in the unrelated fetchActiveVotingSession()), and fetchAllRounds()
+            // swallows per-round auth failures internally via authenticateVotingSessionOrNull
+            // rather than propagating them. So catching VotingConfigException specifically
+            // here cannot accidentally absorb a real round-fetch/auth failure — only a genuine
+            // config problem lands here, and everything else still falls through to the
+            // caller's normal LCE error handling. A non-VotingConfigException failure here
+            // means a real round-fetch failure, which must still fail this whole refresh —
+            // rethrow unconditionally instead of swallowing it.
+            refreshVotingRounds()
+        } catch (exception: VotingConfigException) {
+            nextConfigIssue = exception
+        }
+        if (nextConfigIssue == null) {
+            runCatching {
+                // MOB-1808: this used to be RefreshActiveVotingSessionUseCase, which — despite
+                // its name — fetches the service config AND the entire round list, redundantly
+                // re-doing the fetchAllRounds() refreshVotingRounds() (above) just did. Its only
+                // non-redundant job is storing the resolved VotingConfigSnapshot into
+                // votingConfigRepository (refreshVotingRounds() above never does this — it just
+                // resolves+caches the config for its own internal use); RefreshVotingServiceConfigUseCase
+                // does just that store, without the second round-list fetch (confirmed live:
+                // the old call was doubling every /rounds request during the CHP screen's
+                // auto-refresh). This call is NOT the configIssue error-surfacing site anymore —
+                // it only runs once refreshVotingRounds() above has already proven the config
+                // resolves cleanly, so with the TTL cache (bumped to 10min) this is a guaranteed
+                // cache hit in practice; the try/catch above is the real error path now (Milan's
+                // #2483 review: the old ordering made this probe's error-surfacing dead code).
+                // RefreshActiveVotingSessionUseCase itself is unchanged and still used as-is by
+                // VotingHomeHooksImpl, which genuinely wants its round-list side effect for
+                // pending-Keystone-request recovery.
+                refreshVotingServiceConfig()
+            }.onFailure { throwable ->
+                if (throwable is VotingConfigException) {
+                    nextConfigIssue = throwable
+                } else {
+                    Log.w(TAG, "Voting service config refresh failed", throwable)
+                }
             }
         }
         configIssue = nextConfigIssue

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingVM.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingVM.kt
@@ -29,8 +29,8 @@ import co.electriccoin.zcash.ui.common.repository.effectiveChoices
 import co.electriccoin.zcash.ui.common.repository.toVotingAccountScopeId
 import co.electriccoin.zcash.ui.common.usecase.ErrorMapperUseCase
 import co.electriccoin.zcash.ui.common.usecase.ObserveSelectedWalletAccountUseCase
-import co.electriccoin.zcash.ui.common.usecase.RefreshActiveVotingSessionUseCase
 import co.electriccoin.zcash.ui.common.usecase.RefreshVotingRoundsUseCase
+import co.electriccoin.zcash.ui.common.usecase.RefreshVotingServiceConfigUseCase
 import co.electriccoin.zcash.ui.common.usecase.TrackVotingSharesUseCase
 import co.electriccoin.zcash.ui.common.usecase.VotingShareTrackingResult
 import co.electriccoin.zcash.ui.design.component.ButtonState
@@ -64,7 +64,7 @@ import java.time.format.DateTimeFormatter
 
 @Suppress("LargeClass")
 class VoteCoinholderPollingVM(
-    private val refreshActiveVotingSession: RefreshActiveVotingSessionUseCase,
+    private val refreshVotingServiceConfig: RefreshVotingServiceConfigUseCase,
     private val refreshVotingRounds: RefreshVotingRoundsUseCase,
     private val configurationRepository: ConfigurationRepository,
     private val votingChainConfigRepository: VotingChainConfigRepository,
@@ -565,12 +565,21 @@ class VoteCoinholderPollingVM(
         refreshVotingRounds()
         var nextConfigIssue: VotingConfigException? = null
         runCatching {
-            refreshActiveVotingSession()
+            // MOB-1808: this used to be RefreshActiveVotingSessionUseCase, which — despite its
+            // name — fetches the service config AND the entire round list, redundantly re-doing
+            // the fetchAllRounds() that refreshVotingRounds() (above) just did. Its only real job
+            // here is to re-probe fetchServiceConfig() so a VotingConfigException surfaces as
+            // configIssue below; RefreshVotingServiceConfigUseCase does just that, without the
+            // second round-list fetch (confirmed live: this was doubling every /rounds request
+            // during the CHP screen's auto-refresh). RefreshActiveVotingSessionUseCase itself is
+            // unchanged and still used as-is by VotingHomeHooksImpl, which genuinely wants its
+            // round-list side effect for pending-Keystone-request recovery.
+            refreshVotingServiceConfig()
         }.onFailure { throwable ->
             if (throwable is VotingConfigException) {
                 nextConfigIssue = throwable
             } else {
-                Log.w(TAG, "Active round refresh failed", throwable)
+                Log.w(TAG, "Voting service config refresh failed", throwable)
             }
         }
         configIssue = nextConfigIssue

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingVM.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingVM.kt
@@ -555,8 +555,10 @@ class VoteCoinholderPollingVM(
             // every flow entry / user-driven refresh drops the cached resolved config so
             // downstream callers (authenticateVotingSession, configuredVoteServerUrls,
             // delegateShares) cannot serve a stale config across flow openings. Auto-refresh
-            // polls leave the cache intact since they already force-refresh via
-            // RefreshVotingRoundsUseCase -> fetchServiceConfig.
+            // polls (resetVisibleConfigError = false here) deliberately leave the cache intact —
+            // fetchServiceConfig() no longer force-refreshes on every call (MOB-1808: it now
+            // reuses a source-matching cache entry up to CONFIG_CACHE_TTL_MS old), so the
+            // periodic tick simply rides that TTL instead of forcing a fresh config every 5s.
             votingApiProvider.invalidateConfigCache()
         }
 

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingVM.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingVM.kt
@@ -585,6 +585,26 @@ class VoteCoinholderPollingVM(
         }
         configIssue = nextConfigIssue
 
+        // MOB-1808 review (round 2): swallowing every config-leg failure into configIssue and
+        // returning successfully is only safe when cached rounds are still visible — the
+        // cache-and-fresh pattern (line ~175 above) keeps showing those while configIssue sits
+        // quietly behind them, and the dedicated configErrorSheet still catches a real config
+        // problem when the user taps an ACTIVE card. With an EMPTY rounds repo (first-ever
+        // screen entry, or right after a config-source switch's hard
+        // clearLoadedVotingStateForServiceConfigRefresh()), there is no cached content to fall
+        // back to and no ACTIVE card to tap — silently completing here produced
+        // roundsLceState = Success -> emptyList() and the misleading "there are no polls"
+        // noRoundsSheet instead of a real error+retry state, for something as ordinary as being
+        // offline. Rethrow so roundsLce.execute()'s catch (MutableLce.kt) routes it through the
+        // normal LCE failure path instead, which withLce (below) turns into the proper
+        // error+retry state via errorStateMapper.
+        if (nextConfigIssue != null &&
+            votingApiRepository.snapshot.value.rounds
+                .isEmpty()
+        ) {
+            throw nextConfigIssue
+        }
+
         selectedAccountUuid.value?.let { accountUuid ->
             refreshRecoveryVoteCounts(votingApiRepository.snapshot.value.rounds, accountUuid)
         } ?: run {

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingVM.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingVM.kt
@@ -368,7 +368,11 @@ class VoteCoinholderPollingVM(
 
     private fun refreshVotingData() {
         roundsLce.execute {
-            refreshVotingDataInternal(resetVisibleConfigError = true)
+            // softRefresh = true (MOB-1808): this is the pull-to-refresh action — it should
+            // behave like onScreenEntered()'s re-entry refresh, keeping the currently-visible
+            // (possibly stale) rounds up while a fresh fetch runs, not clear the repository
+            // cache first and force the full-screen loading view back for the whole round trip.
+            refreshVotingDataInternal(resetVisibleConfigError = true, softRefresh = true)
         }
     }
 
@@ -381,7 +385,11 @@ class VoteCoinholderPollingVM(
                 }
 
                 try {
-                    refreshVotingDataInternal(resetVisibleConfigError = false)
+                    // softRefresh = true (MOB-1808): this timer fires every 5s while any round is
+                    // ACTIVE/TALLYING (votingDataAutoRefreshIntervalMs()) — without softRefresh this
+                    // was a hard refresh (votingApiRepository.clear()) on every tick, wiping the
+                    // cache and forcing the full-screen shimmer back roughly every 10s in practice.
+                    refreshVotingDataInternal(resetVisibleConfigError = false, softRefresh = true)
                 } catch (exception: CancellationException) {
                     throw exception
                 } catch (throwable: Throwable) {

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingVM.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingVM.kt
@@ -121,7 +121,6 @@ class VoteCoinholderPollingVM(
                 }
         }
         observeVotingChainConfigChanges()
-        startVotingDataAutoRefresh()
         startForegroundShareTracking()
     }
 
@@ -376,29 +375,6 @@ class VoteCoinholderPollingVM(
         }
     }
 
-    private fun startVotingDataAutoRefresh() {
-        viewModelScope.launch {
-            while (true) {
-                delay(votingDataAutoRefreshIntervalMs())
-                if (roundsLce.state.value.loading) {
-                    continue
-                }
-
-                try {
-                    // softRefresh = true (MOB-1808): this timer fires every 5s while any round is
-                    // ACTIVE/TALLYING (votingDataAutoRefreshIntervalMs()) — without softRefresh this
-                    // was a hard refresh (votingApiRepository.clear()) on every tick, wiping the
-                    // cache and forcing the full-screen shimmer back roughly every 10s in practice.
-                    refreshVotingDataInternal(resetVisibleConfigError = false, softRefresh = true)
-                } catch (exception: CancellationException) {
-                    throw exception
-                } catch (throwable: Throwable) {
-                    Log.w(TAG, "Round list auto refresh failed", throwable)
-                }
-            }
-        }
-    }
-
     /**
      * Foreground driver that mirrors iOS `pollShareStatus` (`VotingStore+Navigation.swift:267-419`).
      *
@@ -602,18 +578,6 @@ class VoteCoinholderPollingVM(
         votingConfigRepository.clear()
         votingSessionStore.clear()
         votingApiRepository.clear()
-    }
-
-    private fun votingDataAutoRefreshIntervalMs(): Long {
-        val rounds = votingApiRepository.snapshot.value.rounds
-        val hasRoundChangingStatus =
-            rounds.isEmpty() ||
-                rounds.any { round -> round.status == SessionStatus.ACTIVE || round.status == SessionStatus.TALLYING }
-        return if (hasRoundChangingStatus) {
-            ROUND_STATUS_AUTO_REFRESH_INTERVAL_MS
-        } else {
-            ROUND_LIST_AUTO_REFRESH_INTERVAL_MS
-        }
     }
 
     private fun refreshRecoveryVoteCounts(
@@ -840,8 +804,6 @@ class VoteCoinholderPollingVM(
 
     private companion object {
         const val TAG = "VoteCoinholderPolling"
-        const val ROUND_STATUS_AUTO_REFRESH_INTERVAL_MS = 5_000L
-        const val ROUND_LIST_AUTO_REFRESH_INTERVAL_MS = 30_000L
 
         // Minimum sleep between successive `TrackVotingSharesUseCase` invocations for a round.
         // Matches `MIN_DELAY_MILLIS` inside the use case itself; duplicated here as a defensive

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingVM.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingVM.kt
@@ -530,11 +530,12 @@ class VoteCoinholderPollingVM(
             // Mirror iOS `prepareForServiceConfigRefresh` (VotingStore+Session.swift:644-647):
             // every flow entry / user-driven refresh drops the cached resolved config so
             // downstream callers (authenticateVotingSession, configuredVoteServerUrls,
-            // delegateShares) cannot serve a stale config across flow openings. Auto-refresh
-            // polls (resetVisibleConfigError = false here) deliberately leave the cache intact —
-            // fetchServiceConfig() no longer force-refreshes on every call (MOB-1808: it now
-            // reuses a source-matching cache entry up to CONFIG_CACHE_TTL_MS old), so the
-            // periodic tick simply rides that TTL instead of forcing a fresh config every 5s.
+            // delegateShares) cannot serve a stale config across flow openings. All three
+            // remaining callers (onScreenEntered, refreshVotingData, refreshVotingDataForConfigChange)
+            // pass resetVisibleConfigError = true, so this always runs now — MOB-1808 removed the
+            // periodic auto-refresh tick that used to call this with resetVisibleConfigError =
+            // false to deliberately skip invalidation and ride fetchServiceConfig()'s
+            // CONFIG_CACHE_TTL_MS cache instead; the screen no longer has a background caller.
             votingApiProvider.invalidateConfigCache()
         }
 

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingVM.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingVM.kt
@@ -150,6 +150,7 @@ class VoteCoinholderPollingVM(
                 onBack = ::onBack,
                 onRefresh = ::refreshVotingData,
                 onConfigSettings = ::onConfigSettings,
+                isInitialLoading = true,
             )
 
     val state =
@@ -163,10 +164,23 @@ class VoteCoinholderPollingVM(
             val apiSnapshot = apiSnapshotWithConfig.apiSnapshot
             val rounds =
                 when {
-                    !apiSnapshotWithConfig.isSelectedConfigLoaded -> null
+                    // Cache-and-fresh: show the repository's last-fetched rounds immediately,
+                    // even before *this* VM instance (recreated on every screen re-entry) has
+                    // completed its own load — `isSelectedConfigLoaded` is VM-local state that
+                    // resets to false on every fresh instance, but `apiSnapshot.rounds` is a
+                    // repository-scoped cache that `onScreenEntered()`'s soft refresh
+                    // deliberately preserves (see softRefresh's "avoid card flicker" comment in
+                    // refreshVotingDataInternal). A genuine config-source switch or explicit
+                    // refresh already clears the repository first (clearLoadedVotingStateForServiceConfigRefresh),
+                    // so trusting non-empty `apiSnapshot.rounds` here never shows stale-source data.
                     apiSnapshot.rounds.isNotEmpty() -> apiSnapshot.rounds
+
+                    !apiSnapshotWithConfig.isSelectedConfigLoaded -> null
+
                     roundsLceState.loading -> null
+
                     roundsLceState.content is LceContent.Success -> emptyList()
+
                     else -> null
                 }
 

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingView.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/coinholderpolling/VoteCoinholderPollingView.kt
@@ -16,9 +16,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -53,8 +57,12 @@ import co.electriccoin.zcash.ui.screen.voting.VoteTrustIndicator
 import co.electriccoin.zcash.ui.screen.voting.component.VoteAppBar
 import co.electriccoin.zcash.ui.screen.voting.component.VoteTrustIndicatorView
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun VoteCoinholderPollingView(state: VoteCoinholderPollingState) {
+fun VoteCoinholderPollingView(
+    state: VoteCoinholderPollingState,
+    isRefreshing: Boolean = false,
+) {
     ZashiConfirmationBottomSheet(state = state.configErrorSheet)
     ZashiConfirmationBottomSheet(state = state.unverifiedPollWarningSheet)
     ZashiConfirmationBottomSheet(state = state.noRoundsSheet)
@@ -95,30 +103,55 @@ fun VoteCoinholderPollingView(state: VoteCoinholderPollingState) {
                         showDivider = false,
                     )
                 } else {
-                    LazyColumn(
+                    // Pull-to-refresh indicator is placed below the (internal) top bar above,
+                    // not around the whole scaffold — otherwise it renders over the toolbar title
+                    // instead of over the round list it actually refreshes. The content Box itself
+                    // still starts at y=0 (frosted-header effect: the list scrolls under the
+                    // transparent toolbar), so the default top-aligned indicator needs an explicit
+                    // offset by the same `padding.calculateTopPadding()` the list content uses,
+                    // or it renders behind/under the toolbar instead of below it.
+                    val pullToRefreshState = rememberPullToRefreshState()
+                    PullToRefreshBox(
+                        isRefreshing = isRefreshing,
+                        onRefresh = state.onRefresh,
+                        state = pullToRefreshState,
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding =
-                            PaddingValues(
-                                start = ZashiDimensions.Spacing.spacing3xl,
-                                top = padding.calculateTopPadding() + ZashiDimensions.Spacing.spacingLg,
-                                end = ZashiDimensions.Spacing.spacing3xl,
-                                bottom = padding.calculateBottomPadding() + ZashiDimensions.Spacing.spacing3xl
-                            ),
-                        verticalArrangement = Arrangement.spacedBy(ZashiDimensions.Spacing.spacing4xl)
+                        indicator = {
+                            PullToRefreshDefaults.Indicator(
+                                state = pullToRefreshState,
+                                isRefreshing = isRefreshing,
+                                modifier =
+                                    Modifier
+                                        .align(Alignment.TopCenter)
+                                        .padding(top = padding.calculateTopPadding()),
+                            )
+                        },
                     ) {
-                        items(
-                            activeRounds,
-                            key = { it.roundId },
-                            contentType = { "pollcard" }
-                        ) { round ->
-                            PollCard(round)
-                        }
-                        items(
-                            pastRounds,
-                            key = { it.roundId },
-                            contentType = { "pollcard" }
-                        ) { round ->
-                            PollCard(round)
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            contentPadding =
+                                PaddingValues(
+                                    start = ZashiDimensions.Spacing.spacing3xl,
+                                    top = padding.calculateTopPadding() + ZashiDimensions.Spacing.spacingLg,
+                                    end = ZashiDimensions.Spacing.spacing3xl,
+                                    bottom = padding.calculateBottomPadding() + ZashiDimensions.Spacing.spacing3xl
+                                ),
+                            verticalArrangement = Arrangement.spacedBy(ZashiDimensions.Spacing.spacing4xl)
+                        ) {
+                            items(
+                                activeRounds,
+                                key = { it.roundId },
+                                contentType = { "pollcard" }
+                            ) { round ->
+                                PollCard(round)
+                            }
+                            items(
+                                pastRounds,
+                                key = { it.roundId },
+                                contentType = { "pollcard" }
+                            ) { round ->
+                                PollCard(round)
+                            }
                         }
                     }
                 }

--- a/feature-voting/src/main/java/co/electriccoin/zcash/voting/di/FeatureVotingModule.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/voting/di/FeatureVotingModule.kt
@@ -29,6 +29,7 @@ import co.electriccoin.zcash.ui.common.usecase.ParseVotingKeystonePCZTUseCase
 import co.electriccoin.zcash.ui.common.usecase.PrepareVotingRoundUseCase
 import co.electriccoin.zcash.ui.common.usecase.RefreshActiveVotingSessionUseCase
 import co.electriccoin.zcash.ui.common.usecase.RefreshVotingRoundsUseCase
+import co.electriccoin.zcash.ui.common.usecase.RefreshVotingServiceConfigUseCase
 import co.electriccoin.zcash.ui.common.usecase.ResolveVotingRoundSessionUseCase
 import co.electriccoin.zcash.ui.common.usecase.SkipRemainingKeystoneBundlesUseCase
 import co.electriccoin.zcash.ui.common.usecase.SubmitVotesUseCase
@@ -103,6 +104,7 @@ val featureVotingModule =
 
         // Use cases
         factoryOf(::RefreshActiveVotingSessionUseCase)
+        factoryOf(::RefreshVotingServiceConfigUseCase)
         // Explicit factory: the defaulted logEndorsementFailure lambda must use its Kotlin
         // default — factoryOf resolves ALL constructor params via Koin and dies on the Function1
         // (mirrors CheckMigrationRecoveryUseCase's registration in featureMigrationModule).

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/KtorVotingApiProviderTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/KtorVotingApiProviderTest.kt
@@ -575,12 +575,40 @@ class KtorVotingApiProviderTest {
             provider.invalidateConfigCache()
             provider.fetchServiceConfig()
 
-            // Regression pin for the fallthrough bug an earlier review caught: getResolvedConfigWithTtl()'s
-            // expiry fallthrough used to call into getResolvedConfig(forceRefresh = false), whose own
-            // cache check had no age awareness at all, so an invalidated-but-source-matching entry could
-            // still be silently re-served forever. resolveConfigCached() now folds both the TTL and
-            // non-TTL reads into one mutex-guarded check, so invalidation always forces a real refetch
-            // here too, not just on the fetchAllRounds() path already covered above.
+            // NOTE (Milan's #2483 round-2 review): this pins invalidation-forces-refetch on the
+            // TTL path specifically (mirrors invalidateConfigCacheForcesRefetch above, which only
+            // covers the non-TTL fetchAllRounds() path) - it does NOT pin the TTL-expiry
+            // fallthrough itself. invalidateConfigCache() nulls cachedResolvedConfigFetchedAtMs
+            // outright, which exercises resolveConfigCached()'s cache-MISS branch (fetchedAtMs ==
+            // null); the old buggy code (getResolvedConfigWithTtl() falling through to
+            // getResolvedConfig(forceRefresh = false) with no age check at all) would also have
+            // passed this test, since a null fetchedAtMs was never the bug - a genuinely EXPIRED
+            // but still-present entry was. See
+            // fetchServiceConfigRefetchesAfterTtlExpiry below for the real expiry pin.
+            assertEquals(2, requestLog.count { path -> path == "/static-voting-config.json" })
+            assertEquals(2, requestLog.count { path -> path == "/dynamic-voting-config.json" })
+        }
+
+    @Test
+    fun fetchServiceConfigRefetchesAfterTtlExpiry() =
+        runBlocking {
+            val requestLog = mutableListOf<String>()
+            val provider =
+                multiEndpointProvider(
+                    requestLog = requestLog,
+                    configCacheTtlMillis = SHORT_CONFIG_CACHE_TTL_MILLIS
+                )
+
+            provider.fetchServiceConfig()
+            delay(SHORT_CONFIG_CACHE_TTL_MILLIS * 2)
+            provider.fetchServiceConfig()
+
+            // The real regression pin for the fallthrough bug an earlier review caught: unlike
+            // invalidateConfigCacheForcesRefetchOnTheTtlPath above (cache-miss branch), this
+            // entry is genuinely still PRESENT and source-matching when the TTL check runs - only
+            // its age has crossed configCacheTtlMillis. getResolvedConfigWithTtl()'s old
+            // fallthrough into getResolvedConfig(forceRefresh = false) had no age awareness at
+            // all, so this exact scenario used to silently re-serve the stale entry forever.
             assertEquals(2, requestLog.count { path -> path == "/static-voting-config.json" })
             assertEquals(2, requestLog.count { path -> path == "/dynamic-voting-config.json" })
         }
@@ -959,7 +987,8 @@ class KtorVotingApiProviderTest {
 
     private fun multiEndpointProvider(
         requestLog: MutableList<String> = mutableListOf(),
-        timeoutCapabilities: MutableList<Pair<String, Long?>> = mutableListOf()
+        timeoutCapabilities: MutableList<Pair<String, Long?>> = mutableListOf(),
+        configCacheTtlMillis: Long? = null
     ): KtorVotingApiProvider =
         KtorVotingApiProvider(
             httpClientProvider =
@@ -1013,7 +1042,8 @@ class KtorVotingApiProviderTest {
                 },
             configurationRepository = TestConfigurationRepository(),
             votingChainConfigRepository = TestVotingChainConfigRepository(),
-            votingCryptoClient = unusedVotingCryptoClient()
+            votingCryptoClient = unusedVotingCryptoClient(),
+            configCacheTtlMillis = configCacheTtlMillis ?: DEFAULT_TEST_CONFIG_CACHE_TTL_MILLIS
         )
 
     private class SwitchableVotingChainConfigRepository(
@@ -1229,6 +1259,12 @@ class KtorVotingApiProviderTest {
         const val ROUNDS_TEST_PATH = "/shielded-vote/v1/rounds"
         const val TEST_TIMEOUT_MILLIS = 100L
         const val CANCELLATION_DELAY_MILLIS = 50L
+
+        // KtorVotingApiProvider's own default (CONFIG_CACHE_TTL_MS, VotingApiProvider.kt) is
+        // file-private there too, same reasoning as SEMAPHORE_CAP below — this file's real
+        // production-equivalent default for tests that don't care about TTL expiry timing.
+        const val DEFAULT_TEST_CONFIG_CACHE_TTL_MILLIS = 600_000L
+        const val SHORT_CONFIG_CACHE_TTL_MILLIS = 20L
         const val CLIENT_RETRY_MAX_RETRIES = 4
 
         // MAX_CONCURRENT_SHARE_DELEGATIONS in VotingApiProvider.kt is 16 and file-private (a

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/KtorVotingApiProviderTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/KtorVotingApiProviderTest.kt
@@ -5,7 +5,9 @@ import co.electriccoin.zcash.ui.common.model.voting.ChainCommitmentTreeLatestRes
 import co.electriccoin.zcash.ui.common.model.voting.ChainCommitmentTreeLeavesResponse
 import co.electriccoin.zcash.ui.common.model.voting.CommitmentTreeLatest
 import co.electriccoin.zcash.ui.common.model.voting.CommitmentTreeLeafPage
+import co.electriccoin.zcash.ui.common.model.voting.EncryptedShare
 import co.electriccoin.zcash.ui.common.model.voting.PinnedConfigSource
+import co.electriccoin.zcash.ui.common.model.voting.SharePayload
 import co.electriccoin.zcash.ui.common.model.voting.VotingConfigException
 import co.electriccoin.zcash.ui.common.repository.ConfigurationRepository
 import co.electriccoin.zcash.ui.common.repository.VotingChainConfigRepository
@@ -31,6 +33,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import java.lang.reflect.Proxy
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -544,6 +547,268 @@ class KtorVotingApiProviderTest {
 
     // endregion
 
+    // region TTL cache for fetchServiceConfig (MOB-1808)
+
+    @Test
+    fun fetchServiceConfigReusesCacheWithinTtlWindow() =
+        runBlocking {
+            val requestLog = mutableListOf<String>()
+            val provider = multiEndpointProvider(requestLog = requestLog)
+
+            provider.fetchServiceConfig()
+            provider.fetchServiceConfig()
+
+            // fetchServiceConfig() goes through getResolvedConfigWithTtl(), a DIFFERENT cache path
+            // than fetchAllRounds()'s getResolvedConfig() (see resolvedConfigIsMemoizedAcrossConsecutiveCalls
+            // above) - this pins the TTL-gated path specifically, not just memoization in general.
+            assertEquals(1, requestLog.count { path -> path == "/static-voting-config.json" })
+            assertEquals(1, requestLog.count { path -> path == "/dynamic-voting-config.json" })
+        }
+
+    @Test
+    fun invalidateConfigCacheForcesRefetchOnTheTtlPath() =
+        runBlocking {
+            val requestLog = mutableListOf<String>()
+            val provider = multiEndpointProvider(requestLog = requestLog)
+
+            provider.fetchServiceConfig()
+            provider.invalidateConfigCache()
+            provider.fetchServiceConfig()
+
+            // Regression pin for the fallthrough bug an earlier review caught: getResolvedConfigWithTtl()'s
+            // expiry fallthrough used to call into getResolvedConfig(forceRefresh = false), whose own
+            // cache check had no age awareness at all, so an invalidated-but-source-matching entry could
+            // still be silently re-served forever. resolveConfigCached() now folds both the TTL and
+            // non-TTL reads into one mutex-guarded check, so invalidation always forces a real refetch
+            // here too, not just on the fetchAllRounds() path already covered above.
+            assertEquals(2, requestLog.count { path -> path == "/static-voting-config.json" })
+            assertEquals(2, requestLog.count { path -> path == "/dynamic-voting-config.json" })
+        }
+
+    @Test
+    fun concurrentColdCacheFetchServiceConfigCallsCoalesceOntoOneFetch() =
+        runBlocking {
+            val requestLog = mutableListOf<String>()
+            val provider =
+                KtorVotingApiProvider(
+                    httpClientProvider =
+                        object : HttpClientProvider {
+                            override suspend fun supportsKtorTimeouts(): Boolean = true
+
+                            override suspend fun createTor(): HttpClient = create()
+
+                            override suspend fun create(): HttpClient =
+                                HttpClient(
+                                    MockEngine { request ->
+                                        val path = request.url.encodedPath
+                                        requestLog += path
+                                        when (path) {
+                                            "/static-voting-config.json" -> {
+                                                // Held open deliberately so a second concurrent caller's
+                                                // configMutex.withLock has a real window to contend on
+                                                // while the first is still resolving, not just win a
+                                                // same-tick race.
+                                                delay(CANCELLATION_DELAY_MILLIS)
+                                                respond(
+                                                    content = staticConfigJson(dynamicConfigUrl = DYNAMIC_CONFIG_URL),
+                                                    status = HttpStatusCode.OK,
+                                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                                )
+                                            }
+
+                                            "/dynamic-voting-config.json" -> {
+                                                respond(
+                                                    content = validDynamicServiceConfigJson(),
+                                                    status = HttpStatusCode.OK,
+                                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                                )
+                                            }
+
+                                            else -> {
+                                                respond(content = "not found", status = HttpStatusCode.NotFound)
+                                            }
+                                        }
+                                    }
+                                ) {
+                                    expectSuccess = true
+                                    install(ContentNegotiation) { json() }
+                                }
+                        },
+                    configurationRepository = TestConfigurationRepository(),
+                    votingChainConfigRepository = TestVotingChainConfigRepository(),
+                    votingCryptoClient = unusedVotingCryptoClient()
+                )
+
+            // Regression pin for the race an earlier review caught alongside the TTL fallthrough bug:
+            // two callers racing a cold/expired cache used to each independently decide "expired" and
+            // both fire a real fetch. resolveConfigCached()'s single configMutex.withLock section now
+            // makes the second, slightly-later caller wait for and reuse the first's in-flight fetch.
+            val first = async { provider.fetchServiceConfig() }
+            val second = async { provider.fetchServiceConfig() }
+            first.await()
+            second.await()
+
+            assertEquals(1, requestLog.count { path -> path == "/static-voting-config.json" })
+            assertEquals(1, requestLog.count { path -> path == "/dynamic-voting-config.json" })
+        }
+
+    // endregion
+
+    // region delegateShares concurrency cap and per-share timeout handling (MOB-1808)
+
+    @Test
+    fun postShareTimeoutIsTreatedAsAFailureNotACancellation() =
+        runBlocking {
+            val share = makeDelegateSharePayload()
+            val provider =
+                KtorVotingApiProvider(
+                    httpClientProvider =
+                        object : HttpClientProvider {
+                            override suspend fun supportsKtorTimeouts(): Boolean = false
+
+                            override suspend fun createTor(): HttpClient = create()
+
+                            override suspend fun create(): HttpClient =
+                                HttpClient(
+                                    MockEngine { request ->
+                                        when (request.url.encodedPath) {
+                                            "/static-voting-config.json" -> {
+                                                respond(
+                                                    content = staticConfigJson(dynamicConfigUrl = DYNAMIC_CONFIG_URL),
+                                                    status = HttpStatusCode.OK,
+                                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                                )
+                                            }
+
+                                            "/dynamic-voting-config.json" -> {
+                                                respond(
+                                                    content = validDynamicServiceConfigJson(),
+                                                    status = HttpStatusCode.OK,
+                                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                                )
+                                            }
+
+                                            // Never responds - with supportsKtorTimeouts = false, Ktor's
+                                            // own HttpTimeout plugin is a no-op under Tor, so only
+                                            // postShare()'s app-side withTorRequestTimeoutFallback bounds
+                                            // this attempt (MOB-1808).
+                                            "/shielded-vote/v1/shares" -> {
+                                                awaitCancellation()
+                                            }
+
+                                            else -> {
+                                                respond(content = "not found", status = HttpStatusCode.NotFound)
+                                            }
+                                        }
+                                    }
+                                ) {
+                                    expectSuccess = true
+                                    install(ContentNegotiation) { json() }
+                                }
+                        },
+                    configurationRepository = TestConfigurationRepository(),
+                    votingChainConfigRepository = TestVotingChainConfigRepository(),
+                    votingCryptoClient = unusedVotingCryptoClient(),
+                    shareRequestTimeoutMillis = TEST_TIMEOUT_MILLIS
+                )
+
+            // Regression pin for the postShare() catch-clause restructuring (MOB-1808 review): the
+            // TimeoutCancellationException that withTorRequestTimeoutFallback's own deadline throws
+            // must be treated as an ordinary failed attempt, not misidentified as delegateShares'
+            // sibling-cancellation signal (see postShare's own TRAP doc). If it were, this would
+            // surface as a raw CancellationException instead of the normal "no server accepted"
+            // failure below.
+            val exception =
+                assertFailsWith<IllegalStateException> {
+                    provider.delegateShares(listOf(share))
+                }
+            assertFalse(exception is CancellationException)
+            assertEquals("No voting server accepted share ${share.encShare.shareIndex}", exception.message)
+        }
+
+    @Test
+    fun delegateSharesBoundsConcurrentShareDelegationToTheSemaphoreCap() =
+        runBlocking {
+            val inFlight = AtomicInteger(0)
+            val maxObserved = AtomicInteger(0)
+            val provider =
+                KtorVotingApiProvider(
+                    httpClientProvider =
+                        object : HttpClientProvider {
+                            override suspend fun supportsKtorTimeouts(): Boolean = true
+
+                            override suspend fun createTor(): HttpClient = create()
+
+                            override suspend fun create(): HttpClient =
+                                HttpClient(
+                                    MockEngine { request ->
+                                        when (request.url.encodedPath) {
+                                            "/static-voting-config.json" -> {
+                                                respond(
+                                                    content = staticConfigJson(dynamicConfigUrl = DYNAMIC_CONFIG_URL),
+                                                    status = HttpStatusCode.OK,
+                                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                                )
+                                            }
+
+                                            "/dynamic-voting-config.json" -> {
+                                                respond(
+                                                    content = validDynamicServiceConfigJson(),
+                                                    status = HttpStatusCode.OK,
+                                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                                )
+                                            }
+
+                                            "/shielded-vote/v1/shares" -> {
+                                                val current = inFlight.incrementAndGet()
+                                                maxObserved.updateAndGet { max -> maxOf(max, current) }
+                                                delay(SEMAPHORE_TEST_HOLD_MILLIS)
+                                                inFlight.decrementAndGet()
+                                                respond(
+                                                    content = "{}",
+                                                    status = HttpStatusCode.OK,
+                                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                                )
+                                            }
+
+                                            else -> {
+                                                respond(content = "not found", status = HttpStatusCode.NotFound)
+                                            }
+                                        }
+                                    }
+                                ) {
+                                    expectSuccess = true
+                                    install(ContentNegotiation) { json() }
+                                }
+                        },
+                    configurationRepository = TestConfigurationRepository(),
+                    votingChainConfigRepository = TestVotingChainConfigRepository(),
+                    votingCryptoClient = unusedVotingCryptoClient()
+                )
+            val shares = (0 until SHARE_COUNT_ABOVE_SEMAPHORE_CAP).map { index -> makeDelegateSharePayload(index) }
+
+            val results = provider.delegateShares(shares)
+
+            assertEquals(SHARE_COUNT_ABOVE_SEMAPHORE_CAP, results.size)
+            // MAX_CONCURRENT_SHARE_DELEGATIONS in VotingApiProvider.kt is 16 and file-private, so its
+            // value is duplicated here as SEMAPHORE_CAP - regression pin for the fan-out concurrency
+            // cap (MOB-1808): with more shares than the cap all held open concurrently by the delay
+            // above, the semaphore must let exactly SEMAPHORE_CAP requests in flight at once, never more.
+            assertEquals(SEMAPHORE_CAP, maxObserved.get())
+        }
+
+    // endregion
+
+    private fun makeDelegateSharePayload(shareIndex: Int = 0): SharePayload =
+        SharePayload(
+            sharesHash = ByteArray(32) { 1 },
+            proposalId = 3,
+            voteDecision = 1,
+            encShare = EncryptedShare(c1 = ByteArray(32) { 2 }, c2 = ByteArray(32) { 3 }, shareIndex = shareIndex),
+            treePosition = 42L,
+            voteRoundId = "01".repeat(32)
+        )
+
     // region cancellation propagation with the app-side timeout fallback in place (MOB-1809)
 
     @Test
@@ -965,6 +1230,13 @@ class KtorVotingApiProviderTest {
         const val TEST_TIMEOUT_MILLIS = 100L
         const val CANCELLATION_DELAY_MILLIS = 50L
         const val CLIENT_RETRY_MAX_RETRIES = 4
+
+        // MAX_CONCURRENT_SHARE_DELEGATIONS in VotingApiProvider.kt is 16 and file-private (a
+        // top-level `private const val` there is file-scoped, not visible here), so its value is
+        // duplicated as SEMAPHORE_CAP for delegateSharesBoundsConcurrentShareDelegationToTheSemaphoreCap.
+        const val SEMAPHORE_CAP = 16
+        const val SHARE_COUNT_ABOVE_SEMAPHORE_CAP = 20
+        const val SEMAPHORE_TEST_HOLD_MILLIS = 40L
         val TEST_CHAIN_CONFIG_STATE =
             VotingChainConfigState(
                 selected = VotingChainConfigSelection.Custom("test-chain"),

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/VotingConfigWalkTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/VotingConfigWalkTest.kt
@@ -411,7 +411,13 @@ class VotingConfigWalkTest {
                     requestedUrls = requestedUrls
                 )
 
+            // MOB-1808: fetchServiceConfig() now reuses a source-matching cache entry within
+            // CONFIG_CACHE_TTL_MS instead of walking again on every call, so a bare second call
+            // here would short-circuit to the cache and never issue a second request at all.
+            // invalidateConfigCache() forces the second call to actually re-walk, which is what
+            // this test needs to observe a second, freshly-tokenened request.
             provider.fetchServiceConfig()
+            provider.invalidateConfigCache()
             provider.fetchServiceConfig()
 
             assertEquals(2, requestedUrls.size)


### PR DESCRIPTION
## Summary

Investigates and fixes why the Coinholder Polling (CHP) voting screen was slow and firing excessive/redundant backend requests — [MOB-1808](https://linear.app/zodl/issue/MOB-1808/voting-speed-investigation).

Root causes found and fixed, all confirmed live on-device via logcat request tracing (not speculation):

- **Duplicate `/rounds` fetch every auto-refresh tick.** `RefreshActiveVotingSessionUseCase` fetches config *and* the full round list, but `VoteCoinholderPollingVM.refreshVotingDataInternal()` was calling it purely to surface a config exception, right after `RefreshVotingRoundsUseCase` had already fetched the same round list. Extracted a new minimal `RefreshVotingServiceConfigUseCase` (config-fetch-and-store only) for the round-list VM to use instead. `RefreshActiveVotingSessionUseCase` itself is untouched — `VotingHomeHooksImpl`'s pending-Keystone-request recovery check genuinely needs its full round-list-populating behavior. Verified live: `/rounds` went from 2x/cycle to 1x/cycle.
- **Unnecessary periodic auto-refresh on the round list.** The screen polled every 5-30s in the background even when idle. Investigation showed `VoteTallyingVM` already runs its own dedicated, purpose-scoped polling for the one genuinely time-sensitive live transition (ACTIVE -> TALLYING/COMPLETED) a user might be waiting on — the round list's own polling was redundant for that case, and "return to the screen after voting" is already handled correctly by the existing `onScreenEntered()`/`ON_RESUME` reactive path. Removed the periodic auto-refresh entirely; the screen is now purely reactive to entry/return plus manual pull-to-refresh. Verified live: a 24s idle capture on the screen showed exactly 1 `/rounds` + 1 `/endorsed-rounds` request (from entry), then zero further backend activity.
- **TTL cache fallthrough bug** (found by an adversarial Fable-model review): `getResolvedConfigWithTtl()`'s expiry fallthrough called into a cache check with no actual age awareness, so an expired-but-source-matching config entry was silently re-served forever. Consolidated both config-cache paths into a single mutex-guarded `resolveConfigCached()` to close both the fallthrough and a latent race between two callers independently deciding "expired."
- **Share-delegation concurrency/cancellation issues** (also found by the same review): unbounded per-share fan-out sharing one Tor client (serialized, not actually concurrent) with a cancellation-swallowing bug that could fire extra requests after a batch already failed and mis-attribute failures to healthy servers. Fixed with per-share isolated Tor clients, a concurrency cap, correct `CancellationException` rethrow, and an app-side timeout fallback for the Ktor-no-op-under-Tor case. Same shared-client bug fixed in the PIR snapshot resolver's probe fan-out.
- **Service config cache TTL** bumped from 60s to 10min once the fallthrough bug above was fixed for real.

Two independent Fable-model adversarial reviews were run against this branch (once mid-branch, once against the final commits) — both came back with no blocking issues; all findings from both were fixed in follow-up commits already on the branch.

## Test plan

- [x] `:zodl-android:ktlint` and `:zodl-android:detektAll` both pass clean (3 genuinely new detekt findings from this branch's own commits were fixed for real, not baselined: `InstanceOfCheckForException`, `MaxLineLength`, `ForbiddenImport`, plus a `SwallowedException` introduced while fixing the first).
- [x] `feature-voting` unit test suite (187 tests) passes clean on committed code.
- [x] Live-verified on-device (mainnet DIM + testnet DIT builds) throughout: `zodl_an_apk_rust_check` passes (native lib/JNI/16KB-alignment), zero crashes, full vote-submission flow tested successfully multiple times.
- [x] Live logcat request tracing confirmed both the duplicate-`/rounds`-fetch fix (2x -> 1x per cycle) and the auto-refresh removal (zero background requests while idling on the screen).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>