### PR TITLE
MOB-1744: report pre-submission failures accurately instead of a fake gRPC status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 ### Fixed:
 
 - Coinholder Polling's poll list and proposal loading no longer hang indefinitely when a vote server is unreachable over Tor; a slow or dropped connection now fails over to the next server within a bounded time.
+- Support/error reports for a failed transaction no longer claim a fake `gRPC: false, code: -1` status when the failure actually happened before submission (e.g. a Sapling parameter download failure); such reports now correctly identify the real exception instead.
 
 ## [3.10.1 (2512)] - 2026-08-25
 

--- a/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values-es/strings.xml
@@ -698,6 +698,11 @@
         código: <xliff:g example="123" id="code">%3$d</xliff:g>,
         descripción: <xliff:g example="Network unreachable" id="desc">%4$s</xliff:g>
     </string>
+    <string name="send_confirmation_report_status_presubmission_failure" formatted="true">Fallo antes del envío
+        de la transacción (no se realizó ninguna llamada gRPC):
+        <xliff:g example="IOException" id="type">%1$s</xliff:g>:
+        <xliff:g example="Failed to download Sapling parameters" id="detail">%2$s</xliff:g>
+    </string>
     <string name="send_confirmation_multiple_trx_failure_report_unable_open_email">No se pudo abrir la app de correo.</string>
     <string name="send_confirmation_multiple_trx_failure_copy_tag">IDs de Transacción</string>
     <string name="swapAndPay_successSwapInfo">Iniciaste un intercambio exitosamente.\nSigue su estatus en la pantalla de transacciones.</string>

--- a/ui-design-lib/src/main/res/ui/common/values/strings.xml
+++ b/ui-design-lib/src/main/res/ui/common/values/strings.xml
@@ -742,6 +742,11 @@
         code: <xliff:g example="123" id="code">%3$d</xliff:g>,
         description: <xliff:g example="Network unreachable" id="desc">%4$s</xliff:g>
     </string>
