### PR TITLE
MOB-1811: Bound vote-server failover attempts under Tor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed:
+
+- Coinholder Polling's poll list and proposal loading no longer hang indefinitely when a vote server is unreachable over Tor; a slow or dropped connection now fails over to the next server within a bounded time.
+
 ## [3.10.1 (2512)] - 2026-08-25
 
 ### Added:

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -154,6 +154,18 @@ class KtorVotingApiProvider(
      * timeout mechanisms share.
      */
     private val configRequestTimeoutMillis: Long = StaticVotingConfig.CONFIG_REQUEST_TIMEOUT_MS,
+    /**
+     * Per-attempt timeout for every [executeWithVoteServerFailover] call (MOB-1811), overridable
+     * only so tests can inject a short value. One of the ~10 configured vote servers can drop
+     * (not refuse) a Tor connection instead of failing it outright; under Tor
+     * ([HttpClientProvider]'s isolated client has `installTimeouts = false`) Ktor's own
+     * [io.ktor.client.plugins.HttpTimeout] is a no-op, so without this an attempt against that
+     * server can hang indefinitely instead of the failover loop moving on to the next one -
+     * exactly the "waiting for a health check before displaying the proposal" symptom reported
+     * against the round list and the pre-vote screen's [co.electriccoin.zcash.ui.common.usecase
+     * .PrepareVotingRoundUseCase] gate.
+     */
+    private val voteServerFailoverTimeoutMillis: Long = VOTE_SERVER_FAILOVER_TIMEOUT_MILLIS,
 ) : VotingApiProvider {
     private var cachedResolvedConfig: ResolvedVotingConfig? = null
     private val configMutex = Mutex()
@@ -659,12 +671,21 @@ class KtorVotingApiProvider(
         block: suspend HttpClient.(String) -> T
     ): T {
         val serverUrls = configuredVoteServerUrls()
-        return execute {
+        return executeWithKtorTimeoutSupport { supportsKtorTimeouts ->
             withVoteServerFailover(
                 path = path,
                 serverUrls = serverUrls,
                 shouldTryNext = shouldTryNext,
-                operation = { serverUrl -> block(serverUrl) }
+                operation = { serverUrl ->
+                    // MOB-1811: bounds each per-server attempt so one dropping (not refusing)
+                    // Tor connection can't stall the whole failover walk - see the constructor
+                    // param doc above and withConfigRequestTimeoutFallback's own TRAP doc for why
+                    // withVoteServerFailover's catch clauses must (and do) special-case the
+                    // TimeoutCancellationException this throws under Tor.
+                    withConfigRequestTimeoutFallback(supportsKtorTimeouts, voteServerFailoverTimeoutMillis) {
+                        block(serverUrl)
+                    }
+                }
             )
         }
     }
@@ -1012,6 +1033,9 @@ private fun String.withCacheBustIfNeeded(token: String): String {
 private const val HELPER_REQUEST_TIMEOUT_MILLIS = 5_000L
 private const val HELPER_SOCKET_TIMEOUT_MILLIS = 10_000L
 private const val HELPER_CONNECT_TIMEOUT_MILLIS = 5_000L
+
+// MOB-1811: matches CONFIG_REQUEST_TIMEOUT_MS's 15s convention for a bounded network attempt.
+private const val VOTE_SERVER_FAILOVER_TIMEOUT_MILLIS = 15_000L
 private const val TAG = "VotingApiProvider"
 private const val ACTIVE_ROUNDS_PATH = "/shielded-vote/v1/rounds/active"
 private const val ROUNDS_PATH = "/shielded-vote/v1/rounds"

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingApiProvider.kt
@@ -242,6 +242,16 @@ class KtorVotingApiProvider(
         }
     }
 
+    // MOB-1811: these two writes go through the same withVoteServerFailover bound as every read,
+    // so a Tor-slow-but-alive server now gets its payload re-POSTed to the next server after
+    // voteServerFailoverTimeoutMillis instead of hanging indefinitely. Accepted trade-off, not a
+    // new hazard: the body is re-posted byte-identical, so at most one of the two attempts can
+    // land on-chain (the second is a spent-nullifier rejection) — this ambiguity already existed
+    // via 5xx/IOException failover before this fix, the timeout only makes it more likely under a
+    // dropping (not refusing) Tor connection. The #2481 reconcile/VAN-probe recovery machinery
+    // covers exactly this case. Follow-up idea (not implemented here): probe fetchTxConfirmation
+    // for the previous attempt's VAN before re-posting specifically after a timeout, to shrink the
+    // "transaction failed" UX window rather than only rely on the recovery re-run.
     override suspend fun submitDelegation(registration: DelegationRegistration): TxResult =
         executeWithVoteServerFailover(DELEGATE_VOTE_PATH) { baseUrl ->
             postTxResult(

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingServerFailoverException.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/common/provider/VotingServerFailoverException.kt
@@ -3,6 +3,7 @@ package co.electriccoin.zcash.ui.common.provider
 import co.electriccoin.zcash.ui.common.model.voting.VotingConfigException
 import io.ktor.client.plugins.ResponseException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
 
 internal class VotingServerFailoverException(
     val path: String,
@@ -32,10 +33,21 @@ internal suspend fun <T> withVoteServerFailover(
     for (serverUrl in normalizedServerUrls) {
         try {
             return operation(serverUrl)
-        } catch (exception: Exception) {
-            if (exception is CancellationException) {
+        } catch (exception: TimeoutCancellationException) {
+            // MOB-1811: a per-server attempt is now bounded by the caller wrapping [operation]
+            // in withConfigRequestTimeoutFallback (VotingApiProvider.kt) to stop a vote server
+            // that's dropping - not refusing - Tor connections from hanging this whole failover
+            // walk. TimeoutCancellationException EXTENDS CancellationException, so it MUST be
+            // caught here, before the plain CancellationException clause below, or a deliberate
+            // per-attempt timeout would be misread as genuine outer cancellation and abort the
+            // walk instead of falling through to the next server.
+            lastError = exception
+            if (!shouldTryNext(exception)) {
                 throw exception
             }
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (exception: Exception) {
             lastError = exception
             if (!shouldTryNext(exception)) {
                 throw exception
@@ -52,9 +64,17 @@ internal suspend fun <T> withVoteServerFailover(
 
 internal fun shouldTryNextVoteServer(throwable: Throwable): Boolean =
     when (throwable) {
+        // MOB-1811: must precede the plain CancellationException branch below - a
+        // TimeoutCancellationException is this attempt's own bounded deadline firing, not a
+        // reason to give up on the remaining servers.
+        is TimeoutCancellationException -> true
+
         is CancellationException -> false
+
         is VotingConfigException -> false
+
         is ResponseException -> throwable.response.status.value >= HTTP_BAD_REQUEST
+
         else -> true
     }
 

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/KtorVotingApiProviderTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/KtorVotingApiProviderTest.kt
@@ -444,6 +444,73 @@ class KtorVotingApiProviderTest {
 
     // endregion
 
+    // region vote-server failover timeout (MOB-1811)
+
+    @Test
+    fun fetchAllRoundsAppSideTimeoutFallbackFiresWhenVoteServerHangsUnderTor() =
+        runBlocking {
+            val requests = mutableListOf<String>()
+            val provider =
+                KtorVotingApiProvider(
+                    httpClientProvider =
+                        object : HttpClientProvider {
+                            override suspend fun supportsKtorTimeouts(): Boolean = false
+
+                            override suspend fun createTor(): HttpClient = create()
+
+                            override suspend fun create(): HttpClient =
+                                HttpClient(
+                                    MockEngine { request ->
+                                        val path = request.url.encodedPath
+                                        requests += path
+                                        when (path) {
+                                            "/static-voting-config.json" -> {
+                                                respond(
+                                                    content = staticConfigJson(dynamicConfigUrl = DYNAMIC_CONFIG_URL),
+                                                    status = HttpStatusCode.OK,
+                                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                                )
+                                            }
+
+                                            "/dynamic-voting-config.json" -> {
+                                                respond(
+                                                    content = validDynamicServiceConfigJson(),
+                                                    status = HttpStatusCode.OK,
+                                                    headers = headersOf(HttpHeaders.ContentType, "application/json")
+                                                )
+                                            }
+
+                                            // Simulates a vote server dropping (not refusing) the
+                                            // Tor connection - the exact MOB-1811 symptom.
+                                            ROUNDS_TEST_PATH -> {
+                                                awaitCancellation()
+                                            }
+
+                                            else -> {
+                                                respond(content = "not found", status = HttpStatusCode.NotFound)
+                                            }
+                                        }
+                                    }
+                                ) { expectSuccess = true }
+                        },
+                    configurationRepository = TestConfigurationRepository(),
+                    votingChainConfigRepository = TestVotingChainConfigRepository(),
+                    votingCryptoClient = unusedVotingCryptoClient(),
+                    voteServerFailoverTimeoutMillis = TEST_TIMEOUT_MILLIS
+                )
+
+            assertFailsWith<VotingServerFailoverException> {
+                provider.fetchAllRounds()
+            }
+
+            assertEquals(
+                listOf("/static-voting-config.json", "/dynamic-voting-config.json", ROUNDS_TEST_PATH),
+                requests
+            )
+        }
+
+    // endregion
+
     // region memoization (MOB-1809)
 
     @Test

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/VoteServerFailoverTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/provider/VoteServerFailoverTest.kt
@@ -4,7 +4,10 @@ import co.electriccoin.zcash.ui.common.model.voting.StaticVotingConfig
 import co.electriccoin.zcash.ui.common.model.voting.VotingConfigException
 import co.electriccoin.zcash.ui.common.model.voting.toLowerHex
 import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -13,6 +16,54 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class VoteServerFailoverTest {
+    @Test
+    fun timeoutCancellationDuringAttemptFallsThroughToNextServerInsteadOfAborting() =
+        runBlocking {
+            // MOB-1811: a per-server attempt bounded by withConfigRequestTimeoutFallback throws
+            // TimeoutCancellationException (a CancellationException subtype) on expiry. Before
+            // the fix, withVoteServerFailover's catch (exception is CancellationException) branch
+            // misread that as genuine outer cancellation and aborted the whole walk instead of
+            // trying the second server.
+            val triedServers = mutableListOf<String>()
+
+            val result =
+                withVoteServerFailover(
+                    path = "/shielded-vote/v1/rounds",
+                    serverUrls = listOf("https://first.example.com", "https://second.example.com")
+                ) { serverUrl ->
+                    triedServers += serverUrl
+                    if (serverUrl == "https://first.example.com") {
+                        withTimeout(10L) { delay(1_000L) }
+                    }
+                    "rounds"
+                }
+
+            assertEquals("rounds", result)
+            assertEquals(
+                listOf("https://first.example.com", "https://second.example.com"),
+                triedServers
+            )
+        }
+
+    @Test
+    fun genuineCancellationDuringAttemptStillPropagatesInsteadOfTryingNextServer() {
+        val triedServers = mutableListOf<String>()
+
+        assertFailsWith<CancellationException> {
+            runBlocking {
+                withVoteServerFailover(
+                    path = "/shielded-vote/v1/rounds",
+                    serverUrls = listOf("https://first.example.com", "https://second.example.com")
+                ) { serverUrl ->
+                    triedServers += serverUrl
+                    throw CancellationException("outer job cancelled")
+                }
+            }
+        }
+
+        assertEquals(listOf("https://first.example.com"), triedServers)
+    }
+
     @Test
     fun firstVoteServerFailureFallsThroughToSecondServer() =
         runBlocking {


### PR DESCRIPTION
## Summary

Fixes [MOB-1811](https://linear.app/zodl/issue/MOB-1811/android-need-to-defer-health-checks-to-load-the-polls-faster-in-the) (Urgent) — the CHP round list and pre-vote screen could hang for a long, inconsistent time before showing content, reported in Slack as "waiting on a health check before displaying the proposal."

**Root cause:** `withVoteServerFailover()` (`VotingServerFailoverException.kt`) tries each of the ~10 configured vote servers one at a time with **no per-attempt timeout**. Under Tor (`installTimeouts = false`), Ktor's own `HttpTimeout` plugin is a no-op, so a server that *drops* (rather than refuses) the connection can hang one attempt indefinitely before the loop's catch even fires to try the next server. This is the single choke point (`executeWithVoteServerFailover` in `VotingApiProvider.kt`) behind both:
- the CHP round list refresh (`fetchAllRounds()`), and
- the pre-vote screen's `preparationGate` (via `PrepareVotingRoundUseCase` → `fetchServiceConfig()`/`fetchAllRounds()`), which shows only a shimmer until this resolves.

**Fix (scoped to the minimal, low-risk option — no server-health-based skipping or parallel/racing, per explicit decision):**
- Wrap every `executeWithVoteServerFailover()` attempt in the existing `withConfigRequestTimeoutFallback()` app-side timeout helper (already used for the config-fetch legs since MOB-1809), so a dropping server fails fast instead of hanging.
- Fix `withVoteServerFailover()`'s catch ordering: the resulting `TimeoutCancellationException` (which extends `CancellationException`) must be caught **before** the plain `CancellationException` branch, or a deliberate per-attempt timeout gets misread as genuine outer cancellation and aborts the whole failover walk instead of falling through to the next server.
- `shouldTryNextVoteServer()` gets the same special case so its default classification also treats a timeout as retryable, not as a reason to give up.

New constructor param `voteServerFailoverTimeoutMillis` (default 15s, matching the existing config-timeout convention) — overridable only for tests.

## Test plan

- [x] `:zodl-android:ktlint` / `:zodl-android:detektAll` clean.
- [x] New unit tests in `VoteServerFailoverTest.kt`: a `TimeoutCancellationException` from one server attempt now falls through to the next server instead of aborting the walk; a genuine outer `CancellationException` still propagates correctly (regression guard).
- [x] New integration test in `KtorVotingApiProviderTest.kt`: `fetchAllRounds()` against a vote server that hangs (`awaitCancellation()`, simulating a Tor connection being dropped) under `supportsKtorTimeouts = false` now fails fast via `VotingServerFailoverException` instead of hanging.
- [x] Full `feature-voting` unit test suite green (`VoteServerFailoverTest` 12/12, `KtorVotingApiProviderTest` 24/24, no failures module-wide).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>