### PR TITLE
Check that tagged release branches are merged back into their line

### DIFF
--- a/.github/scripts/check-release-merged-back.sh
+++ b/.github/scripts/check-release-merged-back.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Check that every tagged release/ branch has been merged back into its
+# maintenance line, and forward down to main.
+#
+# Usage: check-release-merged-back.sh [pr-base] [pr-ref]
+#
+#   pr-base   branch a pending change targets; that branch is then evaluated
+#             as it would be with the change applied. Omit to check the
+#             branches as they stand.
+#   pr-ref    the pending change; defaults to HEAD (refs/pull/N/merge in CI).
+#
+# A release/ branch counts as released only when a tag points at its tip, so
+# in-flight release branches are skipped. The maintenance line comes from the
+# TAG, not the branch name: in the Swift SDK, release/3.0.0 is tagged 2.8.0-rc.1
+# and belongs to maint/v2.8.x.
+#
+# Branches resolve under refs/remotes/$REMOTE, which defaults to origin -- what
+# CI checks out. Set REMOTE to run this against a local clone whose canonical
+# remote has another name, and run `git fetch` first.
+#
+# Exits 1 when a tagged release is missing from a branch it should be in.
+
+set -euo pipefail
+
+PR_BASE="${1:-}"
+PR_REF="${2:-HEAD}"
+REMOTE="${REMOTE:-origin}"
+
+say() {
+  printf '%s\n' "$*"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then printf '%s\n' "$*" >>"$GITHUB_STEP_SUMMARY"; fi
+}
+
+# Maintenance lines in version order, then main. v:refname sorts v2.10.x after
+# v2.9.x.
+CHAIN=()
+while IFS= read -r ref; do
+  CHAIN+=("$ref")
+done < <(
+  git for-each-ref --sort=v:refname --format='%(refname:lstrip=3)' \
+    "refs/remotes/${REMOTE}/maint/v*"
+)
+CHAIN+=('main')
+
+# Resolve a chain branch, substituting the pending change when it targets it.
+resolve() {
+  if [ -n "$PR_BASE" ] && [ "$1" = "$PR_BASE" ]; then
+    git rev-parse "$PR_REF"
+  else
+    printf '%s/%s\n' "$REMOTE" "$1"
+  fi
+}
+
+say '## Release branches merged back'
+say ''
+
+failed=0
+checked=0
+
+while IFS= read -r rel; do
+  [ -n "$rel" ] || continue
+  ref="${REMOTE}/${rel}"
+
+  tags="$(git tag --points-at "$ref" | tr '\n' ' ')"
+  tags="${tags% }"
+  if [ -z "$tags" ]; then
+    say ":grey_question: \`${rel}\` has no tag at its tip; not a released branch, skipped."
+    continue
+  fi
+
+  # [v]MAJOR.MINOR.PATCH[-anything] -> maint/vMAJOR.MINOR.x. The optional
+  # trailing part covers both a pre-release suffix (2.8.0-rc.1) and the build
+  # number some repos append (3.9.3-2393).
+  tag="${tags%% *}"
+  ver="${tag#v}"
+  major="${ver%%.*}"
+  rest="${ver#*.}"
+  minor="${rest%%.*}"
+  maint="maint/v${major}.${minor}.x"
+
+  # Its own line is the obligation. Anything downstream of it is merge-forward
+  # lag, which the merge-forward jobs already track, so it warns rather than
+  # fails; otherwise the merge-back PR itself would report red for main.
+  # A retired line is simply absent from the chain.
+  own=''
+  downstream=()
+  seen=0
+  for b in "${CHAIN[@]}"; do
+    if [ "$b" = "$maint" ]; then seen=1; own="$b"; continue; fi
+    if [ "$seen" -eq 1 ]; then downstream+=("$b"); fi
+  done
+  if [ "$seen" -eq 0 ]; then
+    own='main'
+    downstream=()
+    say ":grey_question: \`${rel}\` (\`${tag}\`) belongs to \`${maint}\`, which no longer exists; checking main only."
+  fi
+
+  checked=$((checked + 1))
+
+  lagging=()
+  for b in ${downstream[@]+"${downstream[@]}"}; do
+    if ! git merge-base --is-ancestor "$ref" "$(resolve "$b")"; then
+      lagging+=("$b")
+    fi
+  done
+
+  if ! git merge-base --is-ancestor "$ref" "$(resolve "$own")"; then
+    failed=1
+    say ":x: \`${rel}\` (\`${tag}\`) is **not** merged back into \`${own}\`."
+  elif [ "${#lagging[@]}" -ne 0 ]; then
+    list="$(printf '%s, ' "${lagging[@]}")"
+    say ":warning: \`${rel}\` (\`${tag}\`) is in \`${own}\` but has not reached ${list%, } yet."
+  else
+    say ":white_check_mark: \`${rel}\` (\`${tag}\`) is in \`${own}\` and downstream."
+  fi
+done < <(
+  git for-each-ref --sort=v:refname --format='%(refname:lstrip=3)' \
+    "refs/remotes/${REMOTE}/release/*"
+)
+
+say ''
+
+if [ "$checked" -eq 0 ]; then
+  say 'No tagged release branches to check.'
+  exit 0
+fi
+
+if [ "$failed" -eq 0 ]; then
+  say "All ${checked} tagged release branches are merged back into their line."
+  exit 0
+fi
+
+say 'Advisory only. Merge the release branch back into its maintenance line and'
+say 'let it flow forward, rather than cherry-picking, so the tag stays reachable.'
+exit 1