+    <string name="send_confirmation_report_status_presubmission_failure" formatted="true">Failure before transaction
+        submission (no gRPC call was made):
+        <xliff:g example="IOException" id="type">%1$s</xliff:g>:
+        <xliff:g example="Failed to download Sapling parameters" id="detail">%2$s</xliff:g>
+    </string>
     <string name="send_confirmation_multiple_trx_failure_report_unable_open_email">Unable to launch email app.</string>
     <string name="send_confirmation_multiple_trx_failure_copy_tag">Transaction IDs</string>
     <string name="swapAndPay_successSwapInfo">You successfully initiated a swap.\nFollow its status on the transaction screen.</string>

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SendEmailUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/SendEmailUseCase.kt
@@ -87,8 +87,15 @@ class SendEmailUseCase(
 
     /**
      * Sends a support email for failed transaction submission.
+     *
+     * `index=0, grpcError=false` here are not placeholders: [SubmitResult.Failure] is only ever
+     * constructed (see `List<TransactionSubmitResult>.toSubmitResult()`) from a real, non-gRPC
+     * mempool rejection reported by the server, so `grpcError` genuinely is `false` and
+     * [submitResult.code] is the real status code. Contrast with [SubmitResult.Error] below, which
+     * never reached the server at all and must not be reported this way (MOB-1744).
      */
     operator fun invoke(submitResult: SubmitResult.Failure) {
+        val status = submitFailureReportStatus(submitResult)
         sendSupportEmail(
             subject = context.getString(R.string.app_name),
             messageBody =
@@ -104,10 +111,10 @@ class SendEmailUseCase(
                             appendLine(
                                 context.getString(
                                     R.string.send_confirmation_multiple_report_status_failure,
-                                    0,
-                                    false.toString(),
-                                    submitResult.code,
-                                    submitResult.description,
+                                    status.index,
+                                    status.grpcError.toString(),
+                                    status.code,
+                                    status.description,
                                 )
                             )
                         }
@@ -137,28 +144,29 @@ class SendEmailUseCase(
     }
 
     /**
-     * Sends a support email for transaction submission error.
+     * Sends a support email for a pre-submission transaction error.
+     *
+     * [SubmitResult.Error] is only ever constructed (see `ZashiProposalRepository.submit()` and
+     * `KeystoneProposalRepository.submit()`) from an exception caught before or during transaction
+     * creation -- e.g. a missing proposal/PCZT, or a failure thrown while proving/signing such as a
+     * Sapling parameter download timeout -- never from an actual gRPC/mempool response. It used to
+     * be reported with a hardcoded fake `gRPC: false, code: -1` status, which misled support into
+     * thinking a real protocol status was involved when gRPC was never reached (MOB-1744). Report it
+     * as a distinct pre-submission category instead, carrying the real exception type and detail.
      */
-    @Suppress("MagicNumber")
     operator fun invoke(submitResult: SubmitResult.Error) {
+        val detail = submitErrorPreSubmissionDetail(submitResult.cause)
         sendSupportEmail(
             subject = context.getString(R.string.app_name),
             messageBody =
                 EmailUtil.formatMessage(
-                    body = "Error submitting transaction",
+                    body = "Error before transaction submission (no gRPC call was made)",
                     supportInfo =
-                        buildString {
-                            appendLine(context.getString(R.string.send_confirmation_multiple_report_statuses))
-                            appendLine(
-                                context.getString(
-                                    R.string.send_confirmation_multiple_report_status_failure,
-                                    0,
-                                    false.toString(),
-                                    -1,
-                                    submitResult.cause.stackTraceToLimitedString(250),
-                                )
-                            )
-                        }
+                        context.getString(
+                            R.string.send_confirmation_report_status_presubmission_failure,
+                            detail.exceptionType,
+                            detail.description,
+                        )
                 )
         )
     }
@@ -253,3 +261,44 @@ internal fun buildGrpcFailureEmailBody(reportDescription: String?): String =
                 appendLine(it)
             }
     }
+
+/**
+ * The report line for a [SubmitResult.Failure]: `index`/`grpcError` are constant because this
+ * subtype always represents a single, real, non-gRPC mempool rejection (see the KDoc on the
+ * `SubmitResult.Failure` overload above) -- [code] and [description] are the real values reported
+ * by the server, never hardcoded.
+ */
+internal data class SubmitFailureReportStatus(
+    val index: Int,
+    val grpcError: Boolean,
+    val code: Int,
+    val description: String
+)
+
+private const val SUBMIT_FAILURE_REPORT_INDEX = 0
+
+internal fun submitFailureReportStatus(submitResult: SubmitResult.Failure): SubmitFailureReportStatus =
+    SubmitFailureReportStatus(
+        index = SUBMIT_FAILURE_REPORT_INDEX,
+        grpcError = false,
+        code = submitResult.code,
+        description = submitResult.description ?: "Unknown error"
+    )
+
+/**
+ * The real exception type and detail behind a [SubmitResult.Error] -- a failure that happened
+ * before any gRPC call was made. Kept separate from the gRPC-status reporting above so a
+ * pre-submission failure is never rendered with a fake gRPC status (MOB-1744).
+ */
+internal data class SubmitErrorPreSubmissionDetail(
+    val exceptionType: String,
+    val description: String
+)
+
+private const val PRE_SUBMISSION_STACK_TRACE_LIMIT = 250
+
+internal fun submitErrorPreSubmissionDetail(cause: Exception): SubmitErrorPreSubmissionDetail =
+    SubmitErrorPreSubmissionDetail(
+        exceptionType = cause::class.java.simpleName.ifEmpty { cause::class.java.name },
+        description = cause.stackTraceToLimitedString(PRE_SUBMISSION_STACK_TRACE_LIMIT) ?: "Unknown error"
+    )

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/SendEmailUseCaseTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/SendEmailUseCaseTest.kt
@@ -1,13 +1,19 @@
 package co.electriccoin.zcash.ui.common.usecase
 
 import co.electriccoin.zcash.ui.common.model.SubmitResult
+import java.io.IOException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * gRPC-failure support email content (MOB-1145): a timeout uses dedicated copy, a non-timeout failure
  * uses its description, and the body only appends a detail paragraph when there is non-blank detail.
+ *
+ * Also covers MOB-1744: a [SubmitResult.Error] (a failure that happened before any gRPC call was
+ * made, e.g. a Sapling parameter download timeout) must be reported as a distinct pre-submission
+ * category carrying the real exception type/detail, never as a fake gRPC status.
  */
 class SendEmailUseCaseTest {
     @Test
@@ -58,5 +64,65 @@ class SendEmailUseCaseTest {
     @Test
     fun bodyWithDescriptionAppendsParagraph() {
         assertEquals("Grpc failure\n\nserver detail\n", buildGrpcFailureEmailBody("server detail"))
+    }
+
+    /**
+     * A genuine transaction-submission failure (real gRPC/mempool status from the SDK) still
+     * reports its real code and description -- not the fake `code=-1` used for pre-submission
+     * failures (MOB-1744).
+     */
+    @Test
+    fun genuineSubmissionFailureReportsItsRealIndexAndCode() {
+        val status =
+            submitFailureReportStatus(
+                SubmitResult.Failure(
+                    txIds = listOf("tx-1"),
+                    code = 17,
+                    description = "Network unreachable"
+                )
+            )
+
+        assertEquals(0, status.index)
+        assertEquals(false, status.grpcError)
+        assertEquals(17, status.code)
+        assertEquals("Network unreachable", status.description)
+    }
+
+    @Test
+    fun genuineSubmissionFailureWithNullDescriptionFallsBackToUnknownError() {
+        val status =
+            submitFailureReportStatus(
+                SubmitResult.Failure(
+                    txIds = emptyList(),
+                    code = 42,
+                    description = null
+                )
+            )
+
+        assertEquals(42, status.code)
+        assertEquals("Unknown error", status.description)
+    }
+
+    /**
+     * A pre-submission failure -- e.g. an [IOException] thrown while downloading Sapling params,
+     * before any gRPC call was made -- is reported with its real exception type and detail, never
+     * as a fake gRPC status (MOB-1744).
+     */
+    @Test
+    fun preSubmissionFailureReportsRealExceptionTypeAndDetail() {
+        val cause = IOException("Failed to download Sapling parameters")
+
+        val detail = submitErrorPreSubmissionDetail(cause)
+
+        assertEquals("IOException", detail.exceptionType)
+        assertTrue(detail.description.contains("Failed to download Sapling parameters"))
+    }
+
+    @Test
+    fun preSubmissionFailureUsesRealExceptionTypeForDifferentExceptions() {
+        val illegalStateDetail = submitErrorPreSubmissionDetail(IllegalStateException("Transaction proposal is null"))
+
+        assertEquals("IllegalStateException", illegalStateDetail.exceptionType)
+        assertTrue(illegalStateDetail.description.contains("Transaction proposal is null"))
     }
 }


### PR DESCRIPTION
## Summary

- Support/error reports for `SubmitResult.Error` (built when a transaction submission fails **before** any gRPC call is made -- e.g. proposal/PCZT missing, or a proving/signing failure such as a Sapling parameter download timeout) previously hardcoded `gRPC: false, code: -1` in the report, using the same template as a genuine gRPC/mempool status. This made a non-gRPC failure look like a real protocol error to whoever reads the support report.
- `SendEmailUseCase.invoke(SubmitResult.Error)` now reports these as a distinct pre-submission-failure category, carrying the real exception type and detail (via a new `submitErrorPreSubmissionDetail()` helper and a new `send_confirmation_report_status_presubmission_failure` string resource), instead of a fake gRPC status.
- Traced how `SubmitResult.Error` is constructed (`ZashiProposalRepository.submit()`, `KeystoneProposalRepository.submit()`, `ProposalDataSource.submitTransactionInternal()`): the real exception (`cause: Exception`) is already preserved end to end and never generically wrapped away, so no upstream propagation fix was needed -- only the reporting/formatting step in `SendEmailUseCase` was wrong.
- `SubmitResult.Failure`'s existing report (which is a genuine, non-gRPC mempool rejection with a real `code`/`description` from the server) is unchanged, extracted into a small `submitFailureReportStatus()` helper for testability, with a comment explaining why its `index=0, grpcError=false` values are real and not placeholders -- to avoid this being mistaken for the same bug in the future.
- Added a CHANGELOG entry.

Companion SDK-side PR (separate repo, not part of this PR): adds retry/backoff to the actual Sapling-params download that causes this bug's user-visible symptom (worktree `z/wt/mob1744-sdk-retry`). This PR is purely about making the app's error reporting accurate, independent of whether that fix has landed.

## Test plan

- [x] `./gradlew :ui-lib:testZcashmainnetInternalDebugUnitTest --tests "co.electriccoin.zcash.ui.common.usecase.SendEmailUseCaseTest"` -- new tests cover a genuine gRPC/mempool failure still reporting its real code, and a pre-submission failure (e.g. an `IOException` from a param download) reporting its real exception type/detail distinctly from a fake gRPC status.
- [x] `./gradlew :ui-lib:testZcashmainnetInternalDebugUnitTest` (full module) -- all pass.
- [x] `./gradlew ktlintFormat` -- no changes needed.
- [x] `./gradlew detektAll` -- clean.

Linear: https://linear.app/zodl/issue/MOB-1744/timeouts-while-on-android-v393