### PR TITLE
[MOB-1723] Preserve spendable balance during automatic server switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 - Coinholder Polling's poll list and proposal loading no longer hang indefinitely when a vote server is unreachable over Tor; a slow or dropped connection now fails over to the next server within a bounded time.
 - Support/error reports for a failed transaction no longer claim a fake `gRPC: false, code: -1` status when the failure actually happened before submission (e.g. a Sapling parameter download failure); such reports now correctly identify the real exception instead.
+- Opening Send immediately after a cold start no longer falls back to a loading screen while automatic server selection reconnects the wallet. The automatic winner waits for the local balance snapshot, which remains visible while the new server connection settles.
 
 ## [3.10.1 (2512)] - 2026-08-25
 

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/common/usecase/MigrationHomeMessageSourceImpl.kt
@@ -136,10 +136,10 @@ class MigrationHomeMessageSourceImpl(
                 // balance — a wallet can hold a raw balance above dustThreshold made up entirely
                 // of notes too small individually to be worth spending. Falls back to the raw
                 // balance (old behavior) if the SDK call fails, same guard shape as dustThreshold.
-                val orchardBalanceZatoshi = orchardBalance?.value ?: 0L
+                val orchardBalanceZatoshi = orchardBalance?.value
                 val migratableOrchardTotal =
                     runCatching { getOrchardMigrationSdk().migratableOrchardTotal() }
-                        .getOrDefault(orchardBalanceZatoshi)
+                        .getOrDefault(orchardBalanceZatoshi ?: 0L)
                 migrationMessageFor(
                     sdkState = sdkState,
                     snapshot = snapshot,
@@ -330,14 +330,20 @@ class MigrationHomeMessageSourceImpl(
  * found" once the notes it referenced had moved on. Not applied to the other branches above: the
  * celebration branch is explicitly out of scope for this fix, and the plain "Migrate now" branch
  * only shows a CTA (no one-click transfer proposal) so the same race isn't user-visible there.
+ *
+ * [orchardBalanceZatoshi] is null while the balance snapshot has not loaded yet — never coerced to
+ * zero, which would misreport an unknown balance as "nothing left". The three balance-dependent
+ * branches (celebration, residue, plain "Migrate now") each require it non-null and fall through to
+ * `null` (no banner) otherwise; the RequiresAttention and InProgress branches above them don't read
+ * the balance at all, so a null balance never suppresses those.
  */
 @Suppress("CyclomaticComplexMethod")
 internal fun migrationMessageFor(
     sdkState: MigrationState?,
     snapshot: LiveMigrationSnapshot?,
     hasSeenComplete: Boolean,
-    orchardBalanceZatoshi: Long,
-    migratableOrchardTotalZatoshi: Long = orchardBalanceZatoshi,
+    orchardBalanceZatoshi: Long?,
+    migratableOrchardTotalZatoshi: Long = orchardBalanceZatoshi ?: 0L,
     dustThresholdZatoshi: Long = MIGRATION_DUST_THRESHOLD_ZATOSHI,
     isFullySynced: Boolean = true,
     isBackgroundExecutionAvailable: Boolean = true,
@@ -412,6 +418,7 @@ internal fun migrationMessageFor(
         // .onDone() marks it seen.
         sdkState == MigrationState.Complete &&
             !hasSeenComplete &&
+            orchardBalanceZatoshi != null &&
             orchardBalanceZatoshi < MIGRATION_RESIDUAL_MIN_ZATOSHI -> {
             MigrationHomeMessageData(
                 isRunActive = false,
@@ -436,6 +443,7 @@ internal fun migrationMessageFor(
         // proposal ran (Slack repro, 2026-08-24).
         !midRunAttention &&
             isFullySynced &&
+            orchardBalanceZatoshi != null &&
             migratableOrchardTotalZatoshi > dustThresholdZatoshi &&
             orchardBalanceZatoshi < MIGRATION_RESIDUAL_MIN_ZATOSHI -> {
             MigrationHomeMessageData(
@@ -449,7 +457,9 @@ internal fun migrationMessageFor(
         // Migratable balance with no run in progress — covers "never migrated", "a Keystone round
         // finished, residual needs another round" (engine still reports Complete), and "campaign
         // done but new funds arrived". All three correctly say "Migrate now".
-        !midRunAttention && orchardBalanceZatoshi >= MIGRATION_RESIDUAL_MIN_ZATOSHI -> {
+        !midRunAttention &&
+            orchardBalanceZatoshi != null &&
+            orchardBalanceZatoshi >= MIGRATION_RESIDUAL_MIN_ZATOSHI -> {
             MigrationHomeMessageData(isRunActive = false)
         }
 

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/keystonesign/MigrationKeystoneSignVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/keystonesign/MigrationKeystoneSignVM.kt
@@ -228,7 +228,7 @@ class MigrationKeystoneSignVM(
                     ZashiAccountInfoListItemState(
                         icon = account.icon,
                         title = account.name,
-                        subtitle = stringRes("${account.unifiedAddress.address.take(ADDRESS_MAX_LENGTH)}..."),
+                        subtitle = stringRes("${account.unifiedAddress.take(ADDRESS_MAX_LENGTH)}..."),
                     ),
                 badgeText = stringRes(DesignR.string.migrationKeystoneSign_badgeHardware),
                 generateNextQrCode = {

--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/keystonesign/MigrationKeystoneSignVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/keystonesign/MigrationKeystoneSignVM.kt
@@ -228,7 +228,7 @@ class MigrationKeystoneSignVM(
                     ZashiAccountInfoListItemState(
                         icon = account.icon,
                         title = account.name,
-                        subtitle = stringRes("${account.unified.address.address.take(ADDRESS_MAX_LENGTH)}..."),
+                        subtitle = stringRes("${account.unifiedAddress.address.take(ADDRESS_MAX_LENGTH)}..."),
                     ),
                 badgeText = stringRes(DesignR.string.migrationKeystoneSign_badgeHardware),
                 generateNextQrCode = {

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/provider/MigrationTorPreferenceAccountScopingTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/provider/MigrationTorPreferenceAccountScopingTest.kt
@@ -2,7 +2,6 @@ package co.electriccoin.zcash.ui.common.provider
 
 import cash.z.ecc.android.sdk.fixture.AccountFixture
 import cash.z.ecc.android.sdk.model.BlockHeight
-import cash.z.ecc.android.sdk.model.WalletAddress
 import co.electriccoin.zcash.preference.StandardPreferenceProvider
 import co.electriccoin.zcash.preference.api.PreferenceProvider
 import co.electriccoin.zcash.preference.model.entry.PreferenceKey
@@ -209,7 +208,7 @@ private class FakeAccountDataSource(
         birthday: BlockHeight?
     ): cash.z.ecc.android.sdk.model.Account = error("unsupported")
 
-    override suspend fun requestNextShieldedAddress(): WalletAddress.Unified = error("unsupported")
+    override suspend fun requestNextShieldedAddress(): String = error("unsupported")
 
     override suspend fun deleteAccount(account: WalletAccount) = error("unsupported")
 }

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/MigrationBannerStateTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/common/usecase/MigrationBannerStateTest.kt
@@ -541,4 +541,72 @@ class MigrationBannerStateTest {
             )
         assertEquals(MigrationHomeMessageData(isRunActive = false), result)
     }
+
+    /**
+     * A null [orchardBalanceZatoshi] (balance snapshot not loaded yet) must not be treated as a
+     * zero balance — coercing it to zero would make the celebration/residue/"Migrate now" branches
+     * fire (or fail to fire) on a value the wallet never actually reported. With no run active and
+     * no attention condition, an unknown balance must show no banner at all.
+     */
+    @Test
+    fun nullOrchardBalanceWithNoRunShowsNothing() {
+        val result =
+            migrationMessageFor(
+                sdkState = null,
+                snapshot = null,
+                hasSeenComplete = false,
+                orchardBalanceZatoshi = null,
+            )
+        assertNull(result, "A not-yet-loaded balance must not be coerced to zero and must show no banner")
+    }
+
+    /**
+     * Same as above, but the engine reports Complete and the celebration hasn't been seen yet — the
+     * celebration branch requires a known balance below the residual minimum; a null balance must
+     * not satisfy that (0 < MIGRATION_RESIDUAL_MIN_ZATOSHI would incorrectly fire it if coerced).
+     */
+    @Test
+    fun nullOrchardBalanceWithCompleteStateDoesNotFireCelebration() {
+        val result =
+            migrationMessageFor(
+                sdkState = MigrationState.Complete,
+                snapshot = null,
+                hasSeenComplete = false,
+                orchardBalanceZatoshi = null,
+            )
+        assertNull(result, "A not-yet-loaded balance must not fire the celebration branch")
+    }
+
+    /**
+     * A null balance must not suppress the RequiresAttention branch above it — that branch never
+     * reads the balance at all.
+     */
+    @Test
+    fun nullOrchardBalanceDoesNotSuppressRequiresAttentionBanner() {
+        val result =
+            migrationMessageFor(
+                sdkState = MigrationState.RequiresAttention(AttentionReason.TransferExpired),
+                snapshot = snapshot(),
+                hasSeenComplete = false,
+                orchardBalanceZatoshi = null,
+            )
+        assertEquals(MigrationAttentionKind.TRANSFER_EXPIRED, result?.attentionKind)
+    }
+
+    /**
+     * A null balance must not suppress the plain InProgress branch above it either — it also never
+     * reads the balance.
+     */
+    @Test
+    fun nullOrchardBalanceDoesNotSuppressInProgressBanner() {
+        val progress = MigrationProgress(completedTransfers = 1, totalTransfers = 3, nextTransferReadyAtHeight = null)
+        val result =
+            migrationMessageFor(
+                sdkState = MigrationState.InProgress(progress),
+                snapshot = snapshot(),
+                hasSeenComplete = false,
+                orchardBalanceZatoshi = null,
+            )
+        assertEquals(MigrationHomeMessageData(isRunActive = true, completedCount = 1, totalCount = 2), result)
+    }
 }

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/signkeystone/SignKeystoneVotingVM.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/signkeystone/SignKeystoneVotingVM.kt
@@ -133,7 +133,7 @@ class SignKeystoneVotingVM(
                         ZashiAccountInfoListItemState(
                             icon = wallet.icon,
                             title = wallet.name,
-                            subtitle = stringRes("${wallet.unifiedAddress.address.take(ADDRESS_MAX_LENGTH)}...")
+                            subtitle = stringRes("${wallet.unifiedAddress.take(ADDRESS_MAX_LENGTH)}...")
                         ),
                     badgeText = stringRes(R.string.keystone_signWith_hardware),
                     qrData = qrData,

--- a/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/signkeystone/SignKeystoneVotingVM.kt
+++ b/feature-voting/src/main/java/co/electriccoin/zcash/ui/screen/voting/signkeystone/SignKeystoneVotingVM.kt
@@ -133,7 +133,7 @@ class SignKeystoneVotingVM(
                         ZashiAccountInfoListItemState(
                             icon = wallet.icon,
                             title = wallet.name,
-                            subtitle = stringRes("${wallet.unified.address.address.take(ADDRESS_MAX_LENGTH)}...")
+                            subtitle = stringRes("${wallet.unifiedAddress.address.take(ADDRESS_MAX_LENGTH)}...")
                         ),
                     badgeText = stringRes(R.string.keystone_signWith_hardware),
                     qrData = qrData,

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepositoryTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepositoryTest.kt
@@ -5,8 +5,6 @@ import cash.z.ecc.android.sdk.fixture.AccountFixture
 import cash.z.ecc.android.sdk.fixture.WalletAddressFixture
 import cash.z.ecc.android.sdk.fixture.WalletBalanceFixture
 import cash.z.ecc.android.sdk.model.Account
-import cash.z.ecc.android.sdk.model.AccountBalance
-import cash.z.ecc.android.sdk.model.AccountUuid
 import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.Pczt
 import cash.z.ecc.android.sdk.model.WalletAddress
@@ -715,7 +713,6 @@ class VotingKeystoneRepositoryTest {
     ) : SynchronizerProvider {
         override val error: StateFlow<SynchronizerError?> = MutableStateFlow(null)
         override val synchronizer: StateFlow<Synchronizer?> = MutableStateFlow(null)
-        override val walletBalances: Flow<Map<AccountUuid, AccountBalance>?> = flowOf(null)
 
         private val fakeSynchronizer: Synchronizer =
             mockk<Synchronizer>(relaxed = true).also { every { it.network } returns ZcashNetwork.Mainnet }

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepositoryTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepositoryTest.kt
@@ -715,6 +715,7 @@ class VotingKeystoneRepositoryTest {
     ) : SynchronizerProvider {
         override val error: StateFlow<SynchronizerError?> = MutableStateFlow(null)
         override val synchronizer: StateFlow<Synchronizer?> = MutableStateFlow(null)
+        override val retainedSynchronizer = synchronizer
         override val walletBalances: Flow<Map<AccountUuid, AccountBalance>?> = flowOf(null)
 
         private val fakeSynchronizer: Synchronizer =

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepositoryTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepositoryTest.kt
@@ -7,7 +7,6 @@ import cash.z.ecc.android.sdk.fixture.WalletBalanceFixture
 import cash.z.ecc.android.sdk.model.Account
 import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.Pczt
-import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.model.ZcashNetwork
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
@@ -371,14 +370,13 @@ class VotingKeystoneRepositoryTest {
             votingConfigRepository = unsupportedProxy()
         )
 
-    private suspend fun keystoneAccount(): KeystoneAccount =
+    private fun keystoneAccount(): KeystoneAccount =
         KeystoneAccount(
             sdkAccount = AccountFixture.new(),
-            unifiedAddress = WalletAddressFixture.unified(),
-            unifiedBalance = WalletBalanceFixture.newLong(),
+            unifiedAddress = WalletAddressFixture.UNIFIED_ADDRESS_STRING,
             orchardBalance = WalletBalanceFixture.newLong(),
             ironwoodBalance = WalletBalanceFixture.newLong(0, 0, 0),
-            transparentAddress = WalletAddressFixture.transparent(),
+            transparentAddress = WalletAddressFixture.TRANSPARENT_ADDRESS_STRING,
             transparentBalance = Zatoshi(0),
             isSelected = true
         )
@@ -421,7 +419,7 @@ class VotingKeystoneRepositoryTest {
             birthday: BlockHeight?
         ): Account = unsupported()
 
-        override suspend fun requestNextShieldedAddress(): WalletAddress.Unified = unsupported()
+        override suspend fun requestNextShieldedAddress(): String = unsupported()
 
         override suspend fun deleteAccount(account: WalletAccount) = unsupported()
     }

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepositoryTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepositoryTest.kt
@@ -13,8 +13,6 @@ import cash.z.ecc.android.sdk.model.ZcashNetwork
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.model.KeystoneAccount
 import co.electriccoin.zcash.ui.common.model.SynchronizerError
-import co.electriccoin.zcash.ui.common.model.TransparentInfo
-import co.electriccoin.zcash.ui.common.model.UnifiedInfo
 import co.electriccoin.zcash.ui.common.model.WalletAccount
 import co.electriccoin.zcash.ui.common.model.ZashiAccount
 import co.electriccoin.zcash.ui.common.model.voting.Proposal
@@ -376,17 +374,12 @@ class VotingKeystoneRepositoryTest {
     private suspend fun keystoneAccount(): KeystoneAccount =
         KeystoneAccount(
             sdkAccount = AccountFixture.new(),
-            unified =
-                UnifiedInfo(
-                    address = WalletAddressFixture.unified(),
-                    balance = WalletBalanceFixture.newLong()
-                ),
+            unifiedAddress = WalletAddressFixture.unified(),
+            unifiedBalance = WalletBalanceFixture.newLong(),
+            orchardBalance = WalletBalanceFixture.newLong(),
             ironwoodBalance = WalletBalanceFixture.newLong(0, 0, 0),
-            transparent =
-                TransparentInfo(
-                    address = WalletAddressFixture.transparent(),
-                    balance = Zatoshi(0)
-                ),
+            transparentAddress = WalletAddressFixture.transparent(),
+            transparentBalance = Zatoshi(0),
             isSelected = true
         )
 

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepositoryTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/repository/VotingKeystoneRepositoryTest.kt
@@ -715,7 +715,6 @@ class VotingKeystoneRepositoryTest {
     ) : SynchronizerProvider {
         override val error: StateFlow<SynchronizerError?> = MutableStateFlow(null)
         override val synchronizer: StateFlow<Synchronizer?> = MutableStateFlow(null)
-        override val retainedSynchronizer = synchronizer
         override val walletBalances: Flow<Map<AccountUuid, AccountBalance>?> = flowOf(null)
 
         private val fakeSynchronizer: Synchronizer =

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/SkipRemainingKeystoneBundlesUseCaseTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/SkipRemainingKeystoneBundlesUseCaseTest.kt
@@ -222,7 +222,6 @@ private class FakeSynchronizerProvider(
 
     override val error: StateFlow<SynchronizerError?> = MutableStateFlow(null)
     override val synchronizer: StateFlow<Synchronizer?> = MutableStateFlow(fakeSynchronizer)
-    override val retainedSynchronizer = synchronizer
     override val walletBalances: Flow<Map<AccountUuid, AccountBalance>?> = flowOf(null)
 
     override suspend fun getSynchronizer(): Synchronizer = fakeSynchronizer

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/SkipRemainingKeystoneBundlesUseCaseTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/SkipRemainingKeystoneBundlesUseCaseTest.kt
@@ -222,6 +222,7 @@ private class FakeSynchronizerProvider(
 
     override val error: StateFlow<SynchronizerError?> = MutableStateFlow(null)
     override val synchronizer: StateFlow<Synchronizer?> = MutableStateFlow(fakeSynchronizer)
+    override val retainedSynchronizer = synchronizer
     override val walletBalances: Flow<Map<AccountUuid, AccountBalance>?> = flowOf(null)
 
     override suspend fun getSynchronizer(): Synchronizer = fakeSynchronizer

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/SkipRemainingKeystoneBundlesUseCaseTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/SkipRemainingKeystoneBundlesUseCaseTest.kt
@@ -5,8 +5,6 @@ import cash.z.ecc.android.sdk.fixture.AccountFixture
 import cash.z.ecc.android.sdk.fixture.WalletAddressFixture
 import cash.z.ecc.android.sdk.fixture.WalletBalanceFixture
 import cash.z.ecc.android.sdk.model.Account
-import cash.z.ecc.android.sdk.model.AccountBalance
-import cash.z.ecc.android.sdk.model.AccountUuid
 import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.model.Zatoshi
@@ -222,7 +220,6 @@ private class FakeSynchronizerProvider(
 
     override val error: StateFlow<SynchronizerError?> = MutableStateFlow(null)
     override val synchronizer: StateFlow<Synchronizer?> = MutableStateFlow(fakeSynchronizer)
-    override val walletBalances: Flow<Map<AccountUuid, AccountBalance>?> = flowOf(null)
 
     override suspend fun getSynchronizer(): Synchronizer = fakeSynchronizer
 

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/SkipRemainingKeystoneBundlesUseCaseTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/SkipRemainingKeystoneBundlesUseCaseTest.kt
@@ -6,7 +6,6 @@ import cash.z.ecc.android.sdk.fixture.WalletAddressFixture
 import cash.z.ecc.android.sdk.fixture.WalletBalanceFixture
 import cash.z.ecc.android.sdk.model.Account
 import cash.z.ecc.android.sdk.model.BlockHeight
-import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.model.ZcashNetwork
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
@@ -140,14 +139,13 @@ class SkipRemainingKeystoneBundlesUseCaseTest {
         votingRecoveryRepository = recoveryRepository.repository
     )
 
-    private suspend fun keystoneAccount(): KeystoneAccount =
+    private fun keystoneAccount(): KeystoneAccount =
         KeystoneAccount(
             sdkAccount = AccountFixture.new(),
-            unifiedAddress = WalletAddressFixture.unified(),
-            unifiedBalance = WalletBalanceFixture.newLong(),
+            unifiedAddress = WalletAddressFixture.UNIFIED_ADDRESS_STRING,
             orchardBalance = WalletBalanceFixture.newLong(),
             ironwoodBalance = WalletBalanceFixture.newLong(0, 0, 0),
-            transparentAddress = WalletAddressFixture.transparent(),
+            transparentAddress = WalletAddressFixture.TRANSPARENT_ADDRESS_STRING,
             transparentBalance = Zatoshi(0),
             isSelected = true
         )
@@ -201,7 +199,7 @@ private class FakeAccountDataSource(
         birthday: BlockHeight?
     ): Account = unsupported()
 
-    override suspend fun requestNextShieldedAddress(): WalletAddress.Unified = unsupported()
+    override suspend fun requestNextShieldedAddress(): String = unsupported()
 
     override suspend fun deleteAccount(account: WalletAccount) = unsupported()
 }

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/SkipRemainingKeystoneBundlesUseCaseTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/SkipRemainingKeystoneBundlesUseCaseTest.kt
@@ -12,8 +12,6 @@ import cash.z.ecc.android.sdk.model.ZcashNetwork
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.model.KeystoneAccount
 import co.electriccoin.zcash.ui.common.model.SynchronizerError
-import co.electriccoin.zcash.ui.common.model.TransparentInfo
-import co.electriccoin.zcash.ui.common.model.UnifiedInfo
 import co.electriccoin.zcash.ui.common.model.WalletAccount
 import co.electriccoin.zcash.ui.common.model.ZashiAccount
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
@@ -145,17 +143,12 @@ class SkipRemainingKeystoneBundlesUseCaseTest {
     private suspend fun keystoneAccount(): KeystoneAccount =
         KeystoneAccount(
             sdkAccount = AccountFixture.new(),
-            unified =
-                UnifiedInfo(
-                    address = WalletAddressFixture.unified(),
-                    balance = WalletBalanceFixture.newLong()
-                ),
+            unifiedAddress = WalletAddressFixture.unified(),
+            unifiedBalance = WalletBalanceFixture.newLong(),
+            orchardBalance = WalletBalanceFixture.newLong(),
             ironwoodBalance = WalletBalanceFixture.newLong(0, 0, 0),
-            transparent =
-                TransparentInfo(
-                    address = WalletAddressFixture.transparent(),
-                    balance = Zatoshi(0)
-                ),
+            transparentAddress = WalletAddressFixture.transparent(),
+            transparentBalance = Zatoshi(0),
             isSelected = true
         )
 

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCaseRecoveryTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCaseRecoveryTest.kt
@@ -1078,14 +1078,13 @@ class SubmitVotesUseCaseRecoveryTest {
                 createdAtHeight = 1
             )
 
-        suspend fun keystoneAccount() =
+        fun keystoneAccount() =
             KeystoneAccount(
                 sdkAccount = AccountFixture.new(),
-                unifiedAddress = WalletAddressFixture.unified(),
-                unifiedBalance = WalletBalanceFixture.newLong(),
+                unifiedAddress = WalletAddressFixture.UNIFIED_ADDRESS_STRING,
                 orchardBalance = WalletBalanceFixture.newLong(),
                 ironwoodBalance = WalletBalanceFixture.newLong(0, 0, 0),
-                transparentAddress = WalletAddressFixture.transparent(),
+                transparentAddress = WalletAddressFixture.TRANSPARENT_ADDRESS_STRING,
                 transparentBalance = Zatoshi(0),
                 isSelected = true
             )

--- a/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCaseRecoveryTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/ui/common/usecase/SubmitVotesUseCaseRecoveryTest.kt
@@ -7,8 +7,6 @@ import cash.z.ecc.android.sdk.fixture.WalletBalanceFixture
 import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.model.ZcashNetwork
 import co.electriccoin.zcash.ui.common.model.KeystoneAccount
-import co.electriccoin.zcash.ui.common.model.TransparentInfo
-import co.electriccoin.zcash.ui.common.model.UnifiedInfo
 import co.electriccoin.zcash.ui.common.model.voting.BundleDelegationPhase
 import co.electriccoin.zcash.ui.common.model.voting.CastVoteSignature
 import co.electriccoin.zcash.ui.common.model.voting.CommitmentTreeLatest
@@ -1083,17 +1081,12 @@ class SubmitVotesUseCaseRecoveryTest {
         suspend fun keystoneAccount() =
             KeystoneAccount(
                 sdkAccount = AccountFixture.new(),
-                unified =
-                    UnifiedInfo(
-                        address = WalletAddressFixture.unified(),
-                        balance = WalletBalanceFixture.newLong()
-                    ),
+                unifiedAddress = WalletAddressFixture.unified(),
+                unifiedBalance = WalletBalanceFixture.newLong(),
+                orchardBalance = WalletBalanceFixture.newLong(),
                 ironwoodBalance = WalletBalanceFixture.newLong(0, 0, 0),
-                transparent =
-                    TransparentInfo(
-                        address = WalletAddressFixture.transparent(),
-                        balance = Zatoshi(0)
-                    ),
+                transparentAddress = WalletAddressFixture.transparent(),
+                transparentBalance = Zatoshi(0),
                 isSelected = true
             )
     }

--- a/feature-voting/src/test/java/co/electriccoin/zcash/voting/VotingHomeHooksImplTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/voting/VotingHomeHooksImplTest.kt
@@ -173,14 +173,13 @@ class VotingHomeHooksImplTest {
             coVerify(exactly = 1) { refreshActiveVotingSession() }
         }
 
-    private suspend fun keystoneAccount(): KeystoneAccount =
+    private fun keystoneAccount(): KeystoneAccount =
         KeystoneAccount(
             sdkAccount = AccountFixture.new(),
-            unifiedAddress = WalletAddressFixture.unified(),
-            unifiedBalance = WalletBalanceFixture.newLong(),
+            unifiedAddress = WalletAddressFixture.UNIFIED_ADDRESS_STRING,
             orchardBalance = WalletBalanceFixture.newLong(),
             ironwoodBalance = WalletBalanceFixture.newLong(0, 0, 0),
-            transparentAddress = WalletAddressFixture.transparent(),
+            transparentAddress = WalletAddressFixture.TRANSPARENT_ADDRESS_STRING,
             transparentBalance = Zatoshi(0),
             isSelected = true
         )

--- a/feature-voting/src/test/java/co/electriccoin/zcash/voting/VotingHomeHooksImplTest.kt
+++ b/feature-voting/src/test/java/co/electriccoin/zcash/voting/VotingHomeHooksImplTest.kt
@@ -6,8 +6,6 @@ import cash.z.ecc.android.sdk.fixture.WalletBalanceFixture
 import cash.z.ecc.android.sdk.model.Zatoshi
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.common.model.KeystoneAccount
-import co.electriccoin.zcash.ui.common.model.TransparentInfo
-import co.electriccoin.zcash.ui.common.model.UnifiedInfo
 import co.electriccoin.zcash.ui.common.model.voting.SessionStatus
 import co.electriccoin.zcash.ui.common.model.voting.VotingSession
 import co.electriccoin.zcash.ui.common.repository.VotingApiRepository
@@ -178,17 +176,12 @@ class VotingHomeHooksImplTest {
     private suspend fun keystoneAccount(): KeystoneAccount =
         KeystoneAccount(
             sdkAccount = AccountFixture.new(),
-            unified =
-                UnifiedInfo(
-                    address = WalletAddressFixture.unified(),
-                    balance = WalletBalanceFixture.newLong()
-                ),
+            unifiedAddress = WalletAddressFixture.unified(),
+            unifiedBalance = WalletBalanceFixture.newLong(),
+            orchardBalance = WalletBalanceFixture.newLong(),
             ironwoodBalance = WalletBalanceFixture.newLong(0, 0, 0),
-            transparent =
-                TransparentInfo(
-                    address = WalletAddressFixture.transparent(),
-                    balance = Zatoshi(0)
-                ),
+            transparentAddress = WalletAddressFixture.transparent(),
+            transparentBalance = Zatoshi(0),
             isSelected = true
         )
 

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/chooseserver/ChooseServerSelectionTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/chooseserver/ChooseServerSelectionTest.kt
@@ -6,8 +6,6 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.filters.SmallTest
 import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.WalletInitMode
-import cash.z.ecc.android.sdk.model.AccountBalance
-import cash.z.ecc.android.sdk.model.AccountUuid
 import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.PersistableWallet
 import cash.z.ecc.android.sdk.model.SeedPhrase
@@ -46,7 +44,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlin.reflect.KClass
@@ -336,7 +333,6 @@ private class FakeWalletRepository(
 private class FakeSynchronizerProvider : SynchronizerProvider {
     override val error = MutableStateFlow<SynchronizerError?>(null)
     override val synchronizer = MutableStateFlow<Synchronizer?>(MockSynchronizer(ServerValidation.Valid))
-    override val walletBalances: Flow<Map<AccountUuid, AccountBalance>?> = flowOf(null)
 
     override suspend fun getSynchronizer(): Synchronizer = checkNotNull(synchronizer.value)
 

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/chooseserver/ChooseServerSelectionTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/chooseserver/ChooseServerSelectionTest.kt
@@ -336,7 +336,6 @@ private class FakeWalletRepository(
 private class FakeSynchronizerProvider : SynchronizerProvider {
     override val error = MutableStateFlow<SynchronizerError?>(null)
     override val synchronizer = MutableStateFlow<Synchronizer?>(MockSynchronizer(ServerValidation.Valid))
-    override val retainedSynchronizer = synchronizer
     override val walletBalances: Flow<Map<AccountUuid, AccountBalance>?> = flowOf(null)
 
     override suspend fun getSynchronizer(): Synchronizer = checkNotNull(synchronizer.value)

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/chooseserver/ChooseServerSelectionTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/chooseserver/ChooseServerSelectionTest.kt
@@ -336,6 +336,7 @@ private class FakeWalletRepository(
 private class FakeSynchronizerProvider : SynchronizerProvider {
     override val error = MutableStateFlow<SynchronizerError?>(null)
     override val synchronizer = MutableStateFlow<Synchronizer?>(MockSynchronizer(ServerValidation.Valid))
+    override val retainedSynchronizer = synchronizer
     override val walletBalances: Flow<Map<AccountUuid, AccountBalance>?> = flowOf(null)
 
     override suspend fun getSynchronizer(): Synchronizer = checkNotNull(synchronizer.value)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
@@ -3,15 +3,13 @@ package co.electriccoin.zcash.ui.common.datasource
 import android.content.Context
 import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.model.Account
+import cash.z.ecc.android.sdk.model.AccountBalance
 import cash.z.ecc.android.sdk.model.AccountImportSetup
 import cash.z.ecc.android.sdk.model.AccountPurpose
 import cash.z.ecc.android.sdk.model.AccountUuid
 import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.UnifiedAddressRequest
 import cash.z.ecc.android.sdk.model.UnifiedFullViewingKey
-import cash.z.ecc.android.sdk.model.WalletAddress
-import cash.z.ecc.android.sdk.model.WalletBalance
-import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.model.Zip32AccountIndex
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.model.KeystoneAccount
@@ -77,7 +75,7 @@ interface AccountDataSource {
         birthday: BlockHeight? = null
     ): Account
 
-    suspend fun requestNextShieldedAddress(): WalletAddress.Unified
+    suspend fun requestNextShieldedAddress(): String
 
     suspend fun deleteAccount(account: WalletAccount)
 }
@@ -111,71 +109,41 @@ class AccountDataSourceImpl(
                     ?.flatMapLatest { allSdkAccounts ->
                         allSdkAccounts
                             .map { sdkAccount ->
-                                val unifiedAndTransparent =
-                                    combine(
-                                        observeUnifiedAddress(synchronizer, sdkAccount),
-                                        observeUnifiedBalance(synchronizer, sdkAccount),
-                                        observeOrchardBalance(synchronizer, sdkAccount),
-                                        observeTransparentAddress(synchronizer, sdkAccount),
-                                        observeTransparentBalance(synchronizer, sdkAccount),
-                                    ) {
-                                        unifiedAddress,
-                                        unifiedBalance,
-                                        orchardBalance,
-                                        transparentAddress,
-                                        transparentBalance,
-                                        ->
-                                        UnifiedAndTransparentSnapshot(
+                                combine(
+                                    observeAccountBalance(synchronizer, sdkAccount),
+                                    observeUnifiedAddress(synchronizer, sdkAccount),
+                                    observeTransparentAddress(synchronizer, sdkAccount),
+                                    observeSaplingAddress(synchronizer, sdkAccount),
+                                    observeIsSelected(sdkAccount, allSdkAccounts),
+                                ) {
+                                    balance,
+                                    unifiedAddress,
+                                    transparentAddress,
+                                    saplingAddress,
+                                    isSelected,
+                                    ->
+                                    if (isKeystoneAccount(sdkAccount)) {
+                                        KeystoneAccount(
+                                            sdkAccount = sdkAccount,
                                             unifiedAddress = unifiedAddress,
-                                            unifiedBalance = unifiedBalance,
-                                            orchardBalance = orchardBalance,
                                             transparentAddress = transparentAddress,
-                                            transparentBalance = transparentBalance,
-                                        )
-                                    }
-                                val saplingAndSelection =
-                                    combine(
-                                        observeSaplingAddress(synchronizer, sdkAccount),
-                                        observeSaplingBalance(synchronizer, sdkAccount),
-                                        observeIronwoodBalance(synchronizer, sdkAccount),
-                                        observeIsSelected(sdkAccount, allSdkAccounts),
-                                    ) { saplingAddress, saplingBalance, ironwoodBalance, isSelected ->
-                                        SaplingAndSelectionSnapshot(
-                                            saplingAddress = saplingAddress,
-                                            saplingBalance = saplingBalance,
-                                            ironwoodBalance = ironwoodBalance,
+                                            orchardBalance = balance?.orchard,
+                                            ironwoodBalance = balance?.ironwood,
+                                            transparentBalance = balance?.unshielded,
                                             isSelected = isSelected,
                                         )
-                                    }
-                                combine(unifiedAndTransparent, saplingAndSelection) { primary, secondary ->
-                                    when (sdkAccount.keySource?.lowercase()) {
-                                        KEYSTONE_KEYSOURCE -> {
-                                            KeystoneAccount(
-                                                sdkAccount = sdkAccount,
-                                                unifiedAddress = primary.unifiedAddress,
-                                                unifiedBalance = primary.unifiedBalance,
-                                                orchardBalance = primary.orchardBalance,
-                                                ironwoodBalance = secondary.ironwoodBalance,
-                                                transparentAddress = primary.transparentAddress,
-                                                transparentBalance = primary.transparentBalance,
-                                                isSelected = secondary.isSelected,
-                                            )
-                                        }
-
-                                        else -> {
-                                            ZashiAccount(
-                                                sdkAccount = sdkAccount,
-                                                unifiedAddress = primary.unifiedAddress,
-                                                unifiedBalance = primary.unifiedBalance,
-                                                orchardBalance = primary.orchardBalance,
-                                                saplingAddress = secondary.saplingAddress!!,
-                                                saplingBalance = secondary.saplingBalance,
-                                                ironwoodBalance = secondary.ironwoodBalance,
-                                                transparentAddress = primary.transparentAddress,
-                                                transparentBalance = primary.transparentBalance,
-                                                isSelected = secondary.isSelected,
-                                            )
-                                        }
+                                    } else {
+                                        ZashiAccount(
+                                            sdkAccount = sdkAccount,
+                                            unifiedAddress = unifiedAddress,
+                                            transparentAddress = transparentAddress,
+                                            saplingAddress = saplingAddress!!,
+                                            orchardBalance = balance?.orchard,
+                                            saplingBalance = balance?.sapling,
+                                            ironwoodBalance = balance?.ironwood,
+                                            transparentBalance = balance?.unshielded,
+                                            isSelected = isSelected,
+                                        )
                                     }
                                 }
                             }.combineToFlow()
@@ -240,20 +208,20 @@ class AccountDataSourceImpl(
         }
 
     @Suppress("TooGenericExceptionCaught")
-    override suspend fun requestNextShieldedAddress(): WalletAddress.Unified {
-        var result: WalletAddress.Unified? = null
+    override suspend fun requestNextShieldedAddress(): String {
+        var result: String? = null
         scope
             .launch {
                 val accountUuid = getSelectedAccount().sdkAccount.accountUuid
                 log("requestNextShieldedAddress for $accountUuid")
-                val responseChannel = Channel<WalletAddress.Unified>(1)
+                val responseChannel = Channel<String>(1)
                 requestNextShieldedAddressChannel.emit(AddressRequest(accountUuid, responseChannel))
                 try {
                     val address = withTimeoutOrNull(ADDRESS_REQUEST_TIMEOUT) { responseChannel.receive() }
                     if (address == null) {
                         log("timed out waiting for address for $accountUuid")
                     } else {
-                        log("received address ${address.address} for $accountUuid")
+                        log("received address $address for $accountUuid")
                     }
                     result = address
                 } catch (e: Exception) {
@@ -261,7 +229,7 @@ class AccountDataSourceImpl(
                 }
             }.join()
         return (result ?: getSelectedAccount().unifiedAddress).also {
-            log("returning address ${it.address}")
+            log("returning address $it")
         }
     }
 
@@ -284,34 +252,34 @@ class AccountDataSourceImpl(
             }
         }
 
+    private fun isKeystoneAccount(sdkAccount: Account) = sdkAccount.keySource?.lowercase() == KEYSTONE_KEYSOURCE
+
     private fun observeIsSelected(sdkAccount: Account, allAccounts: List<Account>) =
         selectedAccountUUIDProvider
             .uuid
             .map { uuid ->
-                when (sdkAccount.keySource?.lowercase()) {
-                    KEYSTONE_KEYSOURCE -> sdkAccount.accountUuid == uuid || allAccounts.size == 1
-                    else -> uuid == null || sdkAccount.accountUuid == uuid || allAccounts.size == 1
+                if (isKeystoneAccount(sdkAccount)) {
+                    sdkAccount.accountUuid == uuid || allAccounts.size == 1
+                } else {
+                    uuid == null || sdkAccount.accountUuid == uuid || allAccounts.size == 1
                 }
             }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun observeUnifiedAddress(synchronizer: Synchronizer, sdkAccount: Account): Flow<WalletAddress.Unified> {
-        suspend fun rotateAddress(): WalletAddress.Unified {
+    private fun observeUnifiedAddress(synchronizer: Synchronizer, sdkAccount: Account): Flow<String> {
+        suspend fun rotateAddress(): String {
             log("deriving unified address for ${sdkAccount.accountUuid}")
 
             val addressRequest =
-                if (sdkAccount.keySource?.lowercase() == KEYSTONE_KEYSOURCE) {
+                if (isKeystoneAccount(sdkAccount)) {
                     UnifiedAddressRequest.Orchard
                 } else {
                     UnifiedAddressRequest.shielded
                 }
 
-            val address =
-                WalletAddress
-                    .Unified
-                    .new(synchronizer.getCustomUnifiedAddress(sdkAccount, addressRequest))
+            val address = synchronizer.getCustomUnifiedAddress(sdkAccount, addressRequest)
 
-            log("derived address ${address.address} for ${sdkAccount.accountUuid}")
+            log("derived address $address for ${sdkAccount.accountUuid}")
 
             return address
         }
@@ -354,98 +322,37 @@ class AccountDataSourceImpl(
     }
 
     /**
-     * Folds Orchard + Ironwood together — see [WalletAccount.unifiedBalance].
+     * The account's full balance snapshot, or null while the synchronizer hasn't reported one yet
+     * — see [allAccounts]'s kdoc for the null-propagation contract this feeds.
      */
-    private fun observeUnifiedBalance(synchronizer: Synchronizer, sdkAccount: Account): Flow<WalletBalance?> =
+    private fun observeAccountBalance(synchronizer: Synchronizer, sdkAccount: Account): Flow<AccountBalance?> =
         synchronizer.walletBalances
-            .map { balances ->
-                balances?.get(sdkAccount.accountUuid)?.let { balance -> balance.orchard + balance.ironwood }
-            }
+            .map { balances -> balances?.get(sdkAccount.accountUuid) }
 
-    private fun observeOrchardBalance(synchronizer: Synchronizer, sdkAccount: Account): Flow<WalletBalance?> =
-        synchronizer.walletBalances
-            .map { balances ->
-                balances?.get(sdkAccount.accountUuid)?.orchard
-            }
-
-    private fun observeTransparentAddress(
-        synchronizer: Synchronizer,
-        sdkAccount: Account
-    ): Flow<WalletAddress.Transparent> =
+    private fun observeTransparentAddress(synchronizer: Synchronizer, sdkAccount: Account): Flow<String> =
         flow {
-            emit(WalletAddress.Transparent.new(synchronizer.getTransparentAddress(sdkAccount)))
+            emit(synchronizer.getTransparentAddress(sdkAccount))
         }.retryWhen { _, attempt ->
             delay(attempt.coerceAtMost(RETRY_DELAY).seconds)
             true
         }
 
-    private fun observeTransparentBalance(synchronizer: Synchronizer, sdkAccount: Account): Flow<Zatoshi?> =
-        synchronizer.walletBalances
-            .map { balances ->
-                balances?.get(sdkAccount.accountUuid)?.unshielded
-            }
-
-    private fun observeSaplingAddress(
-        synchronizer: Synchronizer,
-        sdkAccount: Account
-    ): Flow<WalletAddress.Sapling?> =
-        if (sdkAccount.keySource == KEYSTONE_KEYSOURCE) {
+    private fun observeSaplingAddress(synchronizer: Synchronizer, sdkAccount: Account): Flow<String?> =
+        if (isKeystoneAccount(sdkAccount)) {
             flowOf(null)
         } else {
             flow {
-                emit(WalletAddress.Sapling.new(synchronizer.getSaplingAddress(sdkAccount)))
+                emit(synchronizer.getSaplingAddress(sdkAccount))
             }.retryWhen { _, attempt ->
                 delay(attempt.coerceAtMost(RETRY_DELAY).seconds)
                 true
             }
         }
-
-    private fun observeSaplingBalance(synchronizer: Synchronizer, sdkAccount: Account): Flow<WalletBalance?> =
-        if (sdkAccount.keySource == KEYSTONE_KEYSOURCE) {
-            flowOf(null)
-        } else {
-            synchronizer.walletBalances
-                .map { balances ->
-                    balances?.get(sdkAccount.accountUuid)?.sapling
-                }
-        }
-
-    /**
-     * Ironwood shares the same unified address as Orchard (no address of its own to observe) —
-     * just its balance.
-     */
-    private fun observeIronwoodBalance(synchronizer: Synchronizer, sdkAccount: Account): Flow<WalletBalance?> =
-        synchronizer.walletBalances
-            .map { balances ->
-                balances?.get(sdkAccount.accountUuid)?.ironwood
-            }
-
-    private operator fun WalletBalance.plus(other: WalletBalance) =
-        WalletBalance(
-            available = available + other.available,
-            changePending = changePending + other.changePending,
-            valuePending = valuePending + other.valuePending
-        )
 }
 
 private data class AddressRequest(
     val accountUuid: AccountUuid,
-    val responseChannel: Channel<WalletAddress.Unified>
-)
-
-private data class UnifiedAndTransparentSnapshot(
-    val unifiedAddress: WalletAddress.Unified,
-    val unifiedBalance: WalletBalance?,
-    val orchardBalance: WalletBalance?,
-    val transparentAddress: WalletAddress.Transparent,
-    val transparentBalance: Zatoshi?,
-)
-
-private data class SaplingAndSelectionSnapshot(
-    val saplingAddress: WalletAddress.Sapling?,
-    val saplingBalance: WalletBalance?,
-    val ironwoodBalance: WalletBalance?,
-    val isSelected: Boolean,
+    val responseChannel: Channel<String>
 )
 
 private const val RETRY_DELAY = 3L

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
@@ -11,9 +11,7 @@ import cash.z.ecc.android.sdk.model.UnifiedAddressRequest
 import cash.z.ecc.android.sdk.model.UnifiedFullViewingKey
 import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.model.WalletBalance
-import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.model.Zip32AccountIndex
-import cash.z.ecc.sdk.extension.ZERO
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.model.KeystoneAccount
 import co.electriccoin.zcash.ui.common.model.SaplingInfo
@@ -99,9 +97,10 @@ class AccountDataSourceImpl(
     private val requestNextShieldedAddressChannel = MutableSharedFlow<AddressRequest>()
 
     /**
-     * A null balances snapshot from the synchronizer must yield no emission (or null for
-     * [allAccounts] itself), never fabricated zeros — zeros are a truth claim about wallet state,
-     * while null means the data simply is not loaded yet.
+     * A null balances snapshot from the synchronizer propagates as null all the way through each
+     * account's balance fields (never suppressed, never defaulted to zero) — a fresh wallet's
+     * accounts are visible immediately, with their balances arriving once the synchronizer reports
+     * them. Zero is only ever a real reported value, never a stand-in for "not loaded yet".
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     override val allAccounts: StateFlow<List<WalletAccount>?> =
@@ -321,11 +320,8 @@ class AccountDataSourceImpl(
 
         val balanceFlow =
             synchronizer.walletBalances
-                .filterNotNull()
                 .map { balances ->
-                    balances[sdkAccount.accountUuid]
-                        ?.let { balance -> balance.orchard + balance.ironwood }
-                        ?: createEmptyWalletBalance()
+                    balances?.get(sdkAccount.accountUuid)?.let { balance -> balance.orchard + balance.ironwood }
                 }
 
         return combine(addressFlow, balanceFlow) { address, balance ->
@@ -341,9 +337,9 @@ class AccountDataSourceImpl(
                 delay(attempt.coerceAtMost(RETRY_DELAY).seconds)
                 true
             }
-        return combine(transparentAddress, synchronizer.walletBalances.filterNotNull()) { address, balances ->
-            val balance = balances[sdkAccount.accountUuid]
-            TransparentInfo(address = address, balance = balance?.unshielded ?: Zatoshi.ZERO)
+        return combine(transparentAddress, synchronizer.walletBalances) { address, balances ->
+            val balance = balances?.get(sdkAccount.accountUuid)
+            TransparentInfo(address = address, balance = balance?.unshielded)
         }
     }
 
@@ -358,22 +354,21 @@ class AccountDataSourceImpl(
                     delay(attempt.coerceAtMost(RETRY_DELAY).seconds)
                     true
                 }
-            combine(saplingAddress, synchronizer.walletBalances.filterNotNull()) { address, balances ->
-                val balance = balances[sdkAccount.accountUuid]
-                SaplingInfo(address = address, balance = balance?.sapling ?: createEmptyWalletBalance())
+            combine(saplingAddress, synchronizer.walletBalances) { address, balances ->
+                val balance = balances?.get(sdkAccount.accountUuid)
+                SaplingInfo(address = address, balance = balance?.sapling)
             }
         }
 
-    // Ironwood shares the same unified address as Orchard (no address of its own to observe) —
-    // just its balance.
-    private fun observeIronwoodBalance(synchronizer: Synchronizer, sdkAccount: Account): Flow<WalletBalance> =
+    /**
+     * Ironwood shares the same unified address as Orchard (no address of its own to observe) —
+     * just its balance.
+     */
+    private fun observeIronwoodBalance(synchronizer: Synchronizer, sdkAccount: Account): Flow<WalletBalance?> =
         synchronizer.walletBalances
-            .filterNotNull()
             .map { balances ->
-                balances[sdkAccount.accountUuid]?.ironwood ?: createEmptyWalletBalance()
+                balances?.get(sdkAccount.accountUuid)?.ironwood
             }
-
-    private fun createEmptyWalletBalance() = WalletBalance(Zatoshi.ZERO, Zatoshi.ZERO, Zatoshi.ZERO)
 
     private operator fun WalletBalance.plus(other: WalletBalance) =
         WalletBalance(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
@@ -113,7 +113,7 @@ class AccountDataSourceImpl(
                                     observeUnified(synchronizer, sdkAccount),
                                     observeTransparent(synchronizer, sdkAccount),
                                     observeSapling(synchronizer, sdkAccount),
-                                    observeIronwoodBalance(sdkAccount),
+                                    observeIronwoodBalance(synchronizer, sdkAccount),
                                     observeIsSelected(sdkAccount, allSdkAccounts),
                                 ) { unified, transparent, sapling, ironwoodBalance, isSelected ->
                                     when (sdkAccount.keySource?.lowercase()) {
@@ -315,7 +315,7 @@ class AccountDataSourceImpl(
             }
 
         val balanceFlow =
-            synchronizerProvider.walletBalances
+            synchronizer.walletBalances
                 .map {
                     it
                         ?.get(sdkAccount.accountUuid)
@@ -336,7 +336,7 @@ class AccountDataSourceImpl(
                 delay(attempt.coerceAtMost(RETRY_DELAY).seconds)
                 true
             }
-        return combine(transparentAddress, synchronizerProvider.walletBalances) { address, balances ->
+        return combine(transparentAddress, synchronizer.walletBalances) { address, balances ->
             val balance = balances?.get(sdkAccount.accountUuid)
             TransparentInfo(address = address, balance = balance?.unshielded ?: Zatoshi.ZERO)
         }
@@ -353,7 +353,7 @@ class AccountDataSourceImpl(
                     delay(attempt.coerceAtMost(RETRY_DELAY).seconds)
                     true
                 }
-            combine(saplingAddress, synchronizerProvider.walletBalances) { address, balances ->
+            combine(saplingAddress, synchronizer.walletBalances) { address, balances ->
                 val balance = balances?.get(sdkAccount.accountUuid)
                 SaplingInfo(address = address, balance = balance?.sapling ?: createEmptyWalletBalance())
             }
@@ -361,8 +361,8 @@ class AccountDataSourceImpl(
 
     // Ironwood shares the same unified address as Orchard (no address of its own to observe) —
     // just its balance.
-    private fun observeIronwoodBalance(sdkAccount: Account): Flow<WalletBalance> =
-        synchronizerProvider.walletBalances.map { balances ->
+    private fun observeIronwoodBalance(synchronizer: Synchronizer, sdkAccount: Account): Flow<WalletBalance> =
+        synchronizer.walletBalances.map { balances ->
             balances?.get(sdkAccount.accountUuid)?.ironwood ?: createEmptyWalletBalance()
         }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
@@ -11,12 +11,10 @@ import cash.z.ecc.android.sdk.model.UnifiedAddressRequest
 import cash.z.ecc.android.sdk.model.UnifiedFullViewingKey
 import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.model.WalletBalance
+import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.model.Zip32AccountIndex
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.model.KeystoneAccount
-import co.electriccoin.zcash.ui.common.model.SaplingInfo
-import co.electriccoin.zcash.ui.common.model.TransparentInfo
-import co.electriccoin.zcash.ui.common.model.UnifiedInfo
 import co.electriccoin.zcash.ui.common.model.WalletAccount
 import co.electriccoin.zcash.ui.common.model.ZashiAccount
 import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
@@ -113,32 +111,69 @@ class AccountDataSourceImpl(
                     ?.flatMapLatest { allSdkAccounts ->
                         allSdkAccounts
                             .map { sdkAccount ->
-                                combine(
-                                    observeUnified(synchronizer, sdkAccount),
-                                    observeTransparent(synchronizer, sdkAccount),
-                                    observeSapling(synchronizer, sdkAccount),
-                                    observeIronwoodBalance(synchronizer, sdkAccount),
-                                    observeIsSelected(sdkAccount, allSdkAccounts),
-                                ) { unified, transparent, sapling, ironwoodBalance, isSelected ->
+                                val unifiedAndTransparent =
+                                    combine(
+                                        observeUnifiedAddress(synchronizer, sdkAccount),
+                                        observeUnifiedBalance(synchronizer, sdkAccount),
+                                        observeOrchardBalance(synchronizer, sdkAccount),
+                                        observeTransparentAddress(synchronizer, sdkAccount),
+                                        observeTransparentBalance(synchronizer, sdkAccount),
+                                    ) {
+                                        unifiedAddress,
+                                        unifiedBalance,
+                                        orchardBalance,
+                                        transparentAddress,
+                                        transparentBalance,
+                                        ->
+                                        UnifiedAndTransparentSnapshot(
+                                            unifiedAddress = unifiedAddress,
+                                            unifiedBalance = unifiedBalance,
+                                            orchardBalance = orchardBalance,
+                                            transparentAddress = transparentAddress,
+                                            transparentBalance = transparentBalance,
+                                        )
+                                    }
+                                val saplingAndSelection =
+                                    combine(
+                                        observeSaplingAddress(synchronizer, sdkAccount),
+                                        observeSaplingBalance(synchronizer, sdkAccount),
+                                        observeIronwoodBalance(synchronizer, sdkAccount),
+                                        observeIsSelected(sdkAccount, allSdkAccounts),
+                                    ) { saplingAddress, saplingBalance, ironwoodBalance, isSelected ->
+                                        SaplingAndSelectionSnapshot(
+                                            saplingAddress = saplingAddress,
+                                            saplingBalance = saplingBalance,
+                                            ironwoodBalance = ironwoodBalance,
+                                            isSelected = isSelected,
+                                        )
+                                    }
+                                combine(unifiedAndTransparent, saplingAndSelection) { primary, secondary ->
                                     when (sdkAccount.keySource?.lowercase()) {
                                         KEYSTONE_KEYSOURCE -> {
                                             KeystoneAccount(
                                                 sdkAccount = sdkAccount,
-                                                unified = unified,
-                                                ironwoodBalance = ironwoodBalance,
-                                                transparent = transparent,
-                                                isSelected = isSelected,
+                                                unifiedAddress = primary.unifiedAddress,
+                                                unifiedBalance = primary.unifiedBalance,
+                                                orchardBalance = primary.orchardBalance,
+                                                ironwoodBalance = secondary.ironwoodBalance,
+                                                transparentAddress = primary.transparentAddress,
+                                                transparentBalance = primary.transparentBalance,
+                                                isSelected = secondary.isSelected,
                                             )
                                         }
 
                                         else -> {
                                             ZashiAccount(
                                                 sdkAccount = sdkAccount,
-                                                unified = unified,
-                                                transparent = transparent,
-                                                sapling = sapling!!,
-                                                ironwoodBalance = ironwoodBalance,
-                                                isSelected = isSelected,
+                                                unifiedAddress = primary.unifiedAddress,
+                                                unifiedBalance = primary.unifiedBalance,
+                                                orchardBalance = primary.orchardBalance,
+                                                saplingAddress = secondary.saplingAddress!!,
+                                                saplingBalance = secondary.saplingBalance,
+                                                ironwoodBalance = secondary.ironwoodBalance,
+                                                transparentAddress = primary.transparentAddress,
+                                                transparentBalance = primary.transparentBalance,
+                                                isSelected = secondary.isSelected,
                                             )
                                         }
                                     }
@@ -225,7 +260,7 @@ class AccountDataSourceImpl(
                     log("failed to receive address for $accountUuid", e)
                 }
             }.join()
-        return (result ?: getSelectedAccount().unified.address).also {
+        return (result ?: getSelectedAccount().unifiedAddress).also {
             log("returning address ${it.address}")
         }
     }
@@ -260,7 +295,7 @@ class AccountDataSourceImpl(
             }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun observeUnified(synchronizer: Synchronizer, sdkAccount: Account): Flow<UnifiedInfo> {
+    private fun observeUnifiedAddress(synchronizer: Synchronizer, sdkAccount: Account): Flow<WalletAddress.Unified> {
         suspend fun rotateAddress(): WalletAddress.Unified {
             log("deriving unified address for ${sdkAccount.accountUuid}")
 
@@ -281,83 +316,98 @@ class AccountDataSourceImpl(
             return address
         }
 
-        val addressFlow =
-            channelFlow {
-                send(rotateAddress())
+        return channelFlow {
+            send(rotateAddress())
 
-                launch {
-                    requestNextShieldedAddressChannel
-                        .filter { it.accountUuid == sdkAccount.accountUuid }
-                        .collect {
-                            val address =
-                                try {
-                                    rotateAddress()
-                                } catch (e: CancellationException) {
-                                    throw e
-                                } catch (e: Exception) {
-                                    it.responseChannel.close(e)
-                                    throw e
-                                }
-                            send(address)
+            launch {
+                requestNextShieldedAddressChannel
+                    .filter { it.accountUuid == sdkAccount.accountUuid }
+                    .collect {
+                        val address =
                             try {
-                                it.responseChannel.send(address)
-                                it.responseChannel.close()
-                            } catch (_: ClosedSendChannelException) {
-                                // ignore
+                                rotateAddress()
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Exception) {
+                                it.responseChannel.close(e)
+                                throw e
                             }
+                        send(address)
+                        try {
+                            it.responseChannel.send(address)
+                            it.responseChannel.close()
+                        } catch (_: ClosedSendChannelException) {
+                            // ignore
                         }
-                }
-
-                awaitClose()
-            }.retryWhen { cause, attempt ->
-                log(
-                    "retrying address derivation for ${sdkAccount.accountUuid}, attempt $attempt",
-                    cause as? Exception
-                )
-                delay(attempt.coerceAtMost(RETRY_DELAY).seconds)
-                true
+                    }
             }
 
-        val balanceFlow =
-            synchronizer.walletBalances
-                .map { balances ->
-                    balances?.get(sdkAccount.accountUuid)?.let { balance -> balance.orchard + balance.ironwood }
-                }
-
-        return combine(addressFlow, balanceFlow) { address, balance ->
-            UnifiedInfo(address = address, balance = balance)
+            awaitClose()
+        }.retryWhen { cause, attempt ->
+            log(
+                "retrying address derivation for ${sdkAccount.accountUuid}, attempt $attempt",
+                cause as? Exception
+            )
+            delay(attempt.coerceAtMost(RETRY_DELAY).seconds)
+            true
         }
     }
 
-    private fun observeTransparent(synchronizer: Synchronizer, sdkAccount: Account): Flow<TransparentInfo> {
-        val transparentAddress =
+    /**
+     * Folds Orchard + Ironwood together — see [WalletAccount.unifiedBalance].
+     */
+    private fun observeUnifiedBalance(synchronizer: Synchronizer, sdkAccount: Account): Flow<WalletBalance?> =
+        synchronizer.walletBalances
+            .map { balances ->
+                balances?.get(sdkAccount.accountUuid)?.let { balance -> balance.orchard + balance.ironwood }
+            }
+
+    private fun observeOrchardBalance(synchronizer: Synchronizer, sdkAccount: Account): Flow<WalletBalance?> =
+        synchronizer.walletBalances
+            .map { balances ->
+                balances?.get(sdkAccount.accountUuid)?.orchard
+            }
+
+    private fun observeTransparentAddress(
+        synchronizer: Synchronizer,
+        sdkAccount: Account
+    ): Flow<WalletAddress.Transparent> =
+        flow {
+            emit(WalletAddress.Transparent.new(synchronizer.getTransparentAddress(sdkAccount)))
+        }.retryWhen { _, attempt ->
+            delay(attempt.coerceAtMost(RETRY_DELAY).seconds)
+            true
+        }
+
+    private fun observeTransparentBalance(synchronizer: Synchronizer, sdkAccount: Account): Flow<Zatoshi?> =
+        synchronizer.walletBalances
+            .map { balances ->
+                balances?.get(sdkAccount.accountUuid)?.unshielded
+            }
+
+    private fun observeSaplingAddress(
+        synchronizer: Synchronizer,
+        sdkAccount: Account
+    ): Flow<WalletAddress.Sapling?> =
+        if (sdkAccount.keySource == KEYSTONE_KEYSOURCE) {
+            flowOf(null)
+        } else {
             flow {
-                emit(WalletAddress.Transparent.new(synchronizer.getTransparentAddress(sdkAccount)))
+                emit(WalletAddress.Sapling.new(synchronizer.getSaplingAddress(sdkAccount)))
             }.retryWhen { _, attempt ->
                 delay(attempt.coerceAtMost(RETRY_DELAY).seconds)
                 true
             }
-        return combine(transparentAddress, synchronizer.walletBalances) { address, balances ->
-            val balance = balances?.get(sdkAccount.accountUuid)
-            TransparentInfo(address = address, balance = balance?.unshielded)
         }
-    }
 
-    private fun observeSapling(synchronizer: Synchronizer, sdkAccount: Account): Flow<SaplingInfo?> =
+    private fun observeSaplingBalance(synchronizer: Synchronizer, sdkAccount: Account): Flow<WalletBalance?> =
         if (sdkAccount.keySource == KEYSTONE_KEYSOURCE) {
             flowOf(null)
         } else {
-            val saplingAddress =
-                flow {
-                    emit(WalletAddress.Sapling.new(synchronizer.getSaplingAddress(sdkAccount)))
-                }.retryWhen { _, attempt ->
-                    delay(attempt.coerceAtMost(RETRY_DELAY).seconds)
-                    true
+            synchronizer.walletBalances
+                .map { balances ->
+                    balances?.get(sdkAccount.accountUuid)?.sapling
                 }
-            combine(saplingAddress, synchronizer.walletBalances) { address, balances ->
-                val balance = balances?.get(sdkAccount.accountUuid)
-                SaplingInfo(address = address, balance = balance?.sapling)
-            }
         }
 
     /**
@@ -383,13 +433,29 @@ private data class AddressRequest(
     val responseChannel: Channel<WalletAddress.Unified>
 )
 
+private data class UnifiedAndTransparentSnapshot(
+    val unifiedAddress: WalletAddress.Unified,
+    val unifiedBalance: WalletBalance?,
+    val orchardBalance: WalletBalance?,
+    val transparentAddress: WalletAddress.Transparent,
+    val transparentBalance: Zatoshi?,
+)
+
+private data class SaplingAndSelectionSnapshot(
+    val saplingAddress: WalletAddress.Sapling?,
+    val saplingBalance: WalletBalance?,
+    val ironwoodBalance: WalletBalance?,
+    val isSelected: Boolean,
+)
+
 private const val RETRY_DELAY = 3L
 
 /**
  * Upper bound on how long [AccountDataSourceImpl.requestNextShieldedAddress] waits for
- * [AccountDataSourceImpl.observeUnified]'s collector to deliver a rotated address. The collector
- * can be unsubscribed during a [kotlinx.coroutines.flow.retryWhen] backoff, so an unbounded wait
- * can hang indefinitely; on timeout the caller falls back to the account's current address.
+ * [AccountDataSourceImpl.observeUnifiedAddress]'s collector to deliver a rotated address. The
+ * collector can be unsubscribed during a [kotlinx.coroutines.flow.retryWhen] backoff, so an
+ * unbounded wait can hang indefinitely; on timeout the caller falls back to the account's current
+ * address.
  */
 private val ADDRESS_REQUEST_TIMEOUT = 15.seconds
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
@@ -21,8 +21,10 @@ import co.electriccoin.zcash.ui.common.model.TransparentInfo
 import co.electriccoin.zcash.ui.common.model.UnifiedInfo
 import co.electriccoin.zcash.ui.common.model.WalletAccount
 import co.electriccoin.zcash.ui.common.model.ZashiAccount
+import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
 import co.electriccoin.zcash.ui.common.provider.SelectedAccountUUIDProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import co.electriccoin.zcash.ui.common.provider.retainWhileWalletExists
 import co.electriccoin.zcash.ui.design.util.combineToFlow
 import co.electriccoin.zcash.ui.util.loggableNot
 import kotlinx.coroutines.CancellationException
@@ -88,6 +90,7 @@ interface AccountDataSource {
 class AccountDataSourceImpl(
     private val synchronizerProvider: SynchronizerProvider,
     private val selectedAccountUUIDProvider: SelectedAccountUUIDProvider,
+    private val persistableWalletProvider: PersistableWalletProvider,
     private val context: Context,
 ) : AccountDataSource {
     private val log = loggableNot("AccountDataSource")
@@ -98,7 +101,7 @@ class AccountDataSourceImpl(
     @OptIn(ExperimentalCoroutinesApi::class)
     override val allAccounts: StateFlow<List<WalletAccount>?> =
         synchronizerProvider
-            .retainedSynchronizer
+            .synchronizer
             .flatMapLatest { synchronizer ->
                 synchronizer
                     ?.accountsFlow
@@ -140,6 +143,7 @@ class AccountDataSourceImpl(
                     }
                     ?: flowOf(null)
             }.map { it?.sortedDescending() }
+            .retainWhileWalletExists(persistableWalletProvider)
             .stateIn(
                 scope = scope,
                 started = SharingStarted.Eagerly,

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
@@ -98,7 +98,7 @@ class AccountDataSourceImpl(
     @OptIn(ExperimentalCoroutinesApi::class)
     override val allAccounts: StateFlow<List<WalletAccount>?> =
         synchronizerProvider
-            .synchronizer
+            .retainedSynchronizer
             .flatMapLatest { synchronizer ->
                 synchronizer
                     ?.accountsFlow

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSource.kt
@@ -98,6 +98,11 @@ class AccountDataSourceImpl(
 
     private val requestNextShieldedAddressChannel = MutableSharedFlow<AddressRequest>()
 
+    /**
+     * A null balances snapshot from the synchronizer must yield no emission (or null for
+     * [allAccounts] itself), never fabricated zeros — zeros are a truth claim about wallet state,
+     * while null means the data simply is not loaded yet.
+     */
     @OptIn(ExperimentalCoroutinesApi::class)
     override val allAccounts: StateFlow<List<WalletAccount>?> =
         synchronizerProvider
@@ -316,9 +321,9 @@ class AccountDataSourceImpl(
 
         val balanceFlow =
             synchronizer.walletBalances
-                .map {
-                    it
-                        ?.get(sdkAccount.accountUuid)
+                .filterNotNull()
+                .map { balances ->
+                    balances[sdkAccount.accountUuid]
                         ?.let { balance -> balance.orchard + balance.ironwood }
                         ?: createEmptyWalletBalance()
                 }
@@ -336,8 +341,8 @@ class AccountDataSourceImpl(
                 delay(attempt.coerceAtMost(RETRY_DELAY).seconds)
                 true
             }
-        return combine(transparentAddress, synchronizer.walletBalances) { address, balances ->
-            val balance = balances?.get(sdkAccount.accountUuid)
+        return combine(transparentAddress, synchronizer.walletBalances.filterNotNull()) { address, balances ->
+            val balance = balances[sdkAccount.accountUuid]
             TransparentInfo(address = address, balance = balance?.unshielded ?: Zatoshi.ZERO)
         }
     }
@@ -353,8 +358,8 @@ class AccountDataSourceImpl(
                     delay(attempt.coerceAtMost(RETRY_DELAY).seconds)
                     true
                 }
-            combine(saplingAddress, synchronizer.walletBalances) { address, balances ->
-                val balance = balances?.get(sdkAccount.accountUuid)
+            combine(saplingAddress, synchronizer.walletBalances.filterNotNull()) { address, balances ->
+                val balance = balances[sdkAccount.accountUuid]
                 SaplingInfo(address = address, balance = balance?.sapling ?: createEmptyWalletBalance())
             }
         }
@@ -362,9 +367,11 @@ class AccountDataSourceImpl(
     // Ironwood shares the same unified address as Orchard (no address of its own to observe) —
     // just its balance.
     private fun observeIronwoodBalance(synchronizer: Synchronizer, sdkAccount: Account): Flow<WalletBalance> =
-        synchronizer.walletBalances.map { balances ->
-            balances?.get(sdkAccount.accountUuid)?.ironwood ?: createEmptyWalletBalance()
-        }
+        synchronizer.walletBalances
+            .filterNotNull()
+            .map { balances ->
+                balances[sdkAccount.accountUuid]?.ironwood ?: createEmptyWalletBalance()
+            }
 
     private fun createEmptyWalletBalance() = WalletBalance(Zatoshi.ZERO, Zatoshi.ZERO, Zatoshi.ZERO)
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/WalletSnapshotDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/WalletSnapshotDataSource.kt
@@ -1,6 +1,5 @@
 package co.electriccoin.zcash.ui.common.datasource
 
-import cash.z.ecc.sdk.ANDROID_STATE_FLOW_TIMEOUT
 import co.electriccoin.zcash.ui.common.model.WalletSnapshot
 import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
@@ -12,7 +11,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -69,7 +67,7 @@ class WalletSnapshotDataSourceImpl(
             }.retainWhileWalletExists(persistableWalletProvider)
             .stateIn(
                 scope = scope,
-                started = SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
+                started = SharingStarted.Eagerly,
                 initialValue = null
             )
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/WalletSnapshotDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/WalletSnapshotDataSource.kt
@@ -29,7 +29,7 @@ class WalletSnapshotDataSourceImpl(
     @OptIn(ExperimentalCoroutinesApi::class)
     val flow =
         synchronizerProvider
-            .synchronizer
+            .retainedSynchronizer
             .flatMapLatest { synchronizer ->
                 if (synchronizer == null) {
                     flowOf(null)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/WalletSnapshotDataSource.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/datasource/WalletSnapshotDataSource.kt
@@ -2,8 +2,10 @@ package co.electriccoin.zcash.ui.common.datasource
 
 import cash.z.ecc.sdk.ANDROID_STATE_FLOW_TIMEOUT
 import co.electriccoin.zcash.ui.common.model.WalletSnapshot
+import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import co.electriccoin.zcash.ui.common.provider.WalletRestoringStateProvider
+import co.electriccoin.zcash.ui.common.provider.retainWhileWalletExists
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -23,13 +25,14 @@ interface WalletSnapshotDataSource {
 class WalletSnapshotDataSourceImpl(
     synchronizerProvider: SynchronizerProvider,
     walletRestoringStateProvider: WalletRestoringStateProvider,
+    persistableWalletProvider: PersistableWalletProvider,
 ) : WalletSnapshotDataSource {
     private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val flow =
         synchronizerProvider
-            .retainedSynchronizer
+            .synchronizer
             .flatMapLatest { synchronizer ->
                 if (synchronizer == null) {
                     flowOf(null)
@@ -63,7 +66,8 @@ class WalletSnapshotDataSourceImpl(
                         snapshot.copy(blocksRemaining = blocksRemaining)
                     }
                 }
-            }.stateIn(
+            }.retainWhileWalletExists(persistableWalletProvider)
+            .stateIn(
                 scope = scope,
                 started = SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
                 initialValue = null

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/WalletAccount.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/WalletAccount.kt
@@ -2,7 +2,6 @@ package co.electriccoin.zcash.ui.common.model
 
 import androidx.annotation.DrawableRes
 import cash.z.ecc.android.sdk.model.Account
-import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.model.WalletBalance
 import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.android.sdk.model.Zip32AccountIndex
@@ -13,18 +12,20 @@ import co.electriccoin.zcash.ui.design.util.stringRes
 sealed interface WalletAccount : Comparable<WalletAccount> {
     val sdkAccount: Account
 
-    val unifiedAddress: WalletAddress.Unified
-    val transparentAddress: WalletAddress.Transparent
-    val saplingAddress: WalletAddress.Sapling?
+    val unifiedAddress: String
+    val transparentAddress: String
+    val saplingAddress: String?
 
     /**
      * TODO [#26]: technical debt, aggregates ORCHARD + IRONWOOD, sync with iOS
      *
-     * Folds Orchard + Ironwood together (see observeUnified in AccountDataSource). Callers that
-     * need the Orchard-only balance should use [orchardBalance] or GetOrchardBalanceUseCase, not
-     * this field. Null while the balance snapshot has not loaded yet.
+     * Folds Orchard + Ironwood together. Callers that need the Orchard-only balance should use
+     * [orchardBalance] or GetOrchardBalanceUseCase, not this field. Null while either contributing
+     * balance has not loaded yet — both pools come from the same `AccountBalance` entry, so their
+     * nullity coincides.
      */
     val unifiedBalance: WalletBalance?
+        get() = orchardBalance?.let { orchard -> ironwoodBalance?.let { ironwood -> orchard + ironwood } }
 
     /**
      * The Orchard-only balance, null while the balance snapshot has not loaded yet.
@@ -114,13 +115,12 @@ sealed interface WalletAccount : Comparable<WalletAccount> {
 
 data class ZashiAccount(
     override val sdkAccount: Account,
-    override val unifiedAddress: WalletAddress.Unified,
-    override val unifiedBalance: WalletBalance?,
+    override val unifiedAddress: String,
+    override val transparentAddress: String,
+    override val saplingAddress: String,
     override val orchardBalance: WalletBalance?,
-    override val saplingAddress: WalletAddress.Sapling,
     override val saplingBalance: WalletBalance?,
     override val ironwoodBalance: WalletBalance?,
-    override val transparentAddress: WalletAddress.Transparent,
     override val transparentBalance: Zatoshi?,
     override val isSelected: Boolean,
 ) : WalletAccount {
@@ -173,11 +173,10 @@ data class ZashiAccount(
 
 data class KeystoneAccount(
     override val sdkAccount: Account,
-    override val unifiedAddress: WalletAddress.Unified,
-    override val unifiedBalance: WalletBalance?,
+    override val unifiedAddress: String,
+    override val transparentAddress: String,
     override val orchardBalance: WalletBalance?,
     override val ironwoodBalance: WalletBalance?,
-    override val transparentAddress: WalletAddress.Transparent,
     override val transparentBalance: Zatoshi?,
     override val isSelected: Boolean,
 ) : WalletAccount {
@@ -187,7 +186,7 @@ data class KeystoneAccount(
     override val name: StringResource
         get() = stringRes(co.electriccoin.zcash.ui.R.string.accounts_keystone)
 
-    override val saplingAddress: WalletAddress.Sapling? = null
+    override val saplingAddress: String? = null
 
     override val saplingBalance: WalletBalance? = null
 
@@ -219,6 +218,19 @@ data class KeystoneAccount(
             is ZashiAccount -> -1
         }
 }
+
+/**
+ * Folds two balances together, e.g. to derive [WalletAccount.unifiedBalance] from Orchard +
+ * Ironwood. Includes [WalletBalance.locked] — unlike a naive total-only sum, the folded value
+ * doesn't silently drop it.
+ */
+private operator fun WalletBalance.plus(other: WalletBalance) =
+    WalletBalance(
+        available = available + other.available,
+        changePending = changePending + other.changePending,
+        valuePending = valuePending + other.valuePending,
+        locked = locked + other.locked,
+    )
 
 /**
  * The single spendability primitive the whole app validates against, so a typing-time check and the

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/WalletAccount.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/WalletAccount.kt
@@ -111,7 +111,42 @@ sealed interface WalletAccount : Comparable<WalletAccount> {
      * false.
      */
     fun canSpend(amount: Zatoshi): Boolean? = spendableShieldedBalance?.let { it >= amount }
+
+    /**
+     * This account's [LoadedAccountBalances], bundled once every contributing figure has loaded.
+     * Null while any of them has not loaded yet.
+     */
+    val loadedBalances: LoadedAccountBalances?
+        get() =
+            LoadedAccountBalances(
+                isAllShielded = isAllShielded ?: return null,
+                totalBalance = totalBalance ?: return null,
+                totalShieldedBalance = totalShieldedBalance ?: return null,
+                totalTransparentBalance = totalTransparentBalance ?: return null,
+                spendableShieldedBalance = spendableShieldedBalance ?: return null,
+                pendingShieldedBalance = pendingShieldedBalance ?: return null,
+                isShieldedPending = isShieldedPending ?: return null,
+                isShieldingAvailable = isShieldingAvailable ?: return null,
+                transparentBalance = transparentBalance ?: return null,
+            )
 }
+
+/**
+ * A [WalletAccount]'s derived balance figures, bundled once they have all loaded so callers work
+ * with plain non-null values instead of each re-deriving (and re-null-checking) the same figures
+ * individually.
+ */
+data class LoadedAccountBalances(
+    val isAllShielded: Boolean,
+    val totalBalance: Zatoshi,
+    val totalShieldedBalance: Zatoshi,
+    val totalTransparentBalance: Zatoshi,
+    val spendableShieldedBalance: Zatoshi,
+    val pendingShieldedBalance: Zatoshi,
+    val isShieldedPending: Boolean,
+    val isShieldingAvailable: Boolean,
+    val transparentBalance: Zatoshi,
+)
 
 data class ZashiAccount(
     override val sdkAccount: Account,
@@ -239,11 +274,3 @@ private operator fun WalletBalance.plus(other: WalletBalance) =
  * answers null — not yet known, never coerced to a definitive answer.
  */
 fun WalletAccount?.canSpend(amount: Zatoshi): Boolean? = if (this == null) false else canSpend(amount)
-
-/**
- * The spendable balance a screen may display for a possibly-not-yet-selected account. Null both
- * when no account is available and while the account's spendable balance has not loaded yet — the
- * UI's loading state consumes this, never zero.
- */
-val WalletAccount?.totalSpendableBalance: Zatoshi?
-    get() = this?.spendableShieldedBalance

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/WalletAccount.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/WalletAccount.kt
@@ -16,12 +16,15 @@ sealed interface WalletAccount : Comparable<WalletAccount> {
     val unified: UnifiedInfo
     val sapling: SaplingInfo?
 
-    // Ironwood shares the same unified address as Orchard (no address of its own), so this is a
-    // plain balance, not an address-carrying *Info like sapling/transparent/unified. Note that
-    // `unified`'s *balance* folds Orchard + Ironwood together (see observeUnified in
-    // AccountDataSource) — callers that need the Orchard-only balance should use
-    // GetOrchardBalanceUseCase, not this field or `unified`.
-    val ironwoodBalance: WalletBalance
+    /**
+     * Ironwood shares the same unified address as Orchard (no address of its own), so this is a
+     * plain balance, not an address-carrying *Info like sapling/transparent/unified. Note that
+     * `unified`'s *balance* folds Orchard + Ironwood together (see observeUnified in
+     * AccountDataSource) — callers that need the Orchard-only balance should use
+     * GetOrchardBalanceUseCase, not this field or `unified`. Null while the balance snapshot has
+     * not loaded yet.
+     */
+    val ironwoodBalance: WalletBalance?
     val transparent: TransparentInfo
     val isSelected: Boolean
     val name: StringResource
@@ -33,39 +36,48 @@ sealed interface WalletAccount : Comparable<WalletAccount> {
         get() = sdkAccount.hdAccountIndex!!
 
     /**
-     * Total transparent + total shielded balance.
+     * Total transparent + total shielded balance. Null while any contributing balance has not
+     * loaded yet.
      */
-    val totalBalance: Zatoshi
+    val totalBalance: Zatoshi?
 
     /**
-     * Total shielded balance including non-spendable.
+     * Total shielded balance including non-spendable. Null while any contributing balance has not
+     * loaded yet.
      */
-    val totalShieldedBalance: Zatoshi
+    val totalShieldedBalance: Zatoshi?
 
     /**
-     * Total spendable transparent balance.
+     * Total spendable transparent balance. Null while the transparent balance has not loaded yet.
      */
-    val totalTransparentBalance: Zatoshi
+    val totalTransparentBalance: Zatoshi?
 
     /**
-     * Spendable & available shielded balance. Might be smaller than total shielded balance.
+     * Spendable & available shielded balance. Might be smaller than total shielded balance. Null
+     * while any contributing balance has not loaded yet.
      */
-    val spendableShieldedBalance: Zatoshi
+    val spendableShieldedBalance: Zatoshi?
 
     /**
-     * Pending shielded Balance.
+     * Pending shielded Balance. Null while any contributing balance has not loaded yet.
      */
-    val pendingShieldedBalance: Zatoshi
+    val pendingShieldedBalance: Zatoshi?
 
-    val isShieldedPending: Boolean
-        get() = pendingShieldedBalance > Zatoshi(0)
+    val isShieldedPending: Boolean?
+        get() = pendingShieldedBalance?.let { it > Zatoshi(0) }
 
     @Suppress("MagicNumber")
-    val isShieldingAvailable: Boolean
-        get() = totalTransparentBalance > Zatoshi(100000L)
+    val isShieldingAvailable: Boolean?
+        get() = totalTransparentBalance?.let { it > Zatoshi(100000L) }
 
-    val isAllShielded: Boolean
+    val isAllShielded: Boolean?
         get() {
+            val totalBalance = totalBalance ?: return null
+            val spendableShieldedBalance = spendableShieldedBalance ?: return null
+            val totalShieldedBalance = totalShieldedBalance ?: return null
+            val totalTransparentBalance = totalTransparentBalance ?: return null
+            val isShieldingAvailable = isShieldingAvailable ?: return null
+
             val isAllShielded = totalBalance == spendableShieldedBalance
             val isAllShieldedWithTransparentDustLeft =
                 totalBalance > spendableShieldedBalance &&
@@ -76,14 +88,19 @@ sealed interface WalletAccount : Comparable<WalletAccount> {
             return isAllShielded || isAllShieldedWithTransparentDustLeft
         }
 
-    fun canSpend(amount: Zatoshi): Boolean = spendableShieldedBalance >= amount
+    /**
+     * Whether [amount] can currently be spent from this account. Null while the spendable shielded
+     * balance has not loaded yet — not enough information to answer, never coerced to true or
+     * false.
+     */
+    fun canSpend(amount: Zatoshi): Boolean? = spendableShieldedBalance?.let { it >= amount }
 }
 
 data class ZashiAccount(
     override val sdkAccount: Account,
     override val unified: UnifiedInfo, // TODO [#26]: technical debt, aggregates ORCHARD + IRONWOOD, sync with iOS
     override val sapling: SaplingInfo,
-    override val ironwoodBalance: WalletBalance,
+    override val ironwoodBalance: WalletBalance?,
     override val transparent: TransparentInfo,
     override val isSelected: Boolean,
 ) : WalletAccount {
@@ -93,24 +110,37 @@ data class ZashiAccount(
     override val icon: Int
         get() = R.drawable.ic_item_zashi
 
-    override val totalBalance: Zatoshi
-        get() = unified.balance.total + sapling.balance.total + transparent.balance
+    override val totalBalance: Zatoshi?
+        get() {
+            val unifiedTotal = unified.balance?.total ?: return null
+            val saplingTotal = sapling.balance?.total ?: return null
+            val transparentBalance = transparent.balance ?: return null
+            return unifiedTotal + saplingTotal + transparentBalance
+        }
 
-    override val totalShieldedBalance: Zatoshi
-        get() = unified.balance.total + sapling.balance.total
+    override val totalShieldedBalance: Zatoshi?
+        get() {
+            val unifiedTotal = unified.balance?.total ?: return null
+            val saplingTotal = sapling.balance?.total ?: return null
+            return unifiedTotal + saplingTotal
+        }
 
-    override val totalTransparentBalance: Zatoshi
+    override val totalTransparentBalance: Zatoshi?
         get() = transparent.balance
 
-    override val spendableShieldedBalance: Zatoshi
-        get() = unified.balance.available + sapling.balance.available
-
-    override val pendingShieldedBalance: Zatoshi
+    override val spendableShieldedBalance: Zatoshi?
         get() {
-            val changePendingShieldedBalance =
-                unified.balance.changePending + sapling.balance.changePending
-            val valuePendingShieldedBalance =
-                unified.balance.valuePending + sapling.balance.valuePending
+            val unifiedAvailable = unified.balance?.available ?: return null
+            val saplingAvailable = sapling.balance?.available ?: return null
+            return unifiedAvailable + saplingAvailable
+        }
+
+    override val pendingShieldedBalance: Zatoshi?
+        get() {
+            val unifiedBalance = unified.balance ?: return null
+            val saplingBalance = sapling.balance ?: return null
+            val changePendingShieldedBalance = unifiedBalance.changePending + saplingBalance.changePending
+            val valuePendingShieldedBalance = unifiedBalance.valuePending + saplingBalance.valuePending
             return changePendingShieldedBalance + valuePendingShieldedBalance
         }
 
@@ -124,7 +154,7 @@ data class ZashiAccount(
 data class KeystoneAccount(
     override val sdkAccount: Account,
     override val unified: UnifiedInfo,
-    override val ironwoodBalance: WalletBalance,
+    override val ironwoodBalance: WalletBalance?,
     override val transparent: TransparentInfo,
     override val isSelected: Boolean,
 ) : WalletAccount {
@@ -136,22 +166,27 @@ data class KeystoneAccount(
 
     override val sapling: SaplingInfo? = null
 
-    override val totalBalance: Zatoshi
-        get() = unified.balance.total + transparent.balance
+    override val totalBalance: Zatoshi?
+        get() {
+            val unifiedTotal = unified.balance?.total ?: return null
+            val transparentBalance = transparent.balance ?: return null
+            return unifiedTotal + transparentBalance
+        }
 
-    override val totalShieldedBalance: Zatoshi
-        get() = unified.balance.total
+    override val totalShieldedBalance: Zatoshi?
+        get() = unified.balance?.total
 
-    override val totalTransparentBalance: Zatoshi
+    override val totalTransparentBalance: Zatoshi?
         get() = transparent.balance
 
-    override val spendableShieldedBalance: Zatoshi
-        get() = unified.balance.available
+    override val spendableShieldedBalance: Zatoshi?
+        get() = unified.balance?.available
 
-    override val pendingShieldedBalance: Zatoshi
-        get() =
-            unified.balance.changePending +
-                unified.balance.valuePending
+    override val pendingShieldedBalance: Zatoshi?
+        get() {
+            val unifiedBalance = unified.balance ?: return null
+            return unifiedBalance.changePending + unifiedBalance.valuePending
+        }
 
     override fun compareTo(other: WalletAccount) =
         when (other) {
@@ -162,29 +197,31 @@ data class KeystoneAccount(
 
 data class UnifiedInfo(
     val address: WalletAddress.Unified,
-    val balance: WalletBalance
+    val balance: WalletBalance?
 )
 
 data class TransparentInfo(
     val address: WalletAddress.Transparent,
-    val balance: Zatoshi
+    val balance: Zatoshi?
 )
 
 data class SaplingInfo(
     val address: WalletAddress.Sapling,
-    val balance: WalletBalance
+    val balance: WalletBalance?
 )
 
 /**
  * The single spendability primitive the whole app validates against, so a typing-time check and the
- * proposal-time check in the SDK can never disagree. A null receiver (no account selected yet) can
- * spend nothing.
+ * proposal-time check in the SDK can never disagree. A null receiver (no account selected yet)
+ * definitively can spend nothing; a present account whose spendable balance has not loaded yet
+ * answers null — not yet known, never coerced to a definitive answer.
  */
-fun WalletAccount?.canSpend(amount: Zatoshi): Boolean = this?.canSpend(amount) ?: false
+fun WalletAccount?.canSpend(amount: Zatoshi): Boolean? = if (this == null) false else canSpend(amount)
 
 /**
- * The spendable balance a screen may display for a possibly-not-yet-selected account, zero when no
- * account is available.
+ * The spendable balance a screen may display for a possibly-not-yet-selected account. Null both
+ * when no account is available and while the account's spendable balance has not loaded yet — the
+ * UI's loading state consumes this, never zero.
  */
-val WalletAccount?.totalSpendableBalance: Zatoshi
-    get() = this?.spendableShieldedBalance ?: Zatoshi(0)
+val WalletAccount?.totalSpendableBalance: Zatoshi?
+    get() = this?.spendableShieldedBalance

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/WalletAccount.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/model/WalletAccount.kt
@@ -13,19 +13,35 @@ import co.electriccoin.zcash.ui.design.util.stringRes
 sealed interface WalletAccount : Comparable<WalletAccount> {
     val sdkAccount: Account
 
-    val unified: UnifiedInfo
-    val sapling: SaplingInfo?
+    val unifiedAddress: WalletAddress.Unified
+    val transparentAddress: WalletAddress.Transparent
+    val saplingAddress: WalletAddress.Sapling?
 
     /**
-     * Ironwood shares the same unified address as Orchard (no address of its own), so this is a
-     * plain balance, not an address-carrying *Info like sapling/transparent/unified. Note that
-     * `unified`'s *balance* folds Orchard + Ironwood together (see observeUnified in
-     * AccountDataSource) — callers that need the Orchard-only balance should use
-     * GetOrchardBalanceUseCase, not this field or `unified`. Null while the balance snapshot has
-     * not loaded yet.
+     * TODO [#26]: technical debt, aggregates ORCHARD + IRONWOOD, sync with iOS
+     *
+     * Folds Orchard + Ironwood together (see observeUnified in AccountDataSource). Callers that
+     * need the Orchard-only balance should use [orchardBalance] or GetOrchardBalanceUseCase, not
+     * this field. Null while the balance snapshot has not loaded yet.
+     */
+    val unifiedBalance: WalletBalance?
+
+    /**
+     * The Orchard-only balance, null while the balance snapshot has not loaded yet.
+     */
+    val orchardBalance: WalletBalance?
+
+    /**
+     * Null for Keystone accounts, and while the balance snapshot has not loaded yet.
+     */
+    val saplingBalance: WalletBalance?
+
+    /**
+     * Ironwood shares the same unified address as Orchard (no address of its own). Null while the
+     * balance snapshot has not loaded yet.
      */
     val ironwoodBalance: WalletBalance?
-    val transparent: TransparentInfo
+    val transparentBalance: Zatoshi?
     val isSelected: Boolean
     val name: StringResource
 
@@ -98,10 +114,14 @@ sealed interface WalletAccount : Comparable<WalletAccount> {
 
 data class ZashiAccount(
     override val sdkAccount: Account,
-    override val unified: UnifiedInfo, // TODO [#26]: technical debt, aggregates ORCHARD + IRONWOOD, sync with iOS
-    override val sapling: SaplingInfo,
+    override val unifiedAddress: WalletAddress.Unified,
+    override val unifiedBalance: WalletBalance?,
+    override val orchardBalance: WalletBalance?,
+    override val saplingAddress: WalletAddress.Sapling,
+    override val saplingBalance: WalletBalance?,
     override val ironwoodBalance: WalletBalance?,
-    override val transparent: TransparentInfo,
+    override val transparentAddress: WalletAddress.Transparent,
+    override val transparentBalance: Zatoshi?,
     override val isSelected: Boolean,
 ) : WalletAccount {
     override val name: StringResource
@@ -112,35 +132,35 @@ data class ZashiAccount(
 
     override val totalBalance: Zatoshi?
         get() {
-            val unifiedTotal = unified.balance?.total ?: return null
-            val saplingTotal = sapling.balance?.total ?: return null
-            val transparentBalance = transparent.balance ?: return null
-            return unifiedTotal + saplingTotal + transparentBalance
+            val unifiedTotal = unifiedBalance?.total ?: return null
+            val saplingTotal = saplingBalance?.total ?: return null
+            val transparent = transparentBalance ?: return null
+            return unifiedTotal + saplingTotal + transparent
         }
 
     override val totalShieldedBalance: Zatoshi?
         get() {
-            val unifiedTotal = unified.balance?.total ?: return null
-            val saplingTotal = sapling.balance?.total ?: return null
+            val unifiedTotal = unifiedBalance?.total ?: return null
+            val saplingTotal = saplingBalance?.total ?: return null
             return unifiedTotal + saplingTotal
         }
 
     override val totalTransparentBalance: Zatoshi?
-        get() = transparent.balance
+        get() = transparentBalance
 
     override val spendableShieldedBalance: Zatoshi?
         get() {
-            val unifiedAvailable = unified.balance?.available ?: return null
-            val saplingAvailable = sapling.balance?.available ?: return null
+            val unifiedAvailable = unifiedBalance?.available ?: return null
+            val saplingAvailable = saplingBalance?.available ?: return null
             return unifiedAvailable + saplingAvailable
         }
 
     override val pendingShieldedBalance: Zatoshi?
         get() {
-            val unifiedBalance = unified.balance ?: return null
-            val saplingBalance = sapling.balance ?: return null
-            val changePendingShieldedBalance = unifiedBalance.changePending + saplingBalance.changePending
-            val valuePendingShieldedBalance = unifiedBalance.valuePending + saplingBalance.valuePending
+            val unified = unifiedBalance ?: return null
+            val sapling = saplingBalance ?: return null
+            val changePendingShieldedBalance = unified.changePending + sapling.changePending
+            val valuePendingShieldedBalance = unified.valuePending + sapling.valuePending
             return changePendingShieldedBalance + valuePendingShieldedBalance
         }
 
@@ -153,9 +173,12 @@ data class ZashiAccount(
 
 data class KeystoneAccount(
     override val sdkAccount: Account,
-    override val unified: UnifiedInfo,
+    override val unifiedAddress: WalletAddress.Unified,
+    override val unifiedBalance: WalletBalance?,
+    override val orchardBalance: WalletBalance?,
     override val ironwoodBalance: WalletBalance?,
-    override val transparent: TransparentInfo,
+    override val transparentAddress: WalletAddress.Transparent,
+    override val transparentBalance: Zatoshi?,
     override val isSelected: Boolean,
 ) : WalletAccount {
     override val icon: Int
@@ -164,28 +187,30 @@ data class KeystoneAccount(
     override val name: StringResource
         get() = stringRes(co.electriccoin.zcash.ui.R.string.accounts_keystone)
 
-    override val sapling: SaplingInfo? = null
+    override val saplingAddress: WalletAddress.Sapling? = null
+
+    override val saplingBalance: WalletBalance? = null
 
     override val totalBalance: Zatoshi?
         get() {
-            val unifiedTotal = unified.balance?.total ?: return null
-            val transparentBalance = transparent.balance ?: return null
-            return unifiedTotal + transparentBalance
+            val unifiedTotal = unifiedBalance?.total ?: return null
+            val transparent = transparentBalance ?: return null
+            return unifiedTotal + transparent
         }
 
     override val totalShieldedBalance: Zatoshi?
-        get() = unified.balance?.total
+        get() = unifiedBalance?.total
 
     override val totalTransparentBalance: Zatoshi?
-        get() = transparent.balance
+        get() = transparentBalance
 
     override val spendableShieldedBalance: Zatoshi?
-        get() = unified.balance?.available
+        get() = unifiedBalance?.available
 
     override val pendingShieldedBalance: Zatoshi?
         get() {
-            val unifiedBalance = unified.balance ?: return null
-            return unifiedBalance.changePending + unifiedBalance.valuePending
+            val unified = unifiedBalance ?: return null
+            return unified.changePending + unified.valuePending
         }
 
     override fun compareTo(other: WalletAccount) =
@@ -194,21 +219,6 @@ data class KeystoneAccount(
             is ZashiAccount -> -1
         }
 }
-
-data class UnifiedInfo(
-    val address: WalletAddress.Unified,
-    val balance: WalletBalance?
-)
-
-data class TransparentInfo(
-    val address: WalletAddress.Transparent,
-    val balance: Zatoshi?
-)
-
-data class SaplingInfo(
-    val address: WalletAddress.Sapling,
-    val balance: WalletBalance?
-)
 
 /**
  * The single spendability primitive the whole app validates against, so a typing-time check and the

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SynchronizerProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SynchronizerProvider.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -42,8 +41,9 @@ interface SynchronizerProvider {
      * `null` every time the synchronizer is rebuilt (e.g. an automatic server switch tears down
      * and reconstructs the whole engine), which would otherwise flash every balance display
      * (top-line, per-pool breakdown) to 0.000 for the few seconds the new instance takes to
-     * re-establish itself. This retains the last known non-null value across that gap so
-     * consumers never observe a spurious drop to zero. Central here (rather than patched into
+     * re-establish itself. Retained across that gap via [retainWhileWalletExists] (MOB-1723), so
+     * consumers never observe a spurious drop to zero, while the value clears as soon as the
+     * wallet is removed. Central here (rather than patched into
      * each consumer) since [AccountDataSource], [co.electriccoin.zcash.ui.common.usecase.GetBalancePoolsUseCase],
      * [co.electriccoin.zcash.ui.common.usecase.GetOrchardBalanceUseCase] and
      * [co.electriccoin.zcash.ui.common.viewmodel.WalletViewModel] all read this independently.
@@ -109,13 +109,10 @@ class SynchronizerProviderImpl(
                 initialValue = walletCoordinator.synchronizer.value
             )
 
-    private val lastKnownWalletBalances = MutableStateFlow<Map<AccountUuid, AccountBalance>?>(null)
-
     override val walletBalances: Flow<Map<AccountUuid, AccountBalance>?> =
         synchronizer
             .flatMapLatest { it?.walletBalances ?: flowOf(null) }
-            .onEach { if (it != null) lastKnownWalletBalances.value = it }
-            .map { it ?: lastKnownWalletBalances.value }
+            .retainWhileWalletExists(persistableWalletProvider)
 
     init {
         scope.launch {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SynchronizerProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SynchronizerProvider.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
@@ -25,6 +26,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -34,6 +36,12 @@ interface SynchronizerProvider {
     val error: StateFlow<SynchronizerError?>
 
     val synchronizer: StateFlow<Synchronizer?>
+
+    /**
+     * UI-facing synchronizer state that retains the last instance during a rebuild. It clears when
+     * the wallet is removed and is replaced as soon as the coordinator publishes a new instance.
+     */
+    val retainedSynchronizer: StateFlow<Synchronizer?>
 
     /**
      * MOB-1664: [Synchronizer.walletBalances] is per-synchronizer-instance state that resets to
@@ -106,6 +114,20 @@ class SynchronizerProviderImpl(
                 started = SharingStarted.Lazily,
                 initialValue = walletCoordinator.synchronizer.value
             )
+
+    override val retainedSynchronizer: StateFlow<Synchronizer?> =
+        combine(
+            synchronizer,
+            persistableWalletProvider.persistableWallet.map { it != null }.distinctUntilChanged(),
+        ) { current, hasWallet ->
+            current to hasWallet
+        }.scan(synchronizer.value) { retained, (current, hasWallet) ->
+            resolveRetainedSynchronizer(retained, current, hasWallet)
+        }.stateIn(
+            scope = scope,
+            started = SharingStarted.Eagerly,
+            initialValue = synchronizer.value
+        )
 
     private val lastKnownWalletBalances = MutableStateFlow<Map<AccountUuid, AccountBalance>?>(null)
 
@@ -182,3 +204,14 @@ class SynchronizerProviderImpl(
         return pipeline
     }
 }
+
+internal fun resolveRetainedSynchronizer(
+    retained: Synchronizer?,
+    current: Synchronizer?,
+    hasWallet: Boolean,
+): Synchronizer? =
+    when {
+        !hasWallet -> null
+        current != null -> current
+        else -> retained
+    }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SynchronizerProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SynchronizerProvider.kt
@@ -2,6 +2,8 @@ package co.electriccoin.zcash.ui.common.provider
 
 import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.WalletCoordinator
+import cash.z.ecc.android.sdk.model.AccountBalance
+import cash.z.ecc.android.sdk.model.AccountUuid
 import co.electriccoin.zcash.spackle.Twig
 import co.electriccoin.zcash.ui.common.migration.MigrationSyncedHook
 import co.electriccoin.zcash.ui.common.model.SynchronizerError
@@ -21,6 +23,7 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
@@ -171,6 +174,12 @@ class SynchronizerProviderImpl(
  * MOB-1664 is the balance-flash precedent this generalizes: [Synchronizer.walletBalances] resets
  * to `null` on every rebuild, which used to flash balance displays to 0.000 for the few seconds a
  * new instance takes to re-establish itself.
+ *
+ * The retained value lives in this operator's [kotlinx.coroutines.flow.scan] accumulator, which is
+ * per-collection: under [kotlinx.coroutines.flow.stateIn] it must be paired with
+ * [kotlinx.coroutines.flow.SharingStarted.Eagerly], never `WhileSubscribed` — a `WhileSubscribed`
+ * restart tears down that collection and starts a fresh one, discarding the retained value and
+ * re-emitting the seed null.
  */
 internal fun <T : Any> Flow<T?>.retainWhileWalletExists(
     persistableWalletProvider: PersistableWalletProvider
@@ -194,3 +203,13 @@ internal fun <T : Any> resolveRetained(
         current != null -> current
         else -> retained
     }
+
+/**
+ * The raw per-instance wallet balances, keyed by account. Null while the synchronizer is absent or
+ * has not loaded a balance snapshot yet. Retention is the caller's choice — this is the shared seam
+ * every balance-observing use case reads from instead of copying its own
+ * `synchronizer.flatMapLatest { it?.walletBalances ?: flowOf(null) }`.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+internal fun SynchronizerProvider.rawWalletBalances(): Flow<Map<AccountUuid, AccountBalance>?> =
+    synchronizer.flatMapLatest { it?.walletBalances ?: flowOf(null) }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SynchronizerProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SynchronizerProvider.kt
@@ -38,12 +38,6 @@ interface SynchronizerProvider {
     val synchronizer: StateFlow<Synchronizer?>
 
     /**
-     * UI-facing synchronizer state that retains the last instance during a rebuild. It clears when
-     * the wallet is removed and is replaced as soon as the coordinator publishes a new instance.
-     */
-    val retainedSynchronizer: StateFlow<Synchronizer?>
-
-    /**
      * MOB-1664: [Synchronizer.walletBalances] is per-synchronizer-instance state that resets to
      * `null` every time the synchronizer is rebuilt (e.g. an automatic server switch tears down
      * and reconstructs the whole engine), which would otherwise flash every balance display
@@ -114,20 +108,6 @@ class SynchronizerProviderImpl(
                 started = SharingStarted.Lazily,
                 initialValue = walletCoordinator.synchronizer.value
             )
-
-    override val retainedSynchronizer: StateFlow<Synchronizer?> =
-        combine(
-            synchronizer,
-            persistableWalletProvider.persistableWallet.map { it != null }.distinctUntilChanged(),
-        ) { current, hasWallet ->
-            current to hasWallet
-        }.scan(synchronizer.value) { retained, (current, hasWallet) ->
-            resolveRetainedSynchronizer(retained, current, hasWallet)
-        }.stateIn(
-            scope = scope,
-            started = SharingStarted.Eagerly,
-            initialValue = synchronizer.value
-        )
 
     private val lastKnownWalletBalances = MutableStateFlow<Map<AccountUuid, AccountBalance>?>(null)
 
@@ -205,11 +185,31 @@ class SynchronizerProviderImpl(
     }
 }
 
-internal fun resolveRetainedSynchronizer(
-    retained: Synchronizer?,
-    current: Synchronizer?,
+/**
+ * MOB-1723: retains the last non-null value of UI-facing wallet-derived state across the gap in
+ * which an automatic server switch (or any other rebuild) tears down and reconstructs the
+ * Synchronizer, so screens do not collapse to a loading state mid-rebuild. Clears to null as soon
+ * as the wallet is removed, so a deleted wallet's state is never shown. This retains plain data
+ * only — never the Synchronizer instance itself, whose close() cancels its coroutineScope and
+ * disposes its clients, making a retained instance a dead object with silently-frozen flows.
+ */
+internal fun <T : Any> Flow<T?>.retainWhileWalletExists(
+    persistableWalletProvider: PersistableWalletProvider
+): Flow<T?> =
+    combine(
+        this,
+        persistableWalletProvider.persistableWallet.map { it != null }.distinctUntilChanged(),
+    ) { current, hasWallet ->
+        current to hasWallet
+    }.scan(null as T?) { retained, (current, hasWallet) ->
+        resolveRetained(retained = retained, current = current, hasWallet = hasWallet)
+    }
+
+internal fun <T : Any> resolveRetained(
+    retained: T?,
+    current: T?,
     hasWallet: Boolean,
-): Synchronizer? =
+): T? =
     when {
         !hasWallet -> null
         current != null -> current

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SynchronizerProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SynchronizerProvider.kt
@@ -2,8 +2,6 @@ package co.electriccoin.zcash.ui.common.provider
 
 import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.WalletCoordinator
-import cash.z.ecc.android.sdk.model.AccountBalance
-import cash.z.ecc.android.sdk.model.AccountUuid
 import co.electriccoin.zcash.spackle.Twig
 import co.electriccoin.zcash.ui.common.migration.MigrationSyncedHook
 import co.electriccoin.zcash.ui.common.model.SynchronizerError
@@ -23,7 +21,6 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.stateIn
@@ -35,20 +32,6 @@ interface SynchronizerProvider {
     val error: StateFlow<SynchronizerError?>
 
     val synchronizer: StateFlow<Synchronizer?>
-
-    /**
-     * MOB-1664: [Synchronizer.walletBalances] is per-synchronizer-instance state that resets to
-     * `null` every time the synchronizer is rebuilt (e.g. an automatic server switch tears down
-     * and reconstructs the whole engine), which would otherwise flash every balance display
-     * (top-line, per-pool breakdown) to 0.000 for the few seconds the new instance takes to
-     * re-establish itself. Retained across that gap via [retainWhileWalletExists] (MOB-1723), so
-     * consumers never observe a spurious drop to zero, while the value clears as soon as the
-     * wallet is removed. Central here (rather than patched into
-     * each consumer) since [AccountDataSource], [co.electriccoin.zcash.ui.common.usecase.GetBalancePoolsUseCase],
-     * [co.electriccoin.zcash.ui.common.usecase.GetOrchardBalanceUseCase] and
-     * [co.electriccoin.zcash.ui.common.viewmodel.WalletViewModel] all read this independently.
-     */
-    val walletBalances: Flow<Map<AccountUuid, AccountBalance>?>
 
     /**
      * Get synchronizer and wait for it to be ready.
@@ -108,11 +91,6 @@ class SynchronizerProviderImpl(
                 started = SharingStarted.Lazily,
                 initialValue = walletCoordinator.synchronizer.value
             )
-
-    override val walletBalances: Flow<Map<AccountUuid, AccountBalance>?> =
-        synchronizer
-            .flatMapLatest { it?.walletBalances ?: flowOf(null) }
-            .retainWhileWalletExists(persistableWalletProvider)
 
     init {
         scope.launch {
@@ -189,6 +167,10 @@ class SynchronizerProviderImpl(
  * as the wallet is removed, so a deleted wallet's state is never shown. This retains plain data
  * only — never the Synchronizer instance itself, whose close() cancels its coroutineScope and
  * disposes its clients, making a retained instance a dead object with silently-frozen flows.
+ *
+ * MOB-1664 is the balance-flash precedent this generalizes: [Synchronizer.walletBalances] resets
+ * to `null` on every rebuild, which used to flash balance displays to 0.000 for the few seconds a
+ * new instance takes to re-establish itself.
  */
 internal fun <T : Any> Flow<T?>.retainWhileWalletExists(
     persistableWalletProvider: PersistableWalletProvider

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
@@ -7,6 +7,7 @@ import co.electriccoin.zcash.ui.common.provider.IsServerSelectionAutomaticProvid
 import co.electriccoin.zcash.ui.common.provider.LightWalletEndpointProvider
 import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import co.electriccoin.zcash.ui.common.provider.rawWalletBalances
 import co.electriccoin.zcash.ui.common.provider.retainWhileWalletExists
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -53,8 +54,8 @@ class AutomaticServerRepositoryImpl(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private val walletBalances =
-        synchronizerProvider.synchronizer
-            .flatMapLatest { it?.walletBalances ?: flowOf(null) }
+        synchronizerProvider
+            .rawWalletBalances()
             .retainWhileWalletExists(persistableWalletProvider)
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
@@ -7,6 +7,7 @@ import co.electriccoin.zcash.ui.common.provider.IsServerSelectionAutomaticProvid
 import co.electriccoin.zcash.ui.common.provider.LightWalletEndpointProvider
 import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import co.electriccoin.zcash.ui.common.provider.retainWhileWalletExists
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -51,6 +52,12 @@ class AutomaticServerRepositoryImpl(
                 keystoneProposalRepository.submitState.value != null
 
     @OptIn(ExperimentalCoroutinesApi::class)
+    private val walletBalances =
+        synchronizerProvider.synchronizer
+            .flatMapLatest { it?.walletBalances ?: flowOf(null) }
+            .retainWhileWalletExists(persistableWalletProvider)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
     override val isServerAutomatic: Flow<Boolean> =
         isServerSelectionAutomaticProvider
             .observe()
@@ -91,7 +98,7 @@ class AutomaticServerRepositoryImpl(
                 if (isAutomatic) {
                     combine(
                         walletRepository.fastestEndpoints,
-                        synchronizerProvider.walletBalances,
+                        walletBalances,
                         ::resolveAutomaticServerCandidate,
                     ).filterNotNull().distinctUntilChanged()
                 } else {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
@@ -91,6 +91,16 @@ class AutomaticServerRepositoryImpl(
         )
     }
 
+    /**
+     * Subscribes to the automatic-server candidate pipeline and the app-foreground signal.
+     *
+     * The candidate flow is intentionally left un-deduplicated: [WalletRepository.updateWalletEndpoint]
+     * already no-ops when the new endpoint matches the persisted one, so a redundant candidate here
+     * is cheap, whereas deduplicating upstream would permanently suppress a candidate that was
+     * skipped while [isAppInTransactionState] and never resurface it on a later emission. A
+     * different endpoint rebuilds the Synchronizer; the candidate waits for the first local balance
+     * snapshot, and UI consumers retain the previous state through the replacement.
+     */
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun init() {
         isServerAutomatic
@@ -100,13 +110,11 @@ class AutomaticServerRepositoryImpl(
                         walletRepository.fastestEndpoints,
                         walletBalances,
                         ::resolveAutomaticServerCandidate,
-                    ).filterNotNull().distinctUntilChanged()
+                    ).filterNotNull()
                 } else {
                     emptyFlow()
                 }
             }.onEach { fastestServer ->
-                // A different endpoint rebuilds the Synchronizer. The candidate waits for the
-                // first local balance snapshot; UI consumers retain that state through replacement.
                 if (!isAppInTransactionState) {
                     walletRepository.updateWalletEndpoint(fastestServer)
                 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
@@ -1,18 +1,21 @@
 package co.electriccoin.zcash.ui.common.repository
 
 import co.electriccoin.zcash.ui.common.datasource.resolveIsServerSelectionAutomatic
+import co.electriccoin.zcash.ui.common.model.FastestServersState
 import co.electriccoin.zcash.ui.common.provider.ApplicationStateProvider
 import co.electriccoin.zcash.ui.common.provider.IsServerSelectionAutomaticProvider
 import co.electriccoin.zcash.ui.common.provider.LightWalletEndpointProvider
 import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
+import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
@@ -33,6 +36,7 @@ class AutomaticServerRepositoryImpl(
     private val zashiProposalRepository: ZashiProposalRepository,
     private val keystoneProposalRepository: KeystoneProposalRepository,
     private val applicationStateProvider: ApplicationStateProvider,
+    private val synchronizerProvider: SynchronizerProvider,
     private val persistableWalletProvider: PersistableWalletProvider,
     private val lightWalletEndpointProvider: LightWalletEndpointProvider,
     private val isServerSelectionAutomaticProvider: IsServerSelectionAutomaticProvider,
@@ -85,13 +89,17 @@ class AutomaticServerRepositoryImpl(
         isServerAutomatic
             .flatMapLatest { isAutomatic ->
                 if (isAutomatic) {
-                    walletRepository.fastestEndpoints
-                        .filter { !it.isLoading }
-                        .mapNotNull { it.servers?.firstOrNull() }
+                    combine(
+                        walletRepository.fastestEndpoints,
+                        synchronizerProvider.walletBalances,
+                        ::resolveAutomaticServerCandidate,
+                    ).filterNotNull().distinctUntilChanged()
                 } else {
                     emptyFlow()
                 }
             }.onEach { fastestServer ->
+                // A different endpoint rebuilds the Synchronizer. The candidate waits for the
+                // first local balance snapshot; UI consumers retain that state through replacement.
                 if (!isAppInTransactionState) {
                     walletRepository.updateWalletEndpoint(fastestServer)
                 }
@@ -106,3 +114,14 @@ class AutomaticServerRepositoryImpl(
             }.launchIn(scope)
     }
 }
+
+internal fun resolveAutomaticServerCandidate(
+    fastestEndpoints: FastestServersState,
+    localBalances: Map<*, *>?,
+) =
+    fastestEndpoints.servers
+        ?.firstOrNull()
+        ?.takeIf {
+            !fastestEndpoints.isLoading &&
+                localBalances != null
+        }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/FlexaRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/FlexaRepository.kt
@@ -15,7 +15,7 @@ import com.flexa.identity.buildIdentity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import java.security.MessageDigest
 import java.util.UUID
@@ -45,8 +45,11 @@ class FlexaRepositoryImpl(
                 Twig.info { "Flexa initialized" }
 
                 accountDataSource.zashiAccount
-                    .map { it?.totalShieldedBalance to it?.spendableShieldedBalance }
-                    .collect { (total, available) ->
+                    .mapNotNull { account ->
+                        val total = account?.totalShieldedBalance
+                        val available = account?.spendableShieldedBalance
+                        if (total != null && available != null) total to available else null
+                    }.collect { (total, available) ->
                         val totalZec = total.convertZatoshiToZec().toDouble()
                         val availableZec = available.convertZatoshiToZec().toDouble()
                         Flexa.updateAssetAccounts(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetBalancePoolsUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetBalancePoolsUseCase.kt
@@ -6,7 +6,6 @@ import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
@@ -43,32 +42,30 @@ class GetBalancePoolsUseCase(
 ) {
     @OptIn(ExperimentalCoroutinesApi::class)
     fun observe(): Flow<BalancePools?> =
-        combine(
-            synchronizerProvider.retainedSynchronizer,
-            accountDataSource.selectedAccount
-        ) { synchronizer, account ->
-            synchronizer to account
-        }.flatMapLatest { (synchronizer, account) ->
-            if (synchronizer == null || account == null) {
-                flowOf(null)
-            } else {
-                synchronizerProvider.walletBalances.map { balances ->
-                    val balance = balances?.get(account.sdkAccount.accountUuid)
-                    val orchard = (balance?.orchard?.total ?: Zatoshi.ZERO) + (balance?.orchard?.locked ?: Zatoshi.ZERO)
-                    val sapling = (balance?.sapling?.total ?: Zatoshi.ZERO) + (balance?.sapling?.locked ?: Zatoshi.ZERO)
-                    val ironwood =
-                        (balance?.ironwood?.total ?: Zatoshi.ZERO) + (balance?.ironwood?.locked ?: Zatoshi.ZERO)
-                    val transparent = balance?.unshielded ?: Zatoshi.ZERO
-                    BalancePools(
-                        total = orchard + sapling + transparent + ironwood,
-                        orchard = orchard,
-                        sapling = sapling,
-                        transparent = transparent,
-                        ironwood = ironwood,
-                    )
+        accountDataSource.selectedAccount
+            .flatMapLatest { account ->
+                if (account == null) {
+                    flowOf(null)
+                } else {
+                    synchronizerProvider.walletBalances.map { balances ->
+                        val balance = balances?.get(account.sdkAccount.accountUuid)
+                        val orchard =
+                            (balance?.orchard?.total ?: Zatoshi.ZERO) + (balance?.orchard?.locked ?: Zatoshi.ZERO)
+                        val sapling =
+                            (balance?.sapling?.total ?: Zatoshi.ZERO) + (balance?.sapling?.locked ?: Zatoshi.ZERO)
+                        val ironwood =
+                            (balance?.ironwood?.total ?: Zatoshi.ZERO) + (balance?.ironwood?.locked ?: Zatoshi.ZERO)
+                        val transparent = balance?.unshielded ?: Zatoshi.ZERO
+                        BalancePools(
+                            total = orchard + sapling + transparent + ironwood,
+                            orchard = orchard,
+                            sapling = sapling,
+                            transparent = transparent,
+                            ironwood = ironwood,
+                        )
+                    }
                 }
             }
-        }
 }
 
 data class BalancePools(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetBalancePoolsUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetBalancePoolsUseCase.kt
@@ -3,12 +3,14 @@ package co.electriccoin.zcash.ui.common.usecase
 import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.sdk.extension.ZERO
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
+import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import co.electriccoin.zcash.ui.common.provider.retainWhileWalletExists
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
 
 /**
  * Observes the balance of the selected account broken down per Zcash pool.
@@ -39,33 +41,34 @@ import kotlinx.coroutines.flow.map
 class GetBalancePoolsUseCase(
     private val synchronizerProvider: SynchronizerProvider,
     private val accountDataSource: AccountDataSource,
+    private val persistableWalletProvider: PersistableWalletProvider,
 ) {
     @OptIn(ExperimentalCoroutinesApi::class)
     fun observe(): Flow<BalancePools?> =
-        accountDataSource.selectedAccount
-            .flatMapLatest { account ->
-                if (account == null) {
-                    flowOf(null)
-                } else {
-                    synchronizerProvider.walletBalances.map { balances ->
-                        val balance = balances?.get(account.sdkAccount.accountUuid)
-                        val orchard =
-                            (balance?.orchard?.total ?: Zatoshi.ZERO) + (balance?.orchard?.locked ?: Zatoshi.ZERO)
-                        val sapling =
-                            (balance?.sapling?.total ?: Zatoshi.ZERO) + (balance?.sapling?.locked ?: Zatoshi.ZERO)
-                        val ironwood =
-                            (balance?.ironwood?.total ?: Zatoshi.ZERO) + (balance?.ironwood?.locked ?: Zatoshi.ZERO)
-                        val transparent = balance?.unshielded ?: Zatoshi.ZERO
-                        BalancePools(
-                            total = orchard + sapling + transparent + ironwood,
-                            orchard = orchard,
-                            sapling = sapling,
-                            transparent = transparent,
-                            ironwood = ironwood,
-                        )
-                    }
-                }
+        combine(
+            accountDataSource.selectedAccount,
+            synchronizerProvider.synchronizer.flatMapLatest { it?.walletBalances ?: flowOf(null) },
+        ) { account, balances ->
+            if (account == null || balances == null) {
+                null
+            } else {
+                val balance = balances[account.sdkAccount.accountUuid]
+                val orchard =
+                    (balance?.orchard?.total ?: Zatoshi.ZERO) + (balance?.orchard?.locked ?: Zatoshi.ZERO)
+                val sapling =
+                    (balance?.sapling?.total ?: Zatoshi.ZERO) + (balance?.sapling?.locked ?: Zatoshi.ZERO)
+                val ironwood =
+                    (balance?.ironwood?.total ?: Zatoshi.ZERO) + (balance?.ironwood?.locked ?: Zatoshi.ZERO)
+                val transparent = balance?.unshielded ?: Zatoshi.ZERO
+                BalancePools(
+                    total = orchard + sapling + transparent + ironwood,
+                    orchard = orchard,
+                    sapling = sapling,
+                    transparent = transparent,
+                    ironwood = ironwood,
+                )
             }
+        }.retainWhileWalletExists(persistableWalletProvider)
 }
 
 data class BalancePools(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetBalancePoolsUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetBalancePoolsUseCase.kt
@@ -1,7 +1,6 @@
 package co.electriccoin.zcash.ui.common.usecase
 
 import cash.z.ecc.android.sdk.model.Zatoshi
-import cash.z.ecc.sdk.extension.ZERO
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
@@ -17,8 +16,9 @@ import kotlinx.coroutines.flow.flowOf
  *
  * Unlike [AccountDataSource] (which aggregates Orchard + Ironwood into a single unified balance),
  * this reads the raw per-pool balances from the SDK so the UI can present each pool separately.
- * Ironwood reflects whatever the SDK reports; it is [Zatoshi.ZERO] when the pool is empty or not
- * yet reported.
+ * Every field of [cash.z.ecc.android.sdk.model.AccountBalance] is non-null, so once the account's
+ * entry is found in the map there is nothing left to default to zero — a missing entry (map
+ * present but the account not in it yet) is the only "not loaded" case, and it emits null.
  *
  * Each pool's displayed total is `raw.total + raw.locked` — [cash.z.ecc.android.sdk.model.WalletBalance.locked]
  * is real, owned value the wallet currently sees as committed to a transaction proposal or PCZT
@@ -49,25 +49,19 @@ class GetBalancePoolsUseCase(
             accountDataSource.selectedAccount,
             synchronizerProvider.synchronizer.flatMapLatest { it?.walletBalances ?: flowOf(null) },
         ) { account, balances ->
-            if (account == null || balances == null) {
-                null
-            } else {
-                val balance = balances[account.sdkAccount.accountUuid]
-                val orchard =
-                    (balance?.orchard?.total ?: Zatoshi.ZERO) + (balance?.orchard?.locked ?: Zatoshi.ZERO)
-                val sapling =
-                    (balance?.sapling?.total ?: Zatoshi.ZERO) + (balance?.sapling?.locked ?: Zatoshi.ZERO)
-                val ironwood =
-                    (balance?.ironwood?.total ?: Zatoshi.ZERO) + (balance?.ironwood?.locked ?: Zatoshi.ZERO)
-                val transparent = balance?.unshielded ?: Zatoshi.ZERO
-                BalancePools(
-                    total = orchard + sapling + transparent + ironwood,
-                    orchard = orchard,
-                    sapling = sapling,
-                    transparent = transparent,
-                    ironwood = ironwood,
-                )
-            }
+            if (account == null || balances == null) return@combine null
+            val balance = balances[account.sdkAccount.accountUuid] ?: return@combine null
+            val orchard = balance.orchard.total + balance.orchard.locked
+            val sapling = balance.sapling.total + balance.sapling.locked
+            val ironwood = balance.ironwood.total + balance.ironwood.locked
+            val transparent = balance.unshielded
+            BalancePools(
+                total = orchard + sapling + transparent + ironwood,
+                orchard = orchard,
+                sapling = sapling,
+                transparent = transparent,
+                ironwood = ironwood,
+            )
         }.retainWhileWalletExists(persistableWalletProvider)
 }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetBalancePoolsUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetBalancePoolsUseCase.kt
@@ -4,12 +4,13 @@ import cash.z.ecc.android.sdk.model.Zatoshi
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import co.electriccoin.zcash.ui.common.provider.rawWalletBalances
 import co.electriccoin.zcash.ui.common.provider.retainWhileWalletExists
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 
 /**
  * Observes the balance of the selected account broken down per Zcash pool.
@@ -45,24 +46,30 @@ class GetBalancePoolsUseCase(
 ) {
     @OptIn(ExperimentalCoroutinesApi::class)
     fun observe(): Flow<BalancePools?> =
-        combine(
-            accountDataSource.selectedAccount,
-            synchronizerProvider.synchronizer.flatMapLatest { it?.walletBalances ?: flowOf(null) },
-        ) { account, balances ->
-            if (account == null || balances == null) return@combine null
-            val balance = balances[account.sdkAccount.accountUuid] ?: return@combine null
-            val orchard = balance.orchard.total + balance.orchard.locked
-            val sapling = balance.sapling.total + balance.sapling.locked
-            val ironwood = balance.ironwood.total + balance.ironwood.locked
-            val transparent = balance.unshielded
-            BalancePools(
-                total = orchard + sapling + transparent + ironwood,
-                orchard = orchard,
-                sapling = sapling,
-                transparent = transparent,
-                ironwood = ironwood,
-            )
-        }.retainWhileWalletExists(persistableWalletProvider)
+        accountDataSource.selectedAccount
+            .flatMapLatest { account ->
+                if (account == null) {
+                    flowOf(null)
+                } else {
+                    synchronizerProvider
+                        .rawWalletBalances()
+                        .map { balances ->
+                            balances?.get(account.sdkAccount.accountUuid)?.let { balance ->
+                                val orchard = balance.orchard.total + balance.orchard.locked
+                                val sapling = balance.sapling.total + balance.sapling.locked
+                                val ironwood = balance.ironwood.total + balance.ironwood.locked
+                                val transparent = balance.unshielded
+                                BalancePools(
+                                    total = orchard + sapling + transparent + ironwood,
+                                    orchard = orchard,
+                                    sapling = sapling,
+                                    transparent = transparent,
+                                    ironwood = ironwood,
+                                )
+                            }
+                        }.retainWhileWalletExists(persistableWalletProvider)
+                }
+            }
 }
 
 data class BalancePools(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetBalancePoolsUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetBalancePoolsUseCase.kt
@@ -44,7 +44,7 @@ class GetBalancePoolsUseCase(
     @OptIn(ExperimentalCoroutinesApi::class)
     fun observe(): Flow<BalancePools?> =
         combine(
-            synchronizerProvider.synchronizer,
+            synchronizerProvider.retainedSynchronizer,
             accountDataSource.selectedAccount
         ) { synchronizer, account ->
             synchronizer to account

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCase.kt
@@ -102,7 +102,7 @@ class GetHomeMessageUseCase(
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun observeShieldFundsMessage() =
         accountDataSource.selectedAccount.flatMapLatest { account ->
-            val transparentBalance = account?.transparent?.balance
+            val transparentBalance = account?.transparentBalance
             when {
                 account == null || transparentBalance == null -> {
                     flowOf(null)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCase.kt
@@ -102,17 +102,18 @@ class GetHomeMessageUseCase(
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun observeShieldFundsMessage() =
         accountDataSource.selectedAccount.flatMapLatest { account ->
+            val transparentBalance = account?.transparent?.balance
             when {
-                account == null -> {
+                account == null || transparentBalance == null -> {
                     flowOf(null)
                 }
 
-                account.isShieldingAvailable -> {
+                account.isShieldingAvailable == true -> {
                     messageAvailabilityDataSource.canShowShieldMessage
                         .map { canShowShieldMessage ->
                             when {
                                 !canShowShieldMessage -> null
-                                else -> HomeMessageData.ShieldFunds(account.transparent.balance)
+                                else -> HomeMessageData.ShieldFunds(transparentBalance)
                             }
                         }
                 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetIronwoodBalanceUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetIronwoodBalanceUseCase.kt
@@ -24,9 +24,9 @@ class GetIronwoodBalanceUseCase(
     private val accountDataSource: AccountDataSource,
 ) {
     suspend operator fun invoke(): Zatoshi {
-        synchronizerProvider.getSynchronizer()
+        val synchronizer = synchronizerProvider.getSynchronizer()
         val account = accountDataSource.getSelectedAccount()
-        val balances = synchronizerProvider.walletBalances.filterNotNull().first()
+        val balances = synchronizer.walletBalances.filterNotNull().first()
         val ironwood = balances[account.sdkAccount.accountUuid]?.ironwood ?: return Zatoshi.ZERO
         return ironwood.total + ironwood.locked
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetOrchardBalanceUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetOrchardBalanceUseCase.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.flowOf
  *
  * Reads the raw, un-folded per-pool Orchard balance directly from the synchronizer, mirroring
  * [GetBalancePoolsUseCase]'s pattern. This deliberately avoids
- * `co.electriccoin.zcash.ui.common.model.WalletAccount.unified`: that field folds Orchard +
+ * `co.electriccoin.zcash.ui.common.model.WalletAccount.unifiedBalance`: that field folds Orchard +
  * Ironwood balances together, so once migration completes (real Orchard = 0) it would keep
  * reporting the full post-migration total as "still Orchard" — which is exactly the bug that made
  * the home screen's "Migration required" banner stick around forever after a full migration.

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetOrchardBalanceUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetOrchardBalanceUseCase.kt
@@ -3,14 +3,16 @@ package co.electriccoin.zcash.ui.common.usecase
 import cash.z.ecc.android.sdk.model.Zatoshi
 import cash.z.ecc.sdk.extension.ZERO
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
+import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import co.electriccoin.zcash.ui.common.provider.retainWhileWalletExists
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.map
 
 /**
  * The real, spendable Orchard balance for the currently selected wallet account — the balance
@@ -26,24 +28,25 @@ import kotlinx.coroutines.flow.map
 class GetOrchardBalanceUseCase(
     private val synchronizerProvider: SynchronizerProvider,
     private val accountDataSource: AccountDataSource,
+    private val persistableWalletProvider: PersistableWalletProvider,
 ) {
     suspend operator fun invoke(): Zatoshi {
-        synchronizerProvider.getSynchronizer()
+        val synchronizer = synchronizerProvider.getSynchronizer()
         val account = accountDataSource.getSelectedAccount()
-        val balances = synchronizerProvider.walletBalances.filterNotNull().first()
+        val balances = synchronizer.walletBalances.filterNotNull().first()
         return balances[account.sdkAccount.accountUuid]?.orchard?.available ?: Zatoshi.ZERO
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     fun observe(): Flow<Zatoshi?> =
-        accountDataSource.selectedAccount
-            .flatMapLatest { account ->
-                if (account == null) {
-                    flowOf(null)
-                } else {
-                    synchronizerProvider.walletBalances.map { balances ->
-                        balances?.get(account.sdkAccount.accountUuid)?.orchard?.available
-                    }
-                }
+        combine(
+            accountDataSource.selectedAccount,
+            synchronizerProvider.synchronizer.flatMapLatest { it?.walletBalances ?: flowOf(null) },
+        ) { account, balances ->
+            if (account == null || balances == null) {
+                null
+            } else {
+                balances[account.sdkAccount.accountUuid]?.orchard?.available
             }
+        }.retainWhileWalletExists(persistableWalletProvider)
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetOrchardBalanceUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetOrchardBalanceUseCase.kt
@@ -38,7 +38,7 @@ class GetOrchardBalanceUseCase(
     @OptIn(ExperimentalCoroutinesApi::class)
     fun observe(): Flow<Zatoshi?> =
         combine(
-            synchronizerProvider.synchronizer,
+            synchronizerProvider.retainedSynchronizer,
             accountDataSource.selectedAccount
         ) { synchronizer, account ->
             synchronizer to account

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetOrchardBalanceUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetOrchardBalanceUseCase.kt
@@ -5,14 +5,15 @@ import cash.z.ecc.sdk.extension.ZERO
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import co.electriccoin.zcash.ui.common.provider.rawWalletBalances
 import co.electriccoin.zcash.ui.common.provider.retainWhileWalletExists
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 
 /**
  * The real, spendable Orchard balance for the currently selected wallet account — the balance
@@ -39,14 +40,15 @@ class GetOrchardBalanceUseCase(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     fun observe(): Flow<Zatoshi?> =
-        combine(
-            accountDataSource.selectedAccount,
-            synchronizerProvider.synchronizer.flatMapLatest { it?.walletBalances ?: flowOf(null) },
-        ) { account, balances ->
-            if (account == null || balances == null) {
-                null
-            } else {
-                balances[account.sdkAccount.accountUuid]?.orchard?.available
+        accountDataSource.selectedAccount
+            .flatMapLatest { account ->
+                if (account == null) {
+                    flowOf(null)
+                } else {
+                    synchronizerProvider
+                        .rawWalletBalances()
+                        .map { balances -> balances?.get(account.sdkAccount.accountUuid)?.orchard?.available }
+                        .retainWhileWalletExists(persistableWalletProvider)
+                }
             }
-        }.retainWhileWalletExists(persistableWalletProvider)
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetOrchardBalanceUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetOrchardBalanceUseCase.kt
@@ -6,7 +6,6 @@ import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -37,18 +36,14 @@ class GetOrchardBalanceUseCase(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     fun observe(): Flow<Zatoshi?> =
-        combine(
-            synchronizerProvider.retainedSynchronizer,
-            accountDataSource.selectedAccount
-        ) { synchronizer, account ->
-            synchronizer to account
-        }.flatMapLatest { (synchronizer, account) ->
-            if (synchronizer == null || account == null) {
-                flowOf(null)
-            } else {
-                synchronizerProvider.walletBalances.map { balances ->
-                    balances?.get(account.sdkAccount.accountUuid)?.orchard?.available
+        accountDataSource.selectedAccount
+            .flatMapLatest { account ->
+                if (account == null) {
+                    flowOf(null)
+                } else {
+                    synchronizerProvider.walletBalances.map { balances ->
+                        balances?.get(account.sdkAccount.accountUuid)?.orchard?.available
+                    }
                 }
             }
-        }
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/ObserveABContactPickedUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/ObserveABContactPickedUseCase.kt
@@ -37,6 +37,6 @@ class ObserveABContactPickedUseCase(
 
     fun onWalletAccountPicked(account: WalletAccount) =
         scope.launch {
-            bus.emit(account.unified.address.address)
+            bus.emit(account.unifiedAddress.address)
         }
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/ObserveABContactPickedUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/ObserveABContactPickedUseCase.kt
@@ -37,6 +37,6 @@ class ObserveABContactPickedUseCase(
 
     fun onWalletAccountPicked(account: WalletAccount) =
         scope.launch {
-            bus.emit(account.unifiedAddress.address)
+            bus.emit(account.unifiedAddress)
         }
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCase.kt
@@ -53,7 +53,7 @@ class RequestSwapQuoteUseCase(
                 swapRepository.requestExactInputQuote(
                     amount = amount,
                     address = address,
-                    refundAddress = newAddress.address,
+                    refundAddress = newAddress,
                     destinationAsset = selectedAsset,
                     slippage = slippage
                 )
@@ -76,7 +76,7 @@ class RequestSwapQuoteUseCase(
                 swapRepository.requestExactOutputQuote(
                     amount = amount,
                     address = address,
-                    refundAddress = newAddress.address,
+                    refundAddress = newAddress,
                     destinationAsset = selectedAsset,
                     slippage = slippage
                 )
@@ -100,7 +100,7 @@ class RequestSwapQuoteUseCase(
                     .requestFlexInputIntoZec(
                         amount = amount,
                         refundAddress = refundAddress,
-                        destinationAddress = newAddress.address,
+                        destinationAddress = newAddress,
                         originAsset = selectedAsset,
                         slippage = slippage
                     )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/WalletViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/WalletViewModel.kt
@@ -26,7 +26,7 @@ class WalletViewModel(
     synchronizerProvider: SynchronizerProvider,
     private val walletRepository: WalletRepository,
 ) : ViewModel() {
-    val synchronizer = synchronizerProvider.synchronizer
+    val synchronizer = synchronizerProvider.retainedSynchronizer
 
     val secretState: StateFlow<SecretState> = walletRepository.secretState
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/WalletViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/WalletViewModel.kt
@@ -52,7 +52,7 @@ class WalletViewModel(
                 } else {
                     combine(
                         synchronizer.fullyScannedHeight,
-                        synchronizerProvider.walletBalances,
+                        synchronizer.walletBalances,
                         walletRepository.isIronwoodAnnouncementShown,
                     ) { scannedHeight, balances, isShown ->
                         val activationHeight = IronwoodActivation.heightFor(synchronizer.network)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/WalletViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/viewmodel/WalletViewModel.kt
@@ -26,7 +26,7 @@ class WalletViewModel(
     synchronizerProvider: SynchronizerProvider,
     private val walletRepository: WalletRepository,
 ) : ViewModel() {
-    val synchronizer = synchronizerProvider.retainedSynchronizer
+    val synchronizer = synchronizerProvider.synchronizer
 
     val secretState: StateFlow<SecretState> = walletRepository.secretState
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/accountlist/AccountListVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/accountlist/AccountListVM.kt
@@ -41,7 +41,7 @@ class AccountListVM(
                                 AccountListItem.Account(
                                     ZashiAccountListItemState(
                                         title = account.name,
-                                        subtitle = stringResByAddress(account.unified.address.address),
+                                        subtitle = stringResByAddress(account.unifiedAddress.address),
                                         icon =
                                             when (account) {
                                                 is KeystoneAccount -> R.drawable.ic_item_keystone

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/accountlist/AccountListVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/accountlist/AccountListVM.kt
@@ -41,7 +41,7 @@ class AccountListVM(
                                 AccountListItem.Account(
                                     ZashiAccountListItemState(
                                         title = account.name,
-                                        subtitle = stringResByAddress(account.unifiedAddress.address),
+                                        subtitle = stringResByAddress(account.unifiedAddress),
                                         icon =
                                             when (account) {
                                                 is KeystoneAccount -> R.drawable.ic_item_keystone

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/addressbook/SelectABRecipientVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/addressbook/SelectABRecipientVM.kt
@@ -82,7 +82,7 @@ class SelectABRecipientVM(
                                 name = account.name,
                                 address =
                                     stringResByAddress(
-                                        "${account.unifiedAddress.address.take(ADDRESS_MAX_LENGTH)}..."
+                                        "${account.unifiedAddress.take(ADDRESS_MAX_LENGTH)}..."
                                     ),
                                 onClick = { onWalletAccountClick(account) }
                             )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/addressbook/SelectABRecipientVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/addressbook/SelectABRecipientVM.kt
@@ -82,7 +82,7 @@ class SelectABRecipientVM(
                                 name = account.name,
                                 address =
                                     stringResByAddress(
-                                        "${account.unified.address.address.take(ADDRESS_MAX_LENGTH)}..."
+                                        "${account.unifiedAddress.address.take(ADDRESS_MAX_LENGTH)}..."
                                     ),
                                 onClick = { onWalletAccountClick(account) }
                             )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/advancedsettings/debug/DebugVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/advancedsettings/debug/DebugVM.kt
@@ -123,7 +123,7 @@ class DebugVM(
                             is ZashiAccount -> "Zashi"
                             is KeystoneAccount -> "Keystone"
                         }
-                    "$label\n${account.unifiedAddress.address}"
+                    "$label\n${account.unifiedAddress}"
                 }
             copyToClipboardUseCase(text)
             navigationRouter.forward(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/advancedsettings/debug/DebugVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/advancedsettings/debug/DebugVM.kt
@@ -123,7 +123,7 @@ class DebugVM(
                             is ZashiAccount -> "Zashi"
                             is KeystoneAccount -> "Keystone"
                         }
-                    "$label\n${account.unified.address.address}"
+                    "$label\n${account.unifiedAddress.address}"
                 }
             copyToClipboardUseCase(text)
             navigationRouter.forward(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/balances/BalanceWidgetVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/balances/BalanceWidgetVM.kt
@@ -76,17 +76,13 @@ class BalanceWidgetVM(
         val isAllShielded = account.isAllShielded ?: return null
         if (isAllShielded) return null
 
-        val totalBalance = account.totalBalance ?: return null
-        val spendableShieldedBalance = account.spendableShieldedBalance ?: return null
-        val isShieldedPending = account.isShieldedPending ?: return null
-        val totalShieldedBalance = account.totalShieldedBalance ?: return null
-        val totalTransparentBalance = account.totalTransparentBalance ?: return null
+        val b = account.loadedBalances ?: return null
 
         return when {
-            totalBalance > spendableShieldedBalance &&
-                isShieldedPending &&
-                totalShieldedBalance > Zatoshi(0) &&
-                spendableShieldedBalance == Zatoshi(0) -> {
+            b.totalBalance > b.spendableShieldedBalance &&
+                b.isShieldedPending &&
+                b.totalShieldedBalance > Zatoshi(0) &&
+                b.spendableShieldedBalance == Zatoshi(0) -> {
                 BalanceButtonState(
                     icon = R.drawable.ic_balances_expand,
                     text = stringRes(R.string.widget_balances_button_spendable),
@@ -95,11 +91,11 @@ class BalanceWidgetVM(
                 )
             }
 
-            totalBalance > spendableShieldedBalance &&
-                !isShieldedPending &&
-                totalShieldedBalance > Zatoshi(0) &&
-                spendableShieldedBalance == Zatoshi(0) &&
-                totalTransparentBalance == Zatoshi(0) -> {
+            b.totalBalance > b.spendableShieldedBalance &&
+                !b.isShieldedPending &&
+                b.totalShieldedBalance > Zatoshi(0) &&
+                b.spendableShieldedBalance == Zatoshi(0) &&
+                b.totalTransparentBalance == Zatoshi(0) -> {
                 BalanceButtonState(
                     icon = R.drawable.ic_balances_expand,
                     text = stringRes(R.string.widget_balances_button_spendable),
@@ -108,11 +104,11 @@ class BalanceWidgetVM(
                 )
             }
 
-            totalBalance > spendableShieldedBalance -> {
+            b.totalBalance > b.spendableShieldedBalance -> {
                 BalanceButtonState(
                     icon = R.drawable.ic_balances_expand,
                     text = stringRes(R.string.widget_balances_button_spendable),
-                    amount = spendableShieldedBalance,
+                    amount = b.spendableShieldedBalance,
                     onClick = ::onBalanceButtonClick
                 )
             }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/balances/BalanceWidgetVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/balances/BalanceWidgetVM.kt
@@ -53,7 +53,6 @@ class BalanceWidgetVM(
                 )
         )
 
-    @Suppress("CyclomaticComplexMethod")
     private fun createState(
         account: WalletAccount?,
         exchangeRate: ExchangeRateState,
@@ -63,60 +62,66 @@ class BalanceWidgetVM(
         exchangeRate = if (args.isExchangeRateButtonEnabled) exchangeRate else null,
         button =
             when {
-                !args.isBalanceButtonEnabled -> {
-                    null
-                }
-
-                account == null -> {
-                    null
-                }
-
-                account.isAllShielded -> {
-                    null
-                }
-
-                account.totalBalance > account.spendableShieldedBalance &&
-                    account.isShieldedPending &&
-                    account.totalShieldedBalance > Zatoshi(0) &&
-                    account.spendableShieldedBalance == Zatoshi(0) -> {
-                    BalanceButtonState(
-                        icon = R.drawable.ic_balances_expand,
-                        text = stringRes(R.string.widget_balances_button_spendable),
-                        amount = null,
-                        onClick = ::onBalanceButtonClick
-                    )
-                }
-
-                account.totalBalance > account.spendableShieldedBalance &&
-                    !account.isShieldedPending &&
-                    account.totalShieldedBalance > Zatoshi(0) &&
-                    account.spendableShieldedBalance == Zatoshi(0) &&
-                    account.totalTransparentBalance == Zatoshi(0) -> {
-                    BalanceButtonState(
-                        icon = R.drawable.ic_balances_expand,
-                        text = stringRes(R.string.widget_balances_button_spendable),
-                        amount = null,
-                        onClick = ::onBalanceButtonClick
-                    )
-                }
-
-                account.totalBalance > account.spendableShieldedBalance -> {
-                    BalanceButtonState(
-                        icon = R.drawable.ic_balances_expand,
-                        text = stringRes(R.string.widget_balances_button_spendable),
-                        amount = account.spendableShieldedBalance,
-                        onClick = ::onBalanceButtonClick
-                    )
-                }
-
-                else -> {
-                    null
-                }
+                !args.isBalanceButtonEnabled -> null
+                account == null -> null
+                else -> createBalanceButtonState(account)
             },
         showDust = args.showDust,
         onBalanceClick =
             if (args.isBalanceBreakdownEnabled && account != null) ::onBalanceClick else null
     )
+
+    @Suppress("CyclomaticComplexMethod", "ReturnCount")
+    private fun createBalanceButtonState(account: WalletAccount): BalanceButtonState? {
+        val isAllShielded = account.isAllShielded ?: return null
+        if (isAllShielded) return null
+
+        val totalBalance = account.totalBalance ?: return null
+        val spendableShieldedBalance = account.spendableShieldedBalance ?: return null
+        val isShieldedPending = account.isShieldedPending ?: return null
+        val totalShieldedBalance = account.totalShieldedBalance ?: return null
+        val totalTransparentBalance = account.totalTransparentBalance ?: return null
+
+        return when {
+            totalBalance > spendableShieldedBalance &&
+                isShieldedPending &&
+                totalShieldedBalance > Zatoshi(0) &&
+                spendableShieldedBalance == Zatoshi(0) -> {
+                BalanceButtonState(
+                    icon = R.drawable.ic_balances_expand,
+                    text = stringRes(R.string.widget_balances_button_spendable),
+                    amount = null,
+                    onClick = ::onBalanceButtonClick
+                )
+            }
+
+            totalBalance > spendableShieldedBalance &&
+                !isShieldedPending &&
+                totalShieldedBalance > Zatoshi(0) &&
+                spendableShieldedBalance == Zatoshi(0) &&
+                totalTransparentBalance == Zatoshi(0) -> {
+                BalanceButtonState(
+                    icon = R.drawable.ic_balances_expand,
+                    text = stringRes(R.string.widget_balances_button_spendable),
+                    amount = null,
+                    onClick = ::onBalanceButtonClick
+                )
+            }
+
+            totalBalance > spendableShieldedBalance -> {
+                BalanceButtonState(
+                    icon = R.drawable.ic_balances_expand,
+                    text = stringRes(R.string.widget_balances_button_spendable),
+                    amount = spendableShieldedBalance,
+                    onClick = ::onBalanceButtonClick
+                )
+            }
+
+            else -> {
+                null
+            }
+        }
+    }
 
     private fun onBalanceButtonClick() = navigationRouter.forward(SpendableBalanceArgs)
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/balances/spendable/SpendableBalanceVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/balances/spendable/SpendableBalanceVM.kt
@@ -194,5 +194,5 @@ private fun WalletAccount.loadedBalancesOrNull(): LoadedAccountBalances? =
         pendingShieldedBalance = pendingShieldedBalance ?: return null,
         isShieldedPending = isShieldedPending ?: return null,
         isShieldingAvailable = isShieldingAvailable ?: return null,
-        transparentBalance = transparent.balance ?: return null,
+        transparentBalance = this.transparentBalance ?: return null,
     )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/balances/spendable/SpendableBalanceVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/balances/spendable/SpendableBalanceVM.kt
@@ -52,31 +52,36 @@ class SpendableBalanceVM(
                     )
             )
 
+    @Suppress("ReturnCount")
     private fun createState(account: WalletAccount?, transactions: List<ListTransactionData>?): SpendableBalanceState? {
         if (account == null) return null
+        val balances = account.loadedBalancesOrNull() ?: return null
         return SpendableBalanceState(
             title = stringRes(R.string.balances_spendableBalance_title),
-            message = createMessage(account, transactions),
-            positive = createPositiveButton(account),
+            message = createMessage(balances, transactions),
+            positive = createPositiveButton(balances),
             onBack = ::onBack,
-            rows = createInfoRows(account, transactions),
-            shieldButton = createShieldButtonState(account)
+            rows = createInfoRows(balances, transactions),
+            shieldButton = createShieldButtonState(balances)
         )
     }
 
-    private fun createMessage(account: WalletAccount, transactions: List<ListTransactionData>?): StringResource {
+    private fun createMessage(
+        balances: LoadedAccountBalances,
+        transactions: List<ListTransactionData>?
+    ): StringResource {
         val pending =
             when {
-                account.isAllShielded -> {
+                balances.isAllShielded -> {
                     stringRes(R.string.balances_everythingDone)
                 }
 
-                account.totalBalance > account.spendableShieldedBalance &&
+                balances.totalBalance > balances.spendableShieldedBalance &&
                     transactions.orEmpty().any { it.transaction.isPending } -> {
                     stringRes(R.string.balances_infoPending)
                 }
 
-                account.totalBalance > account.spendableShieldedBalance -> {
+                balances.totalBalance > balances.spendableShieldedBalance -> {
                     stringRes(R.string.balances_infoSyncing)
                 }
 
@@ -91,7 +96,7 @@ class SpendableBalanceVM(
                 CURRENCY_TICKER,
                 stringRes(Zatoshi.typicalFee, HIDDEN),
                 CURRENCY_TICKER
-            ).takeIf { account.isShieldingAvailable }
+            ).takeIf { balances.isShieldingAvailable }
 
         return if (pending != null && shielding != null) {
             pending + stringRes("\n\n") + shielding
@@ -100,10 +105,10 @@ class SpendableBalanceVM(
         }
     }
 
-    private fun createPositiveButton(account: WalletAccount) =
+    private fun createPositiveButton(balances: LoadedAccountBalances) =
         ButtonState(
             text =
-                if (account.isShieldingAvailable) {
+                if (balances.isShieldingAvailable) {
                     stringRes(co.electriccoin.zcash.ui.design.R.string.balances_dismiss)
                 } else {
                     stringRes(co.electriccoin.zcash.ui.design.R.string.general_ok)
@@ -112,7 +117,7 @@ class SpendableBalanceVM(
         )
 
     private fun createInfoRows(
-        account: WalletAccount,
+        balances: LoadedAccountBalances,
         transactions: List<ListTransactionData>?
     ): List<SpendableBalanceRowState> {
         val hasPendingTransaction = transactions.orEmpty().any { it.transaction.isPending }
@@ -121,25 +126,25 @@ class SpendableBalanceVM(
                 title = stringRes(R.string.balances_spendableBalance),
                 icon = imageRes(R.drawable.ic_balance_shield),
                 value =
-                    stringRes(account.spendableShieldedBalance)
+                    stringRes(balances.spendableShieldedBalance)
             ),
             when {
-                account.totalShieldedBalance > account.spendableShieldedBalance &&
-                    account.isShieldedPending &&
+                balances.totalShieldedBalance > balances.spendableShieldedBalance &&
+                    balances.isShieldedPending &&
                     hasPendingTransaction -> {
                     SpendableBalanceRowState(
                         title = stringRes(R.string.balances_pending),
                         icon = loadingImageRes(),
-                        value = stringRes(account.pendingShieldedBalance)
+                        value = stringRes(balances.pendingShieldedBalance)
                     )
                 }
 
-                account.totalShieldedBalance > account.spendableShieldedBalance && hasPendingTransaction -> {
+                balances.totalShieldedBalance > balances.spendableShieldedBalance && hasPendingTransaction -> {
                     SpendableBalanceRowState(
                         title = stringRes(R.string.balances_pending),
                         icon = loadingImageRes(),
                         value =
-                            stringRes(account.totalShieldedBalance - account.spendableShieldedBalance)
+                            stringRes(balances.totalShieldedBalance - balances.spendableShieldedBalance)
                     )
                 }
 
@@ -150,13 +155,44 @@ class SpendableBalanceVM(
         )
     }
 
-    private fun createShieldButtonState(account: WalletAccount): SpendableBalanceShieldButtonState? =
+    private fun createShieldButtonState(balances: LoadedAccountBalances): SpendableBalanceShieldButtonState? =
         SpendableBalanceShieldButtonState(
-            amount = account.transparent.balance,
+            amount = balances.transparentBalance,
             onShieldClick = ::onShieldClick
-        ).takeIf { account.isShieldingAvailable }
+        ).takeIf { balances.isShieldingAvailable }
 
     private fun onBack() = navigationRouter.back()
 
     private fun onShieldClick() = shieldFunds(closeCurrentScreen = true)
 }
+
+/**
+ * This account's derived balance figures, bundled once they have all loaded so the state builders
+ * above work with plain non-null values instead of each re-deriving (and re-null-checking) the same
+ * figures individually.
+ */
+private data class LoadedAccountBalances(
+    val isAllShielded: Boolean,
+    val totalBalance: Zatoshi,
+    val totalShieldedBalance: Zatoshi,
+    val spendableShieldedBalance: Zatoshi,
+    val pendingShieldedBalance: Zatoshi,
+    val isShieldedPending: Boolean,
+    val isShieldingAvailable: Boolean,
+    val transparentBalance: Zatoshi,
+)
+
+/**
+ * Null while any of this account's balance figures used by this screen has not loaded yet.
+ */
+private fun WalletAccount.loadedBalancesOrNull(): LoadedAccountBalances? =
+    LoadedAccountBalances(
+        isAllShielded = isAllShielded ?: return null,
+        totalBalance = totalBalance ?: return null,
+        totalShieldedBalance = totalShieldedBalance ?: return null,
+        spendableShieldedBalance = spendableShieldedBalance ?: return null,
+        pendingShieldedBalance = pendingShieldedBalance ?: return null,
+        isShieldedPending = isShieldedPending ?: return null,
+        isShieldingAvailable = isShieldingAvailable ?: return null,
+        transparentBalance = transparent.balance ?: return null,
+    )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/balances/spendable/SpendableBalanceVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/balances/spendable/SpendableBalanceVM.kt
@@ -8,6 +8,7 @@ import cash.z.ecc.sdk.extension.typicalFee
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
+import co.electriccoin.zcash.ui.common.model.LoadedAccountBalances
 import co.electriccoin.zcash.ui.common.model.WalletAccount
 import co.electriccoin.zcash.ui.common.repository.isPending
 import co.electriccoin.zcash.ui.common.usecase.GetTransactionsUseCase
@@ -55,7 +56,7 @@ class SpendableBalanceVM(
     @Suppress("ReturnCount")
     private fun createState(account: WalletAccount?, transactions: List<ListTransactionData>?): SpendableBalanceState? {
         if (account == null) return null
-        val balances = account.loadedBalancesOrNull() ?: return null
+        val balances = account.loadedBalances ?: return null
         return SpendableBalanceState(
             title = stringRes(R.string.balances_spendableBalance_title),
             message = createMessage(balances, transactions),
@@ -165,34 +166,3 @@ class SpendableBalanceVM(
 
     private fun onShieldClick() = shieldFunds(closeCurrentScreen = true)
 }
-
-/**
- * This account's derived balance figures, bundled once they have all loaded so the state builders
- * above work with plain non-null values instead of each re-deriving (and re-null-checking) the same
- * figures individually.
- */
-private data class LoadedAccountBalances(
-    val isAllShielded: Boolean,
-    val totalBalance: Zatoshi,
-    val totalShieldedBalance: Zatoshi,
-    val spendableShieldedBalance: Zatoshi,
-    val pendingShieldedBalance: Zatoshi,
-    val isShieldedPending: Boolean,
-    val isShieldingAvailable: Boolean,
-    val transparentBalance: Zatoshi,
-)
-
-/**
- * Null while any of this account's balance figures used by this screen has not loaded yet.
- */
-private fun WalletAccount.loadedBalancesOrNull(): LoadedAccountBalances? =
-    LoadedAccountBalances(
-        isAllShielded = isAllShielded ?: return null,
-        totalBalance = totalBalance ?: return null,
-        totalShieldedBalance = totalShieldedBalance ?: return null,
-        spendableShieldedBalance = spendableShieldedBalance ?: return null,
-        pendingShieldedBalance = pendingShieldedBalance ?: return null,
-        isShieldedPending = isShieldedPending ?: return null,
-        isShieldingAvailable = isShieldingAvailable ?: return null,
-        transparentBalance = this.transparentBalance ?: return null,
-    )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/shieldfunds/ShieldFundsInfoVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/home/shieldfunds/ShieldFundsInfoVM.kt
@@ -34,7 +34,7 @@ class ShieldFundsInfoVM(
             getSelectedWalletAccount.observe(),
             shieldFundsInfoProvider.observe(),
         ) { account, infoEnabled ->
-            val transparentAmount = account?.transparent?.balance ?: Zatoshi(0)
+            val transparentAmount = account?.transparentBalance ?: Zatoshi(0)
             ShieldFundsInfoState(
                 onBack = ::onBack,
                 primaryButton =

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/ExactOutputVMMapper.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/ExactOutputVMMapper.kt
@@ -416,7 +416,7 @@ private data class ExactOutputInternalState(
      * both text fields) renders from, computed once per state instance so the rule can never drift
      * between them.
      */
-    val isInsufficientFunds: Boolean = getZatoshi()?.let { !canSpend(it) } == true
+    val isInsufficientFunds: Boolean = getZatoshi()?.let { canSpend(it) == false } == true
 
     fun getOriginFiatAmount(): BigDecimal? {
         val tokenAmount = amount.amount

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayVM.kt
@@ -317,14 +317,15 @@ internal interface InternalState {
     val swapAssets: SwapAssetsData
     val isEphemeralAddressLocked: Boolean
 
-    val totalSpendableBalance: Zatoshi
+    val totalSpendableBalance: Zatoshi?
         get() = account.totalSpendableBalance
 
     /**
      * Delegates to the shared [co.electriccoin.zcash.ui.common.model.canSpend] primitive.
-     * Re-evaluated whenever the selected account emits a new balance.
+     * Re-evaluated whenever the selected account emits a new balance. Null while the balance has
+     * not loaded yet.
      */
-    fun canSpend(amount: Zatoshi): Boolean = account.canSpend(amount)
+    fun canSpend(amount: Zatoshi): Boolean? = account.canSpend(amount)
 }
 
 internal data class InternalStateImpl(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/pay/PayVM.kt
@@ -10,7 +10,6 @@ import co.electriccoin.zcash.ui.common.model.SwapAsset
 import co.electriccoin.zcash.ui.common.model.SwapMode
 import co.electriccoin.zcash.ui.common.model.WalletAccount
 import co.electriccoin.zcash.ui.common.model.canSpend
-import co.electriccoin.zcash.ui.common.model.totalSpendableBalance
 import co.electriccoin.zcash.ui.common.repository.DEFAULT_SLIPPAGE
 import co.electriccoin.zcash.ui.common.repository.EnhancedABContact
 import co.electriccoin.zcash.ui.common.repository.SwapAssetsData
@@ -316,9 +315,6 @@ internal interface InternalState {
     val account: WalletAccount?
     val swapAssets: SwapAssetsData
     val isEphemeralAddressLocked: Boolean
-
-    val totalSpendableBalance: Zatoshi?
-        get() = account.totalSpendableBalance
 
     /**
      * Delegates to the shared [co.electriccoin.zcash.ui.common.model.canSpend] primitive.

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/qrcode/ext/WalletAddressesExt.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/qrcode/ext/WalletAddressesExt.kt
@@ -1,11 +1,12 @@
 package co.electriccoin.zcash.ui.screen.qrcode.ext
 
+import cash.z.ecc.android.sdk.model.WalletAddress
 import co.electriccoin.zcash.ui.common.model.WalletAccount
 import co.electriccoin.zcash.ui.screen.receive.ReceiveAddressType
 
-internal fun WalletAccount.fromReceiveAddressType(receiveAddressType: ReceiveAddressType) =
+internal suspend fun WalletAccount.fromReceiveAddressType(receiveAddressType: ReceiveAddressType): WalletAddress? =
     when (receiveAddressType) {
-        ReceiveAddressType.Unified -> this.unifiedAddress
-        ReceiveAddressType.Sapling -> this.saplingAddress
-        ReceiveAddressType.Transparent -> this.transparentAddress
+        ReceiveAddressType.Unified -> WalletAddress.Unified.new(unifiedAddress)
+        ReceiveAddressType.Sapling -> saplingAddress?.let { WalletAddress.Sapling.new(it) }
+        ReceiveAddressType.Transparent -> WalletAddress.Transparent.new(transparentAddress)
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/qrcode/ext/WalletAddressesExt.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/qrcode/ext/WalletAddressesExt.kt
@@ -5,7 +5,7 @@ import co.electriccoin.zcash.ui.screen.receive.ReceiveAddressType
 
 internal fun WalletAccount.fromReceiveAddressType(receiveAddressType: ReceiveAddressType) =
     when (receiveAddressType) {
-        ReceiveAddressType.Unified -> this.unified.address
-        ReceiveAddressType.Sapling -> this.sapling?.address
-        ReceiveAddressType.Transparent -> this.transparent.address
+        ReceiveAddressType.Unified -> this.unifiedAddress
+        ReceiveAddressType.Sapling -> this.saplingAddress
+        ReceiveAddressType.Transparent -> this.transparentAddress
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/receive/ReceiveVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/receive/ReceiveVM.kt
@@ -45,14 +45,14 @@ class ReceiveVM(
                     listOfNotNull(
                         createAddressState(
                             account = account,
-                            address = account.unifiedAddress.address,
+                            address = account.unifiedAddress,
                             type = Unified,
                             isExpanded = expandedIndex == 0,
                             onClick = { onAddressClick(0) }
                         ),
                         createAddressState(
                             account = account,
-                            address = account.transparentAddress.address,
+                            address = account.transparentAddress,
                             type = Transparent,
                             isExpanded = expandedIndex == 1,
                             onClick = { onAddressClick(1) }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/receive/ReceiveVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/receive/ReceiveVM.kt
@@ -45,14 +45,14 @@ class ReceiveVM(
                     listOfNotNull(
                         createAddressState(
                             account = account,
-                            address = account.unified.address.address,
+                            address = account.unifiedAddress.address,
                             type = Unified,
                             isExpanded = expandedIndex == 0,
                             onClick = { onAddressClick(0) }
                         ),
                         createAddressState(
                             account = account,
-                            address = account.transparent.address.address,
+                            address = account.transparentAddress.address,
                             type = Transparent,
                             isExpanded = expandedIndex == 1,
                             onClick = { onAddressClick(1) }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/AndroidSend.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/AndroidSend.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalContext
@@ -22,11 +23,11 @@ import co.electriccoin.zcash.ui.common.appbar.ZashiTopAppBarVM
 import co.electriccoin.zcash.ui.common.compose.LocalActivity
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.model.WalletAccount
-import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import co.electriccoin.zcash.ui.common.repository.ExchangeRateRepository
 import co.electriccoin.zcash.ui.common.usecase.ObserveClearSendUseCase
 import co.electriccoin.zcash.ui.common.usecase.PrefillSendData
 import co.electriccoin.zcash.ui.common.usecase.PrefillSendUseCase
+import co.electriccoin.zcash.ui.common.usecase.ValidateAddressUseCase
 import co.electriccoin.zcash.ui.common.wallet.ExchangeRateState
 import co.electriccoin.zcash.ui.design.component.CircularScreenProgressIndicator
 import co.electriccoin.zcash.ui.design.util.StringResource.Companion.NUMBER_FORMAT_LOCALE
@@ -44,6 +45,7 @@ import co.electriccoin.zcash.ui.screen.send.model.MemoState
 import co.electriccoin.zcash.ui.screen.send.model.RecipientAddressState
 import co.electriccoin.zcash.ui.screen.send.model.SendStage
 import co.electriccoin.zcash.ui.screen.send.view.Send
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
@@ -114,7 +116,7 @@ internal fun WrapSend(
 
     val viewModel = koinViewModel<SendViewModel>()
 
-    val synchronizerProvider = koinInject<SynchronizerProvider>()
+    val validateAddress = koinInject<ValidateAddressUseCase>()
 
     val sendAddressBookState by viewModel.sendAddressBookState.collectAsStateWithLifecycle()
 
@@ -219,7 +221,7 @@ internal fun WrapSend(
         prefillSend().collect {
             when (it) {
                 is PrefillSendData.All -> {
-                    val type = synchronizerProvider.getSynchronizer().validateAddress(it.address.orEmpty())
+                    val type = validateAddress(it.address.orEmpty())
                     setSendStage(SendStage.Form)
                     setZecSend(null)
                     viewModel.onRecipientAddressChanged(
@@ -249,7 +251,7 @@ internal fun WrapSend(
                 }
 
                 is PrefillSendData.FromAddressScan -> {
-                    val type = synchronizerProvider.getSynchronizer().validateAddress(it.address)
+                    val type = validateAddress(it.address)
                     setSendStage(SendStage.Form)
                     setZecSend(null)
                     viewModel.onRecipientAddressChanged(
@@ -279,6 +281,8 @@ internal fun WrapSend(
         }
     }
 
+    val recipientValidationJob = remember { mutableStateOf<Job?>(null) }
+
     if (null == selectedAccount) {
         // TODO [#1146]: Consider moving CircularScreenProgressIndicator from Android layer to View layer
         // TODO [#1146]: Improve this by allowing screen composition and updating it after the data is available
@@ -299,17 +303,19 @@ internal fun WrapSend(
             onQrScannerOpen = goToQrScanner,
             hasCameraFeature = hasCameraFeature,
             recipientAddressState = recipientAddressState,
-            onRecipientAddressChange = {
-                scope.launch {
-                    viewModel.onRecipientAddressChanged(
-                        RecipientAddressState.new(
-                            address = it,
-                            // TODO [#342]: Verify Addresses without Synchronizer
-                            // TODO [#342]: https://github.com/zcash/zcash-android-wallet-sdk/issues/342
-                            type = synchronizerProvider.getSynchronizer().validateAddress(it)
+            onRecipientAddressChange = { newAddress ->
+                recipientValidationJob.value?.cancel()
+                recipientValidationJob.value =
+                    scope.launch {
+                        viewModel.onRecipientAddressChanged(
+                            RecipientAddressState.new(
+                                address = newAddress,
+                                // TODO [#342]: Verify Addresses without Synchronizer
+                                // TODO [#342]: https://github.com/zcash/zcash-android-wallet-sdk/issues/342
+                                type = validateAddress(newAddress)
+                            )
                         )
-                    )
-                }
+                    }
             },
             setAmountState = setAmountState,
             amountState = amountState,

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/AndroidSend.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/AndroidSend.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.model.ZecSend
 import cash.z.ecc.android.sdk.model.toZecString
 import cash.z.ecc.android.sdk.type.AddressType
@@ -23,11 +22,11 @@ import co.electriccoin.zcash.ui.common.appbar.ZashiTopAppBarVM
 import co.electriccoin.zcash.ui.common.compose.LocalActivity
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
 import co.electriccoin.zcash.ui.common.model.WalletAccount
+import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import co.electriccoin.zcash.ui.common.repository.ExchangeRateRepository
 import co.electriccoin.zcash.ui.common.usecase.ObserveClearSendUseCase
 import co.electriccoin.zcash.ui.common.usecase.PrefillSendData
 import co.electriccoin.zcash.ui.common.usecase.PrefillSendUseCase
-import co.electriccoin.zcash.ui.common.viewmodel.WalletViewModel
 import co.electriccoin.zcash.ui.common.wallet.ExchangeRateState
 import co.electriccoin.zcash.ui.design.component.CircularScreenProgressIndicator
 import co.electriccoin.zcash.ui.design.util.StringResource.Companion.NUMBER_FORMAT_LOCALE
@@ -56,8 +55,6 @@ internal fun WrapSend(args: Send) {
 
     val navigationRouter = koinInject<NavigationRouter>()
 
-    val walletViewModel = koinActivityViewModel<WalletViewModel>()
-
     val balanceWidgetVM =
         koinViewModel<BalanceWidgetVM> {
             parametersOf(
@@ -74,8 +71,6 @@ internal fun WrapSend(args: Send) {
     val exchangeRateRepository = koinInject<ExchangeRateRepository>()
 
     val hasCameraFeature = activity.packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY)
-
-    val synchronizer = walletViewModel.synchronizer.collectAsStateWithLifecycle().value
 
     val selectedAccount = accountDataSource.selectedAccount.collectAsStateWithLifecycle(null).value
 
@@ -99,7 +94,6 @@ internal fun WrapSend(args: Send) {
         goBack = { navigationRouter.back() },
         hasCameraFeature = hasCameraFeature,
         sendArguments = args,
-        synchronizer = synchronizer,
         selectedAccount = selectedAccount
     )
 }
@@ -114,12 +108,13 @@ internal fun WrapSend(
     goBack: () -> Unit,
     hasCameraFeature: Boolean,
     sendArguments: Send,
-    synchronizer: Synchronizer?,
     selectedAccount: WalletAccount?,
 ) {
     val scope = rememberCoroutineScope()
 
     val viewModel = koinViewModel<SendViewModel>()
+
+    val synchronizerProvider = koinInject<SynchronizerProvider>()
 
     val sendAddressBookState by viewModel.sendAddressBookState.collectAsStateWithLifecycle()
 
@@ -224,7 +219,7 @@ internal fun WrapSend(
         prefillSend().collect {
             when (it) {
                 is PrefillSendData.All -> {
-                    val type = synchronizer?.validateAddress(it.address.orEmpty())
+                    val type = synchronizerProvider.getSynchronizer().validateAddress(it.address.orEmpty())
                     setSendStage(SendStage.Form)
                     setZecSend(null)
                     viewModel.onRecipientAddressChanged(
@@ -254,7 +249,7 @@ internal fun WrapSend(
                 }
 
                 is PrefillSendData.FromAddressScan -> {
-                    val type = synchronizer?.validateAddress(it.address)
+                    val type = synchronizerProvider.getSynchronizer().validateAddress(it.address)
                     setSendStage(SendStage.Form)
                     setZecSend(null)
                     viewModel.onRecipientAddressChanged(
@@ -284,7 +279,7 @@ internal fun WrapSend(
         }
     }
 
-    if (null == synchronizer || null == selectedAccount) {
+    if (null == selectedAccount) {
         // TODO [#1146]: Consider moving CircularScreenProgressIndicator from Android layer to View layer
         // TODO [#1146]: Improve this by allowing screen composition and updating it after the data is available
         // TODO [#1146]: https://github.com/Electric-Coin-Company/zashi-android/issues/1146
@@ -311,7 +306,7 @@ internal fun WrapSend(
                             address = it,
                             // TODO [#342]: Verify Addresses without Synchronizer
                             // TODO [#342]: https://github.com/zcash/zcash-android-wallet-sdk/issues/342
-                            type = synchronizer.validateAddress(it)
+                            type = synchronizerProvider.getSynchronizer().validateAddress(it)
                         )
                     )
                 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/SendViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/SendViewModel.kt
@@ -57,7 +57,7 @@ class SendViewModel(
                         flow {
                             val exists =
                                 contact != null ||
-                                    accounts.any { it.unifiedAddress.address == recipientAddressState.address }
+                                    accounts.any { it.unifiedAddress == recipientAddressState.address }
                             val isValid = recipientAddressState.type?.isNotValid == false
                             val mode =
                                 if (isValid) {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/SendViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/SendViewModel.kt
@@ -57,7 +57,7 @@ class SendViewModel(
                         flow {
                             val exists =
                                 contact != null ||
-                                    accounts.any { it.unified.address.address == recipientAddressState.address }
+                                    accounts.any { it.unifiedAddress.address == recipientAddressState.address }
                             val isValid = recipientAddressState.type?.isNotValid == false
                             val mode =
                                 if (isValid) {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/view/SendView.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/send/view/SendView.kt
@@ -346,7 +346,7 @@ fun SendButton(
             recipientAddressState.address.isNotEmpty() &&
             amountState is AmountState.Valid &&
             amountState.value.getValue().isNotBlank() &&
-            selectedAccount.canSpend(amountState.zatoshi) &&
+            selectedAccount.canSpend(amountState.zatoshi) == true &&
             // A valid memo is necessary only for non-transparent recipient
             (recipientAddressState.type == AddressType.Transparent || memoState is MemoState.Correct)
 
@@ -574,7 +574,8 @@ fun SendFormAmountTextField(
             }
 
             is AmountState.Valid -> {
-                if (selectedAccount.spendableShieldedBalance < amountState.zatoshi) {
+                val spendableShieldedBalance = selectedAccount.spendableShieldedBalance
+                if (spendableShieldedBalance != null && spendableShieldedBalance < amountState.zatoshi) {
                     stringResource(id = R.string.sheet_insufficientBalance_title)
                 } else {
                     null

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/signkeystonetransaction/SignKeystoneTransactionVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/signkeystonetransaction/SignKeystoneTransactionVM.kt
@@ -85,9 +85,9 @@ class SignKeystoneTransactionVM(
                         title = wallet.name,
                         subtitle =
                             if (proposal is ShieldTransactionProposal) {
-                                stringRes("${wallet.transparent.address.address.take(ADDRESS_MAX_LENGTH)}...")
+                                stringRes("${wallet.transparentAddress.address.take(ADDRESS_MAX_LENGTH)}...")
                             } else {
-                                stringRes("${wallet.unified.address.address.take(ADDRESS_MAX_LENGTH)}...")
+                                stringRes("${wallet.unifiedAddress.address.take(ADDRESS_MAX_LENGTH)}...")
                             }
                     ),
                 badgeText = stringRes(R.string.keystone_signWith_hardware),

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/signkeystonetransaction/SignKeystoneTransactionVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/signkeystonetransaction/SignKeystoneTransactionVM.kt
@@ -85,9 +85,9 @@ class SignKeystoneTransactionVM(
                         title = wallet.name,
                         subtitle =
                             if (proposal is ShieldTransactionProposal) {
-                                stringRes("${wallet.transparentAddress.address.take(ADDRESS_MAX_LENGTH)}...")
+                                stringRes("${wallet.transparentAddress.take(ADDRESS_MAX_LENGTH)}...")
                             } else {
-                                stringRes("${wallet.unifiedAddress.address.take(ADDRESS_MAX_LENGTH)}...")
+                                stringRes("${wallet.unifiedAddress.take(ADDRESS_MAX_LENGTH)}...")
                             }
                     ),
                 badgeText = stringRes(R.string.keystone_signWith_hardware),

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVM.kt
@@ -13,7 +13,6 @@ import co.electriccoin.zcash.ui.common.model.SwapDirection.SWAP_INTO_ZEC
 import co.electriccoin.zcash.ui.common.model.SwapMode
 import co.electriccoin.zcash.ui.common.model.WalletAccount
 import co.electriccoin.zcash.ui.common.model.canSpend
-import co.electriccoin.zcash.ui.common.model.totalSpendableBalance
 import co.electriccoin.zcash.ui.common.repository.DEFAULT_SLIPPAGE
 import co.electriccoin.zcash.ui.common.repository.EnhancedABContact
 import co.electriccoin.zcash.ui.common.repository.SwapAssetsData
@@ -373,9 +372,6 @@ internal interface InternalState {
     val selectedContact: EnhancedABContact?
     val swapDirection: SwapDirection
     val isEphemeralAddressLocked: Boolean
-
-    val totalSpendableBalance: Zatoshi?
-        get() = account.totalSpendableBalance
 
     /**
      * Delegates to the shared [co.electriccoin.zcash.ui.common.model.canSpend] primitive — the same

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVM.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVM.kt
@@ -374,16 +374,17 @@ internal interface InternalState {
     val swapDirection: SwapDirection
     val isEphemeralAddressLocked: Boolean
 
-    val totalSpendableBalance: Zatoshi
+    val totalSpendableBalance: Zatoshi?
         get() = account.totalSpendableBalance
 
     /**
      * Delegates to the shared [co.electriccoin.zcash.ui.common.model.canSpend] primitive — the same
      * one the pre-quote check in
      * [co.electriccoin.zcash.ui.common.usecase.RequestSwapQuoteUseCase.requestExactInput] validates
-     * against. Re-evaluated whenever the selected account emits a new balance.
+     * against. Re-evaluated whenever the selected account emits a new balance. Null while the
+     * balance has not loaded yet.
      */
-    fun canSpend(amount: Zatoshi): Boolean = account.canSpend(amount)
+    fun canSpend(amount: Zatoshi): Boolean? = account.canSpend(amount)
 }
 
 internal data class InternalStateImpl(

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVMMapper.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVMMapper.kt
@@ -161,7 +161,7 @@ internal class SwapVMMapper {
             error =
                 when (state.swapDirection) {
                     SWAP_FROM_ZEC -> {
-                        if (originAmount != null && !state.canSpend(originAmount.convertZecToZatoshi())) {
+                        if (originAmount != null && state.canSpend(originAmount.convertZecToZatoshi()) == false) {
                             stringRes(R.string.send_error_insufficientFunds)
                         } else {
                             null
@@ -271,51 +271,51 @@ internal class SwapVMMapper {
         )
     }
 
+    @Suppress("CyclomaticComplexMethod", "ReturnCount")
     private fun createMaxState(
         state: SwapInternalState,
         onBalanceButtonClick: () -> Unit
     ): ButtonState {
-        val account =
-            state.account ?: return ButtonState(
+        val loadingState =
+            ButtonState(
                 text = stringRes(R.string.balance_availableTitle),
                 isLoading = true,
                 onClick = onBalanceButtonClick
             )
 
+        val account = state.account ?: return loadingState
+        val totalBalance = account.totalBalance ?: return loadingState
+        val spendableShieldedBalance = account.spendableShieldedBalance ?: return loadingState
+        val isShieldedPending = account.isShieldedPending ?: return loadingState
+        val totalShieldedBalance = account.totalShieldedBalance ?: return loadingState
+        val totalTransparentBalance = account.totalTransparentBalance ?: return loadingState
+
         return when {
-            account.totalBalance > account.spendableShieldedBalance &&
-                account.isShieldedPending &&
-                account.totalShieldedBalance > Zatoshi(0) &&
-                account.spendableShieldedBalance == Zatoshi(0) -> {
-                ButtonState(
-                    text = stringRes(R.string.balance_availableTitle),
-                    isLoading = true,
-                    onClick = onBalanceButtonClick
-                )
+            totalBalance > spendableShieldedBalance &&
+                isShieldedPending &&
+                totalShieldedBalance > Zatoshi(0) &&
+                spendableShieldedBalance == Zatoshi(0) -> {
+                loadingState
             }
 
-            account.totalBalance > account.spendableShieldedBalance &&
-                !account.isShieldedPending &&
-                account.totalShieldedBalance > Zatoshi(0) &&
-                account.spendableShieldedBalance == Zatoshi(0) &&
-                account.totalTransparentBalance == Zatoshi(0) -> {
-                ButtonState(
-                    text = stringRes(R.string.balance_availableTitle),
-                    isLoading = true,
-                    onClick = onBalanceButtonClick
-                )
+            totalBalance > spendableShieldedBalance &&
+                !isShieldedPending &&
+                totalShieldedBalance > Zatoshi(0) &&
+                spendableShieldedBalance == Zatoshi(0) &&
+                totalTransparentBalance == Zatoshi(0) -> {
+                loadingState
             }
 
             else -> {
                 val amount =
                     when (state.currencyType) {
                         TOKEN -> {
-                            stringRes(state.totalSpendableBalance, TickerLocation.HIDDEN)
+                            stringRes(spendableShieldedBalance, TickerLocation.HIDDEN)
                         }
 
                         FIAT -> {
                             stringResByDynamicCurrencyNumber(
-                                state.getTotalSpendableFiatBalance(),
+                                state.getTotalSpendableFiatBalance(spendableShieldedBalance),
                                 FiatCurrency.USD.symbol
                             )
                         }
@@ -323,7 +323,6 @@ internal class SwapVMMapper {
 
                 ButtonState(
                     text = stringRes(R.string.swapAndPay_max, amount.asPrivacySensitive()),
-                    // amount = account.spendableShieldedBalance,
                     isLoading = false,
                     onClick = onBalanceButtonClick
                 )
@@ -586,7 +585,7 @@ private data class SwapInternalState(
             SWAP_INTO_ZEC -> swapAssets.zecAsset
         }
 
-    fun getTotalSpendableFiatBalance(): BigDecimal {
+    fun getTotalSpendableFiatBalance(spendableShieldedBalance: Zatoshi): BigDecimal {
         fun Long.convertZatoshiToZecBigDecimal(scale: Int = ZEC_FORMATTER.maximumFractionDigits): BigDecimal =
             BigDecimal(this, MathContext.DECIMAL128)
                 .divide(
@@ -595,7 +594,7 @@ private data class SwapInternalState(
                 ).setScale(scale, ZEC_FORMATTER.roundingMode)
 
         if (swapAssets.zecAsset?.usdPrice == null) return BigDecimal(0)
-        return totalSpendableBalance.value
+        return spendableShieldedBalance.value
             .convertZatoshiToZecBigDecimal()
             .multiply(swapAssets.zecAsset.usdPrice, MathContext.DECIMAL128)
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVMMapper.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/swap/SwapVMMapper.kt
@@ -283,26 +283,21 @@ internal class SwapVMMapper {
                 onClick = onBalanceButtonClick
             )
 
-        val account = state.account ?: return loadingState
-        val totalBalance = account.totalBalance ?: return loadingState
-        val spendableShieldedBalance = account.spendableShieldedBalance ?: return loadingState
-        val isShieldedPending = account.isShieldedPending ?: return loadingState
-        val totalShieldedBalance = account.totalShieldedBalance ?: return loadingState
-        val totalTransparentBalance = account.totalTransparentBalance ?: return loadingState
+        val b = state.account?.loadedBalances ?: return loadingState
 
         return when {
-            totalBalance > spendableShieldedBalance &&
-                isShieldedPending &&
-                totalShieldedBalance > Zatoshi(0) &&
-                spendableShieldedBalance == Zatoshi(0) -> {
+            b.totalBalance > b.spendableShieldedBalance &&
+                b.isShieldedPending &&
+                b.totalShieldedBalance > Zatoshi(0) &&
+                b.spendableShieldedBalance == Zatoshi(0) -> {
                 loadingState
             }
 
-            totalBalance > spendableShieldedBalance &&
-                !isShieldedPending &&
-                totalShieldedBalance > Zatoshi(0) &&
-                spendableShieldedBalance == Zatoshi(0) &&
-                totalTransparentBalance == Zatoshi(0) -> {
+            b.totalBalance > b.spendableShieldedBalance &&
+                !b.isShieldedPending &&
+                b.totalShieldedBalance > Zatoshi(0) &&
+                b.spendableShieldedBalance == Zatoshi(0) &&
+                b.totalTransparentBalance == Zatoshi(0) -> {
                 loadingState
             }
 
@@ -310,12 +305,12 @@ internal class SwapVMMapper {
                 val amount =
                     when (state.currencyType) {
                         TOKEN -> {
-                            stringRes(spendableShieldedBalance, TickerLocation.HIDDEN)
+                            stringRes(b.spendableShieldedBalance, TickerLocation.HIDDEN)
                         }
 
                         FIAT -> {
                             stringResByDynamicCurrencyNumber(
-                                state.getTotalSpendableFiatBalance(spendableShieldedBalance),
+                                state.getTotalSpendableFiatBalance(b.spendableShieldedBalance),
                                 FiatCurrency.USD.symbol
                             )
                         }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSourceImplTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSourceImplTest.kt
@@ -13,8 +13,9 @@ import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
@@ -78,23 +79,13 @@ class AccountDataSourceImplTest {
         )
     }
 
-    private suspend fun <T : Any> awaitValue(timeoutMs: Long = 5_000, poll: () -> T?): T =
-        withTimeout(timeoutMs) {
-            var result = poll()
-            while (result == null) {
-                delay(10)
-                result = poll()
-            }
-            result
-        }
-
     @Test
     fun nullBalancesMapEmitsAccountWithNullBalancesRatherThanNoEmissionOrZeros() =
         runBlocking {
             val walletBalances = MutableStateFlow<Map<AccountUuid, AccountBalance>?>(null)
             val dataSource = dataSource(walletBalances)
 
-            val accounts = awaitValue { dataSource.allAccounts.value }
+            val accounts = withTimeout(5_000) { dataSource.allAccounts.filterNotNull().first() }
 
             assertEquals(1, accounts.size)
             val zashiAccount = accounts.single() as ZashiAccount
@@ -122,7 +113,7 @@ class AccountDataSourceImplTest {
                 )
             val dataSource = dataSource(walletBalances)
 
-            val accounts = awaitValue { dataSource.allAccounts.value }
+            val accounts = withTimeout(5_000) { dataSource.allAccounts.filterNotNull().first() }
 
             assertEquals(1, accounts.size)
             val zashiAccount = accounts.single() as ZashiAccount

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSourceImplTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSourceImplTest.kt
@@ -98,9 +98,9 @@ class AccountDataSourceImplTest {
 
             assertEquals(1, accounts.size)
             val zashiAccount = accounts.single() as ZashiAccount
-            assertNull(zashiAccount.unified.balance)
-            assertNull(zashiAccount.transparent.balance)
-            assertNull(zashiAccount.sapling.balance)
+            assertNull(zashiAccount.unifiedBalance)
+            assertNull(zashiAccount.transparentBalance)
+            assertNull(zashiAccount.saplingBalance)
             assertNull(zashiAccount.ironwoodBalance)
             assertNull(zashiAccount.totalBalance)
             assertNull(zashiAccount.totalShieldedBalance)
@@ -126,10 +126,10 @@ class AccountDataSourceImplTest {
 
             assertEquals(1, accounts.size)
             val zashiAccount = accounts.single() as ZashiAccount
-            assertNotNull(zashiAccount.unified.balance)
-            assertEquals(Zatoshi(500_000L), zashiAccount.unified.balance.available)
-            assertEquals(Zatoshi(250_000L), zashiAccount.transparent.balance)
-            assertEquals(Zatoshi(0), zashiAccount.sapling.balance?.available)
+            assertNotNull(zashiAccount.unifiedBalance)
+            assertEquals(Zatoshi(500_000L), zashiAccount.unifiedBalance.available)
+            assertEquals(Zatoshi(250_000L), zashiAccount.transparentBalance)
+            assertEquals(Zatoshi(0), zashiAccount.saplingBalance?.available)
             assertEquals(Zatoshi(0), zashiAccount.ironwoodBalance?.available)
             assertEquals(Zatoshi(750_000L), zashiAccount.totalBalance)
             assertEquals(Zatoshi(500_000L), zashiAccount.spendableShieldedBalance)

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSourceImplTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSourceImplTest.kt
@@ -1,0 +1,137 @@
+package co.electriccoin.zcash.ui.common.datasource
+
+import cash.z.ecc.android.sdk.Synchronizer
+import cash.z.ecc.android.sdk.model.Account
+import cash.z.ecc.android.sdk.model.AccountBalance
+import cash.z.ecc.android.sdk.model.AccountUuid
+import cash.z.ecc.android.sdk.model.WalletBalance
+import cash.z.ecc.android.sdk.model.Zatoshi
+import co.electriccoin.zcash.ui.common.model.ZashiAccount
+import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
+import co.electriccoin.zcash.ui.common.provider.SelectedAccountUUIDProvider
+import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * MOB-1723: a null balances snapshot from the synchronizer must propagate as null through every
+ * account's balance fields — never suppressed (a fresh wallet's accounts stay invisible) and never
+ * defaulted to zero (a truth claim the wallet hasn't made yet).
+ */
+class AccountDataSourceImplTest {
+    private val accountUuid = AccountUuid.new(ByteArray(16) { it.toByte() })
+    private val account = Account.new(accountUuid)
+
+    private fun zeroBalance() = WalletBalance(Zatoshi(0), Zatoshi(0), Zatoshi(0))
+
+    private fun accountBalance(
+        available: Long,
+        unshielded: Long,
+    ): Map<AccountUuid, AccountBalance> =
+        mapOf(
+            accountUuid to
+                AccountBalance(
+                    sapling = zeroBalance(),
+                    orchard = zeroBalance().copy(available = Zatoshi(available)),
+                    ironwood = zeroBalance(),
+                    unshielded = Zatoshi(unshielded),
+                )
+        )
+
+    private fun dataSource(
+        walletBalances: MutableStateFlow<Map<AccountUuid, AccountBalance>?>
+    ): AccountDataSourceImpl {
+        val synchronizer =
+            mockk<Synchronizer> {
+                every { accountsFlow } returns MutableStateFlow(listOf(account))
+                every { this@mockk.walletBalances } returns walletBalances
+                coEvery { getCustomUnifiedAddress(any(), any()) } returns "unified-address"
+                coEvery { getTransparentAddress(any()) } returns "transparent-address"
+                coEvery { getSaplingAddress(any()) } returns "sapling-address"
+            }
+        val synchronizerProvider =
+            mockk<SynchronizerProvider> {
+                every { this@mockk.synchronizer } returns MutableStateFlow(synchronizer)
+            }
+        val selectedAccountUUIDProvider =
+            mockk<SelectedAccountUUIDProvider> {
+                every { uuid } returns MutableStateFlow(null)
+            }
+        val persistableWalletProvider =
+            mockk<PersistableWalletProvider> {
+                every { persistableWallet } returns MutableStateFlow(mockk(relaxed = true))
+            }
+        return AccountDataSourceImpl(
+            synchronizerProvider = synchronizerProvider,
+            selectedAccountUUIDProvider = selectedAccountUUIDProvider,
+            persistableWalletProvider = persistableWalletProvider,
+            context = mockk(relaxed = true),
+        )
+    }
+
+    private suspend fun <T : Any> awaitValue(timeoutMs: Long = 5_000, poll: () -> T?): T =
+        withTimeout(timeoutMs) {
+            var result = poll()
+            while (result == null) {
+                delay(10)
+                result = poll()
+            }
+            result
+        }
+
+    @Test
+    fun nullBalancesMapEmitsAccountWithNullBalancesRatherThanNoEmissionOrZeros() =
+        runBlocking {
+            val walletBalances = MutableStateFlow<Map<AccountUuid, AccountBalance>?>(null)
+            val dataSource = dataSource(walletBalances)
+
+            val accounts = awaitValue { dataSource.allAccounts.value }
+
+            assertEquals(1, accounts.size)
+            val zashiAccount = accounts.single() as ZashiAccount
+            assertNull(zashiAccount.unified.balance)
+            assertNull(zashiAccount.transparent.balance)
+            assertNull(zashiAccount.sapling.balance)
+            assertNull(zashiAccount.ironwoodBalance)
+            assertNull(zashiAccount.totalBalance)
+            assertNull(zashiAccount.totalShieldedBalance)
+            assertNull(zashiAccount.totalTransparentBalance)
+            assertNull(zashiAccount.spendableShieldedBalance)
+            assertNull(zashiAccount.pendingShieldedBalance)
+            assertNull(zashiAccount.isShieldedPending)
+            assertNull(zashiAccount.isShieldingAvailable)
+            assertNull(zashiAccount.isAllShielded)
+            assertNull(zashiAccount.canSpend(Zatoshi(0)))
+        }
+
+    @Test
+    fun realBalancesSnapshotPopulatesRealValues() =
+        runBlocking {
+            val walletBalances =
+                MutableStateFlow<Map<AccountUuid, AccountBalance>?>(
+                    accountBalance(available = 500_000L, unshielded = 250_000L)
+                )
+            val dataSource = dataSource(walletBalances)
+
+            val accounts = awaitValue { dataSource.allAccounts.value }
+
+            assertEquals(1, accounts.size)
+            val zashiAccount = accounts.single() as ZashiAccount
+            assertNotNull(zashiAccount.unified.balance)
+            assertEquals(Zatoshi(500_000L), zashiAccount.unified.balance.available)
+            assertEquals(Zatoshi(250_000L), zashiAccount.transparent.balance)
+            assertEquals(Zatoshi(0), zashiAccount.sapling.balance?.available)
+            assertEquals(Zatoshi(0), zashiAccount.ironwoodBalance?.available)
+            assertEquals(Zatoshi(750_000L), zashiAccount.totalBalance)
+            assertEquals(Zatoshi(500_000L), zashiAccount.spendableShieldedBalance)
+        }
+}

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSourceImplTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/datasource/AccountDataSourceImplTest.kt
@@ -126,8 +126,9 @@ class AccountDataSourceImplTest {
 
             assertEquals(1, accounts.size)
             val zashiAccount = accounts.single() as ZashiAccount
-            assertNotNull(zashiAccount.unifiedBalance)
-            assertEquals(Zatoshi(500_000L), zashiAccount.unifiedBalance.available)
+            val unifiedBalance = zashiAccount.unifiedBalance
+            assertNotNull(unifiedBalance)
+            assertEquals(Zatoshi(500_000L), unifiedBalance.available)
             assertEquals(Zatoshi(250_000L), zashiAccount.transparentBalance)
             assertEquals(Zatoshi(0), zashiAccount.saplingBalance?.available)
             assertEquals(Zatoshi(0), zashiAccount.ironwoodBalance?.available)

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/provider/SynchronizerProviderTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/provider/SynchronizerProviderTest.kt
@@ -1,39 +1,32 @@
 package co.electriccoin.zcash.ui.common.provider
 
-import cash.z.ecc.android.sdk.Synchronizer
-import io.mockk.mockk
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNull
-import kotlin.test.assertSame
 
 class SynchronizerProviderTest {
     @Test
-    fun retainsSynchronizerDuringWalletRebuild() {
-        val retained = mockk<Synchronizer>()
-
-        assertSame(
-            retained,
-            resolveRetainedSynchronizer(retained, current = null, hasWallet = true)
+    fun retainsPreviousValueDuringRebuild() {
+        assertEquals(
+            "retained",
+            resolveRetained(retained = "retained", current = null, hasWallet = true)
         )
     }
 
     @Test
-    fun replacesRetainedSynchronizer() {
-        val retained = mockk<Synchronizer>()
-        val replacement = mockk<Synchronizer>()
-
-        assertSame(
-            replacement,
-            resolveRetainedSynchronizer(retained, current = replacement, hasWallet = true)
+    fun replacesRetainedValue() {
+        assertEquals(
+            "replacement",
+            resolveRetained(retained = "retained", current = "replacement", hasWallet = true)
         )
     }
 
     @Test
-    fun clearsRetainedSynchronizerWithoutWallet() {
+    fun clearsRetainedValueWithoutWallet() {
         assertNull(
-            resolveRetainedSynchronizer(
-                retained = mockk(),
-                current = mockk(),
+            resolveRetained(
+                retained = "retained",
+                current = "current",
                 hasWallet = false
             )
         )

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/provider/SynchronizerProviderTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/provider/SynchronizerProviderTest.kt
@@ -1,0 +1,41 @@
+package co.electriccoin.zcash.ui.common.provider
+
+import cash.z.ecc.android.sdk.Synchronizer
+import io.mockk.mockk
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class SynchronizerProviderTest {
+    @Test
+    fun retainsSynchronizerDuringWalletRebuild() {
+        val retained = mockk<Synchronizer>()
+
+        assertSame(
+            retained,
+            resolveRetainedSynchronizer(retained, current = null, hasWallet = true)
+        )
+    }
+
+    @Test
+    fun replacesRetainedSynchronizer() {
+        val retained = mockk<Synchronizer>()
+        val replacement = mockk<Synchronizer>()
+
+        assertSame(
+            replacement,
+            resolveRetainedSynchronizer(retained, current = replacement, hasWallet = true)
+        )
+    }
+
+    @Test
+    fun clearsRetainedSynchronizerWithoutWallet() {
+        assertNull(
+            resolveRetainedSynchronizer(
+                retained = mockk(),
+                current = mockk(),
+                hasWallet = false
+            )
+        )
+    }
+}

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepositoryTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepositoryTest.kt
@@ -10,6 +10,7 @@ import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -31,6 +32,8 @@ class AutomaticServerRepositoryTest {
     private val persistableWalletProvider = mockk<PersistableWalletProvider>(relaxed = true)
     private val lightWalletEndpointProvider =
         mockk<LightWalletEndpointProvider>(relaxed = true) { every { getEndpoints() } returns known }
+    private val synchronizerProvider =
+        mockk<SynchronizerProvider>(relaxed = true) { every { synchronizer } returns MutableStateFlow(null) }
 
     private val repository =
         AutomaticServerRepositoryImpl(
@@ -38,7 +41,7 @@ class AutomaticServerRepositoryTest {
             zashiProposalRepository = mockk(relaxed = true),
             keystoneProposalRepository = mockk(relaxed = true),
             applicationStateProvider = mockk(relaxed = true),
-            synchronizerProvider = mockk<SynchronizerProvider>(relaxed = true),
+            synchronizerProvider = synchronizerProvider,
             persistableWalletProvider = persistableWalletProvider,
             lightWalletEndpointProvider = lightWalletEndpointProvider,
             isServerSelectionAutomaticProvider = isAutomaticProvider

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepositoryTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepositoryTest.kt
@@ -2,9 +2,11 @@ package co.electriccoin.zcash.ui.common.repository
 
 import cash.z.ecc.android.sdk.model.PersistableWallet
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
+import co.electriccoin.zcash.ui.common.model.FastestServersState
 import co.electriccoin.zcash.ui.common.provider.IsServerSelectionAutomaticProvider
 import co.electriccoin.zcash.ui.common.provider.LightWalletEndpointProvider
 import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
+import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -36,6 +38,7 @@ class AutomaticServerRepositoryTest {
             zashiProposalRepository = mockk(relaxed = true),
             keystoneProposalRepository = mockk(relaxed = true),
             applicationStateProvider = mockk(relaxed = true),
+            synchronizerProvider = mockk<SynchronizerProvider>(relaxed = true),
             persistableWalletProvider = persistableWalletProvider,
             lightWalletEndpointProvider = lightWalletEndpointProvider,
             isServerSelectionAutomaticProvider = isAutomaticProvider
@@ -82,6 +85,16 @@ class AutomaticServerRepositoryTest {
 
             assertEquals(true, repository.isServerAutomatic())
         }
+
+    @Test
+    fun automaticCandidateWaitsForLocalBalanceSnapshot() {
+        val fastest = FastestServersState(servers = listOf(default), isLoading = false)
+        val loading = FastestServersState(servers = listOf(default), isLoading = true)
+
+        assertEquals(null, resolveAutomaticServerCandidate(fastest, localBalances = null))
+        assertEquals(null, resolveAutomaticServerCandidate(loading, localBalances = emptyMap<Any, Any>()))
+        assertEquals(default, resolveAutomaticServerCandidate(fastest, localBalances = emptyMap<Any, Any>()))
+    }
 
     private fun wallet(walletEndpoint: LightWalletEndpoint) =
         mockk<PersistableWallet> { every { endpoint } returns walletEndpoint }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetBalancePoolsUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetBalancePoolsUseCaseTest.kt
@@ -1,0 +1,105 @@
+package co.electriccoin.zcash.ui.common.usecase
+
+import cash.z.ecc.android.sdk.Synchronizer
+import cash.z.ecc.android.sdk.model.Account
+import cash.z.ecc.android.sdk.model.AccountBalance
+import cash.z.ecc.android.sdk.model.AccountUuid
+import cash.z.ecc.android.sdk.model.WalletBalance
+import cash.z.ecc.android.sdk.model.Zatoshi
+import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
+import co.electriccoin.zcash.ui.common.model.WalletAccount
+import co.electriccoin.zcash.ui.common.model.ZashiAccount
+import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
+import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * MOB-1723 regression: [co.electriccoin.zcash.ui.common.provider.retainWhileWalletExists] must be
+ * scoped per selected account (via `flatMapLatest`), not span the whole account x balances combine —
+ * otherwise switching to an account whose entry is missing from the balances map resurrects the
+ * PREVIOUS account's retained balances instead of correctly reporting "not loaded yet".
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class GetBalancePoolsUseCaseTest {
+    private val accountAUuid = AccountUuid.new(ByteArray(16) { it.toByte() })
+    private val accountBUuid = AccountUuid.new(ByteArray(16) { (it + 1).toByte() })
+
+    private fun zeroBalance() = WalletBalance(Zatoshi(0), Zatoshi(0), Zatoshi(0))
+
+    private fun account(uuid: AccountUuid): WalletAccount =
+        ZashiAccount(
+            sdkAccount = Account.new(uuid),
+            unifiedAddress = "unified-$uuid",
+            transparentAddress = "transparent-$uuid",
+            saplingAddress = "sapling-$uuid",
+            orchardBalance = null,
+            saplingBalance = null,
+            ironwoodBalance = null,
+            transparentBalance = null,
+            isSelected = true,
+        )
+
+    private fun balancesFor(
+        uuid: AccountUuid,
+        available: Long,
+    ): Map<AccountUuid, AccountBalance> =
+        mapOf(
+            uuid to
+                AccountBalance(
+                    sapling = zeroBalance(),
+                    orchard = zeroBalance().copy(available = Zatoshi(available)),
+                    ironwood = zeroBalance(),
+                    unshielded = Zatoshi(0),
+                )
+        )
+
+    @Test
+    fun switchingToAccountMissingFromBalancesMapEmitsNullNotThePreviousAccountsBalances() =
+        runTest {
+            val selectedAccount = MutableStateFlow<WalletAccount?>(account(accountAUuid))
+            val walletBalances =
+                MutableStateFlow<Map<AccountUuid, AccountBalance>?>(balancesFor(accountAUuid, available = 500_000L))
+            val synchronizer = mockk<Synchronizer> { every { this@mockk.walletBalances } returns walletBalances }
+            val synchronizerProvider =
+                mockk<SynchronizerProvider> { every { this@mockk.synchronizer } returns MutableStateFlow(synchronizer) }
+            val accountDataSource =
+                mockk<AccountDataSource> { every { this@mockk.selectedAccount } returns selectedAccount }
+            val persistableWalletProvider =
+                mockk<PersistableWalletProvider> {
+                    every { persistableWallet } returns MutableStateFlow(mockk(relaxed = true))
+                }
+
+            val useCase =
+                GetBalancePoolsUseCase(
+                    synchronizerProvider = synchronizerProvider,
+                    accountDataSource = accountDataSource,
+                    persistableWalletProvider = persistableWalletProvider,
+                )
+
+            val emissions = mutableListOf<BalancePools?>()
+            val job = launch { useCase.observe().collect { emissions += it } }
+            advanceUntilIdle()
+
+            assertEquals(Zatoshi(500_000L), emissions.last()?.orchard, "account A's balance should be visible")
+
+            selectedAccount.value = account(accountBUuid)
+            advanceUntilIdle()
+
+            assertNull(
+                emissions.last(),
+                "switching to account B, missing from the balances map, must emit null, not account A's balance",
+            )
+
+            job.cancelAndJoin()
+        }
+}

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/RequestSwapQuoteUseCaseTest.kt
@@ -1,7 +1,6 @@
 package co.electriccoin.zcash.ui.common.usecase
 
 import cash.z.ecc.android.sdk.Synchronizer
-import cash.z.ecc.android.sdk.model.WalletAddress
 import cash.z.ecc.android.sdk.type.AddressType
 import co.electriccoin.zcash.ui.NavigationRouter
 import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
@@ -289,7 +288,7 @@ class RequestSwapQuoteUseCaseTest {
     ): RequestSwapQuoteUseCase {
         every { swapRepository.quote } returns MutableStateFlow(SwapQuoteData.Success(swapQuote))
 
-        val shieldedAddress = WalletAddress.Unified.new("deposit")
+        val shieldedAddress = "deposit"
         val synchronizer = mockk<Synchronizer> { coEvery { validateAddress(any()) } returns AddressType.Unified }
         val synchronizerProvider = mockk<SynchronizerProvider> { coEvery { getSynchronizer() } returns synchronizer }
         coEvery { accountDataSource.requestNextShieldedAddress() } returns shieldedAddress

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/viewmodel/WalletViewModelTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/viewmodel/WalletViewModelTest.kt
@@ -15,7 +15,6 @@ import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -62,11 +61,11 @@ class WalletViewModelTest {
             mockk<Synchronizer> {
                 every { network } returns ZcashNetwork.Mainnet
                 every { fullyScannedHeight } returns MutableStateFlow(BlockHeight.new(3_500_000L))
+                every { walletBalances } returns MutableStateFlow(balancesWithOrchard(orchardZatoshi))
             }
         val synchronizerProvider =
             mockk<SynchronizerProvider> {
                 every { this@mockk.synchronizer } returns MutableStateFlow(synchronizer)
-                every { walletBalances } returns flowOf(balancesWithOrchard(orchardZatoshi))
             }
         val walletRepository =
             mockk<WalletRepository>(relaxed = true) {


### PR DESCRIPTION
## Issue

MOB-1723

## Summary

- Run automatic server benchmarking during startup.
- Apply its winner only after the SDK publishes the first local balance snapshot.
- Keep the last UI synchronizer, account, wallet snapshot, and balance visible during replacement.
- Replace retained UI state when the new synchronizer is available.
- Clear retained state when the wallet is removed.
- Keep manual server changes and non-UI synchronizer consumers unchanged.

## Root cause

Applying an automatic server winner replaces the synchronizer. The raw synchronizer flow emits `null` during this short rebuild. Send and balance consumers treated that transient value as missing wallet state and showed loading or empty state.

## Result

On cold start, local hydration and server benchmarking run together. If benchmarking wins first, it waits for a non-null local balance map. An empty map is a completed read. The result does not depend on a selected account or a nonzero balance.

The automatic winner can apply while the app is visible. UI consumers keep the prior concrete state during the rebuild. Transaction, worker, lifecycle, and recovery paths still use the raw synchronizer.

Repeated emissions of the same server winner are ignored.

## Testing

- `./gradlew :ui-lib:testZcashmainnetInternalDebugUnitTest --tests co.electriccoin.zcash.ui.common.repository.AutomaticServerRepositoryTest --tests co.electriccoin.zcash.ui.common.provider.SynchronizerProviderTest`
- `./gradlew :feature-voting:compileZcashmainnetInternalDebugUnitTestKotlin`
- `./gradlew ktlintFormat detektAll`
- `git diff --check`

Instrumentation test compilation is currently blocked by existing API mismatches in `MockSynchronizer` and `FakeWalletRepository` against the locally linked SDK. These errors are unrelated to this PR.

## Manual QA

1. Enable automatic server selection and terminate the app.
2. Cold-start and immediately open Send.
3. Confirm the stored spendable balance appears before network synchronization completes.
4. Let the automatic winner apply while the app stays visible.
5. Confirm Send does not show a loading or zero-balance state during replacement.
6. Confirm address validation and sending use the replacement synchronizer.
7. Confirm deleting the wallet clears retained UI state.
