### PR TITLE
Redact PII from migration doc comments

### DIFF
--- a/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/progress/MigrationProgressVM.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/ui/screen/migration/progress/MigrationProgressVM.kt
@@ -64,7 +64,7 @@ class MigrationProgressVM(
         ) { rate, readout ->
             // Everything on this screen derives LIVE from the engine's persisted states — no plan
             // cache to diverge, and no app-side "overdue"/countdown: each row renders purely from
-            // the engine's per-transaction status (decision with Dominik 2026-07-31). The measured
+            // the engine's per-transaction status (decision with the product owner 2026-07-31). The measured
             // block rate is still used for the rough total-duration estimate in the header only.
             // Both come from the SAME readout as the states below — one atomic read, never a fresh
             // states paired with a stale/independently-read tip estimate or vice versa.
@@ -309,7 +309,7 @@ internal fun orchardRemainingZatoshi(
  * existing static total-span framing unchanged: "over ~X" spanning the earliest to the latest
  * scheduled moment across preparations AND transfers.
  *
- * Once in progress (`completedCount > 0` — a concrete, checkable condition, decision with Dominik
+ * Once in progress (`completedCount > 0` — a concrete, checkable condition, decision with the product owner
  * 2026-08-01), the header instead counts down the REMAINING time to the last scheduled moment.
  * This MUST branch explicitly on `remaining > 0` vs `remaining <= 0`: [formatMigrationDuration]
  * floors its input at a network-dependent privacy floor (10 min testnet / 1 hour mainnet, decision
@@ -376,7 +376,7 @@ internal data class MigrationRowDisplay(
 
 /**
  * Row state for a crossing transfer, in Figma's priority order (2026-08-03 finalization, decision
- * with Dominik — replaces the old debug/primary split from 2026-08-01):
+ * with the product owner — replaces the old debug/primary split from 2026-08-01):
  *
  * 1. A genuinely blocked row (`EXPIRED`/`UNPROVABLE_ANCHOR`/`SIGNATURE`/`UNSATISFIABLE` — the ones
  *    that can never self-resolve) keeps its own explicit copy, regardless of schedule time.
@@ -396,7 +396,7 @@ internal data class MigrationRowDisplay(
  *    [isLastRowOverall], which gets "in ~X" (Figma is consistent: only the last row on screen ever
  *    gets the "in" prefix).
  *
- * Never reintroduces "Overdue" or a countdown-to-deadline (decision with Dominik 2026-07-31,
+ * Never reintroduces "Overdue" or a countdown-to-deadline (decision with the product owner 2026-07-31,
  * reaffirmed 2026-08-03) — a late-but-healthy transfer just reads "Ready now".
  *
  * Top-level and internal for unit-testability without Android or Koin.
@@ -474,7 +474,7 @@ internal fun preparationRowDisplay(
 
 /**
  * Collapses Figma's "Confirmed"/"Sent" split into a single broadcast state (2026-08-03, decision
- * with Dominik): [LiveMigrationTransfer] carries no broadcast timestamp, only an optional mined
+ * with the product owner): [LiveMigrationTransfer] carries no broadcast timestamp, only an optional mined
  * height/time, so "Sent {relative} ago" is only shown once [minedAt] is known; until then this
  * reads plain "Sent" rather than inventing a broadcast time the model doesn't have.
  */

--- a/feature-migration/src/main/java/co/electriccoin/zcash/work/MigrationTransferDueReceiver.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/work/MigrationTransferDueReceiver.kt
@@ -9,7 +9,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 /**
- * The worker's DEAD-MAN'S SWITCH (design with Dominik, 2026-07-30): an inexact-while-idle alarm
+ * The worker's DEAD-MAN'S SWITCH (design with the product owner, 2026-07-30): an inexact-while-idle alarm
  * armed by [MigrationScheduler] a late margin PAST the worker's expected run. By construction,
  * firing means the OS had its chance to run the worker and didn't (Doze, App-Standby, OEM
  * killers, user-disabled background) — so this compares the [MigrationWorkerHeartbeat] stamps

--- a/feature-migration/src/main/java/co/electriccoin/zcash/work/MigrationWorkerHeartbeat.kt
+++ b/feature-migration/src/main/java/co/electriccoin/zcash/work/MigrationWorkerHeartbeat.kt
@@ -5,7 +5,7 @@ import androidx.core.content.edit
 
 /**
  * Two plain-SharedPreferences timestamps forming the worker's dead-man's switch (design with
- * Dominik, 2026-07-30 late evening): [stampScheduled] records when the NEXT worker run is
+ * the product owner, 2026-07-30 late evening): [stampScheduled] records when the NEXT worker run is
  * expected (written by [MigrationScheduler.schedule]); [stampRun] records when a worker run
  * actually STARTED. [MigrationTransferDueReceiver]'s alarm fires a late-margin after the expected
  * time and compares the two — a worker that ran clears the check; one the OS silently killed or

--- a/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/progress/MigrationProgressVMTest.kt
+++ b/feature-migration/src/test/java/co/electriccoin/zcash/ui/screen/migration/progress/MigrationProgressVMTest.kt
@@ -17,7 +17,7 @@ import kotlin.time.Instant
 /**
  * Pure-logic coverage for the Migration Progress row rendering and header subtitle.
  *
- * Finalized 2026-08-03 (decision with Dominik) against 4 Figma reference screens: no debug-only
+ * Finalized 2026-08-03 (decision with the product owner) against 4 Figma reference screens: no debug-only
  * raw engine word is shown anywhere anymore, "Overdue" stays gone (decision 2026-07-31, reaffirmed
  * here), and every row falls into exactly one of: a genuinely-blocked state (`EXPIRED` /
  * `UNPROVABLE_ANCHOR` / `SIGNATURE` — the only three blockers that never self-resolve), "Sent"


### PR DESCRIPTION
Replaces the engineer's real name with a generic term ("the product owner") in design-decision provenance comments across the migration feature module. This content was already flagged by the PII keyword hook and fixed once on `feature/MOB-1397` (commit 8473c7961, 2026-08-17), but that fix never made it to `maint/v3.10.x` — cherry-picked here as its own standalone PR so the shared branch stops carrying it.

No behavior change, comment-only diff across 4 files.