--- a/.github/workflows/release-merged-back.yml
+++ b/.github/workflows/release-merged-back.yml
@@ -1,0 +1,58 @@
+# Checks that every tagged release/ branch has been merged back into its
+# maintenance line, and flowed forward to main. A release that is only
+# cherry-picked back leaves its tag unreachable from any live branch, so the
+# released commit stops being part of the history it shipped from.
+#
+# Advisory only: continue-on-error keeps this from blocking. Read the detail in
+# the run summary.
+#
+# Only missing from its OWN maint line fails; not having reached main yet is a
+# warning, since the merge-forward jobs already track that.
+#
+# Run locally with:
+#   ./.github/scripts/check-release-merged-back.sh
+# or, when the canonical remote in your clone is not named origin:
+#   REMOTE=upstream ./.github/scripts/check-release-merged-back.sh
+
+name: Release Merged Back
+
+on:
+  pull_request:
+    branches:
+      # `maint/**` rather than `maint/v*` so the check also runs on pull
+      # requests into a maintenance branch cut before the maint/vX.Y.x naming
+      # was settled on.
+      - 'maint/**'
+      - main
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release_merged_back:
+    name: release branches merged back
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        timeout-minutes: 5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          # Read-only job, and the tag fetch below works unauthenticated against
+          # this public repository, so the credential is not needed past
+          # checkout and should not be left in .git/config.
+          persist-credentials: false
+      - name: Check release branches
+        timeout-minutes: 5
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # Tags are what mark a release branch as released, so fetch them.
+          git fetch --quiet --tags origin '+refs/heads/*:refs/remotes/origin/*'
+          ./.github/scripts/check-release-merged-back.sh "${BASE_REF}"


### PR DESCRIPTION
Closes #2487

Ports `.github/workflows/release-merged-back.yml` and
`.github/scripts/check-release-merged-back.sh` from `zcash-android-wallet-sdk`.

Runs on pull requests into a maintenance branch or `main` and reports any tagged
`release/` branch missing from the line it belongs to. Advisory —
`continue-on-error`, so it never blocks; the detail goes to the run summary.
Missing from its **own** maintenance line fails the job; not having reached
`main` yet only warns, since that is ordinary merge-forward lag.

A release branch counts as released only when a tag points at its tip, so
in-flight release branches are skipped. The maintenance line is derived from the
**tag**, not the branch name, which is what makes it survive both our
`release/3.9.3` to `release/v3.9.3` naming change and the build number our tags
carry (`3.9.3-2393`).

One change from the android SDK original: a `REMOTE` environment override
(default `origin`, which is what CI checks out) so the script can also be run
against a local clone whose canonical remote has another name.

## What it reports today

All 20 tagged release branches are in their line. The two warnings are real
merge-forward lag:

```
:warning: `release/v3.10.0` (`3.10.0-2475`) is in `maint/v3.10.x` but has not reached main yet.
:warning: `release/v3.10.1` (`3.10.1-2512`) is in `maint/v3.10.x` but has not reached main yet.
```

Retired maintenance lines (`maint/v3.2.x` through `maint/v3.7.x`) report as
absent from the chain and fall back to checking `main` alone, which is the
intended behaviour for a line that no longer exists.

## Test plan

- Ran against this repository's real refs before committing — full output above
  is the tail of it; exit status 0.
- Also run against `zodl-ios` and `zodl-swift-wallet-sdk`, where the same script
  is being added, to confirm the tag-derived maintenance mapping holds across
  three different tag conventions.
- `shellcheck` clean; `zizmor --persona regular` clean (pinned action,
  `persist-credentials: false`, top-level `permissions: {}`).
- The workflow itself is unexercised until a pull request targets `main` or a
  `maint/` branch — this PR is the first such trigger, so its own run is the
  check on the check.

Filed with Claude Code assistance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
