### PR TITLE
MOB-1787: make backup prompt outrank migration/error home widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Changed:
+
+- The seed backup prompt now always takes priority over the migration banner and any sync/connectivity error banner once your wallet has received a balance and you haven't backed up your recovery phrase yet, so it can no longer be hidden behind other home screen messages for days.
+
 ## [3.11.0 (2653)] - 2026-09-08
 
 ### Added:

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCase.kt
@@ -68,7 +68,7 @@ class GetHomeMessageUseCase(
                         TrailingPrioritizedInputs(isCoinholderPollingVisible, isCrashReportingVisible)
                     },
                 ) { runtimeMessage, backup, isTorAvailable, isCCAvailable, trailing ->
-                    createMessage(
+                    createHomeMessage(
                         runtimeMessage = runtimeMessage,
                         backup = backup,
                         isTorVisible = isTorAvailable,
@@ -201,57 +201,13 @@ class GetHomeMessageUseCase(
     private fun observeIsTorMessageVisible() =
         isTorEnabledStorageProvider.observe().map { it == null }.distinctUntilChanged()
 
-    private fun createMessage(
-        runtimeMessage: RuntimeMessage?,
-        backup: WalletBackupData,
-        isTorVisible: Boolean,
-        isCurrencyConversionEnabled: Boolean,
-        isCoinholderPollingVisible: Boolean,
-        isCrashReportingVisible: Boolean,
-    ) = when {
-        runtimeMessage != null -> runtimeMessage
-        backup is WalletBackupData.Available -> HomeMessageData.Backup
-        isCoinholderPollingVisible -> HomeMessageData.CoinholderPolling
-        isTorVisible -> HomeMessageData.EnableTor
-        isCurrencyConversionEnabled -> HomeMessageData.EnableCurrencyConversion
-        isCrashReportingVisible -> HomeMessageData.CrashReport
-        else -> null
-    }
-
     private fun prioritizeMessage(message: HomeMessageData?): HomeMessageData? {
-        val isSameMessageUpdate =
-            message?.priority == cache.lastMessage?.priority // same but updated
-        val someMessageBeenShown =
-            cache.lastShownMessage != null // has any message been shown while app in fg
-        val hasNoMessageBeenShownLately = cache.lastMessage == null // has no message been shown
-        val isHigherPriorityMessage =
-            (message?.priority ?: 0) > (cache.lastShownMessage?.priority ?: 0)
         val result =
-            when {
-                message == null -> {
-                    null
-                }
-
-                message is RuntimeMessage -> {
-                    message
-                }
-
-                isSameMessageUpdate -> {
-                    message
-                }
-
-                isHigherPriorityMessage -> {
-                    if (hasNoMessageBeenShownLately) {
-                        if (someMessageBeenShown) null else message
-                    } else {
-                        message
-                    }
-                }
-
-                else -> {
-                    null
-                }
-            }
+            prioritizeHomeMessage(
+                message = message,
+                lastMessage = cache.lastMessage,
+                lastShownMessage = cache.lastShownMessage,
+            )
 
         if (result != null) {
             messageAvailabilityDataSource.onMessageShown()
@@ -295,6 +251,81 @@ class GetHomeMessageUseCase(
         syncMessageShownBefore: Boolean,
         someBalance: Boolean,
     ): RuntimeMessage? = syncingMessageFor(walletSnapshot, syncMessageShownBefore, someBalance)
+}
+
+/**
+ * Resolves the single [HomeMessageData] to show, applying the MOB-1787 rule that an urgent
+ * [HomeMessageData.Backup] (i.e. [backup] is [WalletBackupData.Available] — seed not backed up
+ * and a balance has been received, as already gated by `WalletBackupMessageUseCase`, snooze
+ * included) outranks every [RuntimeMessage], not just the other [co.electriccoin.zcash.ui.common.repository.Prioritized]
+ * messages. When [backup] is [WalletBackupData.Unavailable], behavior is unchanged from before
+ * MOB-1787: [runtimeMessage], then the remaining opt-in messages in their existing order.
+ */
+internal fun createHomeMessage(
+    runtimeMessage: RuntimeMessage?,
+    backup: WalletBackupData,
+    isTorVisible: Boolean,
+    isCurrencyConversionEnabled: Boolean,
+    isCoinholderPollingVisible: Boolean,
+    isCrashReportingVisible: Boolean,
+): HomeMessageData? =
+    when {
+        backup is WalletBackupData.Available -> HomeMessageData.Backup
+        runtimeMessage != null -> runtimeMessage
+        isCoinholderPollingVisible -> HomeMessageData.CoinholderPolling
+        isTorVisible -> HomeMessageData.EnableTor
+        isCurrencyConversionEnabled -> HomeMessageData.EnableCurrencyConversion
+        isCrashReportingVisible -> HomeMessageData.CrashReport
+        else -> null
+    }
+
+/**
+ * Pure decision function behind [GetHomeMessageUseCase]'s `prioritizeMessage` — extracted (like
+ * [createHomeMessage] and [syncingMessageFor]) so its logic is directly unit-testable without
+ * standing up the whole use case's dependency graph.
+ *
+ * MOB-1787: [message] being [RuntimeMessage] or an urgent [HomeMessageData.Backup] (only ever
+ * produced by [createHomeMessage] when the seed is unbacked and a balance has been received) must
+ * always win immediately, bypassing the hysteresis below. That hysteresis exists to avoid flicker
+ * for optional/dismissible [co.electriccoin.zcash.ui.common.repository.Prioritized] messages —
+ * without the [HomeMessageData.Backup] special-case here, a previously-shown [RuntimeMessage]
+ * (priority `Int.MAX_VALUE`) cached as [lastShownMessage] would make Backup's finite priority (5)
+ * look "lower" and get silently filtered out by [isHigherPriorityMessage] below.
+ */
+internal fun prioritizeHomeMessage(
+    message: HomeMessageData?,
+    lastMessage: HomeMessageData?,
+    lastShownMessage: HomeMessageData?,
+): HomeMessageData? {
+    val isSameMessageUpdate = message?.priority == lastMessage?.priority // same but updated
+    val someMessageBeenShown = lastShownMessage != null // has any message been shown while app in fg
+    val hasNoMessageBeenShownLately = lastMessage == null // has no message been shown
+    val isHigherPriorityMessage = (message?.priority ?: 0) > (lastShownMessage?.priority ?: 0)
+    return when {
+        message == null -> {
+            null
+        }
+
+        message is RuntimeMessage || message is HomeMessageData.Backup -> {
+            message
+        }
+
+        isSameMessageUpdate -> {
+            message
+        }
+
+        isHigherPriorityMessage -> {
+            if (hasNoMessageBeenShownLately) {
+                if (someMessageBeenShown) null else message
+            } else {
+                message
+            }
+        }
+
+        else -> {
+            null
+        }
+    }
 }
 
 internal const val SYNCING_BANNER_HIDE_BELOW_BLOCKS = 3456L

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCase.kt
@@ -297,9 +297,9 @@ internal fun prioritizeHomeMessage(
     lastMessage: HomeMessageData?,
     lastShownMessage: HomeMessageData?,
 ): HomeMessageData? {
-    val isSameMessageUpdate = message?.priority == lastMessage?.priority // same but updated
-    val someMessageBeenShown = lastShownMessage != null // has any message been shown while app in fg
-    val hasNoMessageBeenShownLately = lastMessage == null // has no message been shown
+    val isSameMessageUpdate = message?.priority == lastMessage?.priority
+    val someMessageBeenShownInForeground = lastShownMessage != null
+    val hasNoMessageBeenShownLately = lastMessage == null
     val isHigherPriorityMessage = (message?.priority ?: 0) > (lastShownMessage?.priority ?: 0)
     return when {
         message == null -> {
@@ -316,7 +316,7 @@ internal fun prioritizeHomeMessage(
 
         isHigherPriorityMessage -> {
             if (hasNoMessageBeenShownLately) {
-                if (someMessageBeenShown) null else message
+                if (someMessageBeenShownInForeground) null else message
             } else {
                 message
             }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCaseBackupPriorityTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCaseBackupPriorityTest.kt
@@ -1,0 +1,129 @@
+package co.electriccoin.zcash.ui.common.usecase
+
+import co.electriccoin.zcash.ui.common.model.SynchronizerError
+import co.electriccoin.zcash.ui.common.repository.HomeMessageData
+import co.electriccoin.zcash.ui.common.repository.MigrationHomeMessage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * MOB-1787 — an unbacked seed that has received a balance (WalletBackupMessageUseCase's
+ * WalletBackupData.Available, MOB-909's balance-gated condition) must outrank every home-screen
+ * widget, including RuntimeMessage states like migration and sync errors, which previously always
+ * won unconditionally via [createHomeMessage]'s `runtimeMessage != null` short-circuit.
+ */
+class GetHomeMessageUseCaseBackupPriorityTest {
+    /** Minimal concrete [MigrationHomeMessage] stand-in — the real implementation lives in the
+     * feature-migration module, which ui-lib does not depend on. */
+    private object FakeMigrationMessage : MigrationHomeMessage()
+
+    private val syncError = HomeMessageData.Error(SynchronizerError.Critical(cause = null))
+
+    @Test
+    fun `balance received and not backed up outranks active migration message`() {
+        val result =
+            createHomeMessage(
+                runtimeMessage = FakeMigrationMessage,
+                backup = WalletBackupData.Available(WalletBackupLockoutDuration.TWO_DAYS),
+                isTorVisible = false,
+                isCurrencyConversionEnabled = false,
+                isCoinholderPollingVisible = false,
+                isCrashReportingVisible = false,
+            )
+
+        assertEquals(HomeMessageData.Backup, result)
+    }
+
+    @Test
+    fun `balance received and not backed up outranks active sync error message`() {
+        val result =
+            createHomeMessage(
+                runtimeMessage = syncError,
+                backup = WalletBackupData.Available(WalletBackupLockoutDuration.TWO_DAYS),
+                isTorVisible = false,
+                isCurrencyConversionEnabled = false,
+                isCoinholderPollingVisible = false,
+                isCrashReportingVisible = false,
+            )
+
+        assertEquals(HomeMessageData.Backup, result)
+    }
+
+    @Test
+    fun `zero balance regression guard leaves runtime message unaffected`() {
+        // MOB-909: WalletBackupMessageUseCaseImpl reports Unavailable when there's no
+        // ReceiveTransaction yet (balance = 0), regardless of the backup flag itself.
+        val result =
+            createHomeMessage(
+                runtimeMessage = FakeMigrationMessage,
+                backup = WalletBackupData.Unavailable,
+                isTorVisible = false,
+                isCurrencyConversionEnabled = false,
+                isCoinholderPollingVisible = false,
+                isCrashReportingVisible = false,
+            )
+
+        assertEquals(FakeMigrationMessage, result)
+    }
+
+    @Test
+    fun `already backed up seed leaves runtime message unaffected`() {
+        val result =
+            createHomeMessage(
+                runtimeMessage = syncError,
+                backup = WalletBackupData.Unavailable,
+                isTorVisible = false,
+                isCurrencyConversionEnabled = false,
+                isCoinholderPollingVisible = false,
+                isCrashReportingVisible = false,
+            )
+
+        assertEquals(syncError, result)
+    }
+
+    @Test
+    fun `no urgent backup and no runtime message preserves normal Prioritized ordering`() {
+        // Regression guard for task 4 — relative ordering of the rest of the Prioritized family
+        // must be unaffected by the MOB-1787 reordering.
+        val result =
+            createHomeMessage(
+                runtimeMessage = null,
+                backup = WalletBackupData.Unavailable,
+                isTorVisible = true,
+                isCurrencyConversionEnabled = true,
+                isCoinholderPollingVisible = true,
+                isCrashReportingVisible = true,
+            )
+
+        assertEquals(HomeMessageData.CoinholderPolling, result)
+    }
+
+    // --- prioritizeHomeMessage: the urgent Backup message must also bypass the hysteresis that
+    // otherwise protects against flicker between optional/dismissible Prioritized messages, since
+    // otherwise a previously-shown RuntimeMessage (priority Int.MAX_VALUE) cached as
+    // lastShownMessage would make Backup's finite priority (5) look "lower" and get filtered out.
+
+    @Test
+    fun `urgent backup is shown immediately even right after a RuntimeMessage was last shown`() {
+        val result =
+            prioritizeHomeMessage(
+                message = HomeMessageData.Backup,
+                lastMessage = FakeMigrationMessage,
+                lastShownMessage = FakeMigrationMessage,
+            )
+
+        assertEquals(HomeMessageData.Backup, result)
+    }
+
+    @Test
+    fun `urgent backup is shown immediately on first ever message`() {
+        val result =
+            prioritizeHomeMessage(
+                message = HomeMessageData.Backup,
+                lastMessage = null,
+                lastShownMessage = null,
+            )
+
+        assertEquals(HomeMessageData.Backup, result)
+    }
+}

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCaseBackupPriorityTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCaseBackupPriorityTest.kt
@@ -49,10 +49,12 @@ class GetHomeMessageUseCaseBackupPriorityTest {
         assertEquals(HomeMessageData.Backup, result)
     }
 
+    /**
+     * MOB-909: `WalletBackupMessageUseCaseImpl` reports [WalletBackupData.Unavailable] when there is no
+     * `ReceiveTransaction` yet (balance = 0), regardless of the backup flag itself.
+     */
     @Test
     fun `zero balance regression guard leaves runtime message unaffected`() {
-        // MOB-909: WalletBackupMessageUseCaseImpl reports Unavailable when there's no
-        // ReceiveTransaction yet (balance = 0), regardless of the backup flag itself.
         val result =
             createHomeMessage(
                 runtimeMessage = FakeMigrationMessage,
@@ -81,10 +83,9 @@ class GetHomeMessageUseCaseBackupPriorityTest {
         assertEquals(syncError, result)
     }
 
+    /** Regression guard: the relative ordering of the rest of the Prioritized family is unaffected by MOB-1787. */
     @Test
     fun `no urgent backup and no runtime message preserves normal Prioritized ordering`() {
-        // Regression guard for task 4 — relative ordering of the rest of the Prioritized family
-        // must be unaffected by the MOB-1787 reordering.
         val result =
             createHomeMessage(
                 runtimeMessage = null,
@@ -98,11 +99,12 @@ class GetHomeMessageUseCaseBackupPriorityTest {
         assertEquals(HomeMessageData.CoinholderPolling, result)
     }
 
-    // --- prioritizeHomeMessage: the urgent Backup message must also bypass the hysteresis that
-    // otherwise protects against flicker between optional/dismissible Prioritized messages, since
-    // otherwise a previously-shown RuntimeMessage (priority Int.MAX_VALUE) cached as
-    // lastShownMessage would make Backup's finite priority (5) look "lower" and get filtered out.
-
+    /**
+     * [prioritizeHomeMessage]: the urgent Backup message must also bypass the hysteresis that otherwise
+     * protects against flicker between optional/dismissible Prioritized messages. Without the special case,
+     * a previously-shown [RuntimeMessage] (priority `Int.MAX_VALUE`) cached as `lastShownMessage` would make
+     * Backup's finite priority (5) look lower and get filtered out.
+     */
     @Test
     fun `urgent backup is shown immediately even right after a RuntimeMessage was last shown`() {
         val result =

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCaseBackupPriorityTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/GetHomeMessageUseCaseBackupPriorityTest.kt
@@ -50,11 +50,13 @@ class GetHomeMessageUseCaseBackupPriorityTest {
     }
 
     /**
-     * MOB-909: `WalletBackupMessageUseCaseImpl` reports [WalletBackupData.Unavailable] when there is no
-     * `ReceiveTransaction` yet (balance = 0), regardless of the backup flag itself.
+     * Regression guard for the other half of the branch: only [WalletBackupData.Available] jumps the
+     * queue, so a wallet reported as [WalletBackupData.Unavailable] must leave the runtime message alone.
+     * Which conditions collapse to `Unavailable` - no receive transaction yet, an already backed-up seed,
+     * a still-running "remind me later" lockout - is covered directly in [WalletBackupMessageUseCaseImplTest].
      */
     @Test
-    fun `zero balance regression guard leaves runtime message unaffected`() {
+    fun `unavailable backup does not outrank an active migration message`() {
         val result =
             createHomeMessage(
                 runtimeMessage = FakeMigrationMessage,
@@ -69,7 +71,7 @@ class GetHomeMessageUseCaseBackupPriorityTest {
     }
 
     @Test
-    fun `already backed up seed leaves runtime message unaffected`() {
+    fun `unavailable backup does not outrank an active sync error message`() {
         val result =
             createHomeMessage(
                 runtimeMessage = syncError,

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/WalletBackupMessageUseCaseImplTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/usecase/WalletBackupMessageUseCaseImplTest.kt
@@ -1,0 +1,131 @@
+package co.electriccoin.zcash.ui.common.usecase
+
+import co.electriccoin.zcash.ui.common.datasource.AccountDataSource
+import co.electriccoin.zcash.ui.common.model.WalletAccount
+import co.electriccoin.zcash.ui.common.model.ZashiAccount
+import co.electriccoin.zcash.ui.common.provider.WalletBackupFlagStorageProvider
+import co.electriccoin.zcash.ui.common.provider.WalletBackupRemindMeCountStorageProvider
+import co.electriccoin.zcash.ui.common.provider.WalletBackupRemindMeTimestampStorageProvider
+import co.electriccoin.zcash.ui.common.repository.ReceiveTransaction
+import co.electriccoin.zcash.ui.common.repository.SendTransaction
+import co.electriccoin.zcash.ui.common.repository.Transaction
+import co.electriccoin.zcash.ui.common.repository.TransactionRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * MOB-1787/MOB-909: the gate behind the home screen's backup prompt. [WalletBackupMessageUseCaseImpl]
+ * reports [WalletBackupData.Available] only for a Zashi account whose seed is not backed up, which has
+ * already received funds, and whose last "remind me later" lockout has elapsed. Every other combination
+ * collapses to [WalletBackupData.Unavailable] - the state [createHomeMessage] reads as "no urgent
+ * backup", see [GetHomeMessageUseCaseBackupPriorityTest].
+ *
+ * The lockout is measured against the real clock via `Instant.now()`, so a still-running lockout is
+ * asserted on what the flow has emitted after [runCurrent]; its pending `delay` to the end of the
+ * lockout is deliberately left unadvanced.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class WalletBackupMessageUseCaseImplTest {
+    private val receiveTransaction = mockk<ReceiveTransaction>()
+    private val sendTransaction = mockk<SendTransaction>()
+
+    @Test
+    fun unbackedSeedWithReceivedFundsAndNoLockoutIsAvailable() =
+        runTest {
+            val emissions = collectEmissions(useCase(isBackedUp = false, transactions = listOf(receiveTransaction)))
+
+            assertEquals(listOf(WalletBackupData.Available(WalletBackupLockoutDuration.TWO_DAYS)), emissions)
+        }
+
+    @Test
+    fun noReceiveTransactionKeepsBackupUnavailable() =
+        runTest {
+            val emissions = collectEmissions(useCase(isBackedUp = false, transactions = listOf(sendTransaction)))
+
+            assertEquals(listOf(WalletBackupData.Unavailable), emissions)
+        }
+
+    @Test
+    fun alreadyBackedUpSeedKeepsBackupUnavailable() =
+        runTest {
+            val emissions = collectEmissions(useCase(isBackedUp = true, transactions = listOf(receiveTransaction)))
+
+            assertEquals(listOf(WalletBackupData.Unavailable), emissions)
+        }
+
+    @Test
+    fun activeRemindMeLaterLockoutKeepsBackupUnavailable() =
+        runTest {
+            val emissions =
+                collectEmissions(
+                    useCase(
+                        isBackedUp = false,
+                        remindMeCount = 1,
+                        remindMeTimestamp = Instant.now(),
+                        transactions = listOf(receiveTransaction)
+                    )
+                )
+
+            assertEquals(listOf(WalletBackupData.Unavailable), emissions)
+        }
+
+    @Test
+    fun elapsedRemindMeLaterLockoutMakesBackupAvailableAgain() =
+        runTest {
+            val emissions =
+                collectEmissions(
+                    useCase(
+                        isBackedUp = false,
+                        remindMeCount = 1,
+                        remindMeTimestamp = longAgo(),
+                        transactions = listOf(receiveTransaction)
+                    )
+                )
+
+            assertEquals(listOf(WalletBackupData.Available(WalletBackupLockoutDuration.TWO_WEEKS)), emissions)
+        }
+
+    /** Far enough in the past that every [WalletBackupLockoutDuration] lockout has already elapsed. */
+    private fun longAgo(): Instant =
+        Instant.now().minusMillis(WalletBackupLockoutDuration.ONE_MONTH.duration.inWholeMilliseconds)
+
+    private fun TestScope.collectEmissions(useCase: WalletBackupMessageUseCase): List<WalletBackupData> {
+        val emissions = mutableListOf<WalletBackupData>()
+        backgroundScope.launch { useCase.observe().toList(emissions) }
+        runCurrent()
+        return emissions
+    }
+
+    private fun useCase(
+        isBackedUp: Boolean,
+        transactions: List<Transaction>?,
+        remindMeCount: Int = 0,
+        remindMeTimestamp: Instant? = null,
+        account: WalletAccount? = mockk<ZashiAccount>()
+    ) = WalletBackupMessageUseCaseImpl(
+        walletBackupFlagStorageProvider =
+            mockk<WalletBackupFlagStorageProvider> { every { observe() } returns MutableStateFlow(isBackedUp) },
+        walletBackupRemindMeCountStorageProvider =
+            mockk<WalletBackupRemindMeCountStorageProvider> {
+                every { observe() } returns MutableStateFlow(remindMeCount)
+            },
+        walletBackupRemindMeTimestampStorageProvider =
+            mockk<WalletBackupRemindMeTimestampStorageProvider> {
+                every { observe() } returns MutableStateFlow(remindMeTimestamp)
+            },
+        accountDataSource =
+            mockk<AccountDataSource> { every { selectedAccount } returns MutableStateFlow(account) },
+        transactionRepository =
+            mockk<TransactionRepository> { every { this@mockk.transactions } returns MutableStateFlow(transactions) },
+    )
+}


### PR DESCRIPTION
## Summary

Ticket: https://linear.app/zodl/issue/MOB-1787/seed-backup-prompt-should-take-priority-over-migration-and-error-state

Three users lost funds because they never backed up their recovery phrase, and the backup
prompt currently sits below the migration widget and several error states on the home screen —
it could take days before a user even sees it. This PR makes the backup prompt outrank every
other home-screen widget (migration banner, sync/connectivity errors, etc.) whenever the wallet
has received any nonzero balance and the seed has not been backed up (no threshold).

**Root cause:** `HomeMessageData.RuntimeMessage` (migration, disconnected, sync error, syncing,
etc.) always carries `priority = Int.MAX_VALUE` and was checked *before* `Backup` in both
`GetHomeMessageUseCase.createMessage()`'s ordering and `prioritizeMessage()`'s hysteresis gate.
Backup's finite priority (5) meant it could never win against a RuntimeMessage no matter how
urgent the underlying condition.

**Fix:**
- `createMessage`/`createHomeMessage` (extracted to a top-level `internal` function, mirroring
  the existing `syncingMessageFor` pattern, for direct unit testing): check
  `backup is WalletBackupData.Available` before `runtimeMessage != null` instead of after. Every
  occurrence of `HomeMessageData.Backup` is already gated by
  `WalletBackupMessageUseCaseImpl.observe()` on "balance received + not backed up" (MOB-909's
  fix, untouched), so no separate "urgent" flag is needed.
- `prioritizeMessage`/`prioritizeHomeMessage` (same extraction): let an urgent `Backup` message
  bypass the same-priority/hysteresis suppression that `RuntimeMessage` already bypasses —
  otherwise a `RuntimeMessage` cached as `lastShownMessage` (priority `Int.MAX_VALUE`) would make
  Backup's finite priority look "lower" and get silently filtered out.
- Normal relative ordering of `RuntimeMessage` internals (disconnected → error → syncing →
  migration → shield funds) and the rest of the `Prioritized` family (CoinholderPolling, Tor,
  currency conversion, crash report) is unchanged when the urgent-backup condition is false.

## Scope

- **Logic/ordering only — no visual or copy changes.** The Figma link originally attached to the
  ticket resolves to an unrelated "Swap details didn't match" iOS mockup in the shared file, not
  this feature. The existing `WalletBackupMessage.kt` widget visuals are reused as-is. New
  visual/copy work should follow once a corrected Figma link/node is confirmed.
- **Android only** — iOS is tracked separately per the ticket.

## Open product question — needs a decision

`WalletBackupMessageUseCaseImpl` layers a remind-me snooze/lockout (2 days → 2 weeks → 1 month)
on top of the balance/backup condition. This PR does **not** change that mechanism — a user who
tapped "remind me later" can still have the urgent prompt suppressed during the snooze window
even after a balance arrives, since `WalletBackupData.Available` (the trigger this PR keys off)
is only emitted once the snooze window has elapsed. The ticket's "no threshold" wording doesn't
address the snooze mechanism directly, so this is left as-is pending an explicit product
decision on whether the urgent case should bypass snooze. Flagging here rather than guessing.

## Testing

- New `GetHomeMessageUseCaseBackupPriorityTest` (`ui-lib/src/test/.../usecase/`): backup wins
  over an active migration message, backup wins over an active sync error message, balance=0
  regression guard (MOB-909), already-backed-up regression guard, normal `Prioritized` ordering
  preserved when no runtime message/urgent backup, plus two `prioritizeHomeMessage` cases
  confirming the hysteresis bypass.
- `./gradlew :ui-lib:testZcashmainnetInternalDebugUnitTest :feature-migration:testZcashmainnetInternalDebugUnitTest` — all green, no regressions.
- `./gradlew ktlint` and `./gradlew detektAll` — clean, zero findings.
- Built `assembleZcashmainnetInternalDebug`, installed and launched on a local emulator — app
  boots to onboarding without crashing. Full live reproduction of the compound scenario (a
  synced wallet with a real received balance, unbacked seed, and a simultaneously active
  migration/error banner) needs a pre-existing funded test wallet that wasn't available in this
  session, so it was not exercised end-to-end live; the exact decision logic is covered directly
  by the unit tests above instead.

## Test plan

- [ ] On a synced wallet with a received balance and an unbacked seed, trigger a migration or
      sync-error banner and confirm the backup prompt now wins
- [ ] Confirm normal migration/error banners still show as before once the seed is backed up (or
      balance is zero)
- [ ] Product decision recorded on the snooze-bypass question above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KX1k7Wox8bhSDz47hDrVqd