### PR TITLE
MOB-1832: Apply server switch hysteresis to automatic server selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Changed:
 
-- Automatic server selection now switches only to a server that is meaningfully faster than the one you're on (at least 200 ms and 25 % faster), or when the current server fails its health check twice in a row, so the wallet no longer flips between near-equal or briefly slow servers. A switch is never followed by another within ten minutes, and the servers are re-checked at most once every ten minutes instead of on every return to the app.
+- Automatic server selection now switches only to a server that is meaningfully faster than the one you're on (at least 200 ms and 25 % faster), or when the current server fails its health check twice in a row, so the wallet no longer flips between near-equal or briefly slow servers. A switch is never followed by another within thirty minutes, and the servers are re-checked at most once every ten minutes instead of on every return to the app.
 - Coinholder Polling's poll list no longer refreshes itself in the background while you're just browsing it; it now updates when you open the screen, return to it, or pull to refresh.
 - Vote submission is faster and more reliable over Tor: a slow or unresponsive vote-helper server no longer stalls the whole submission.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Changed:
 
+- Automatic server selection now switches only to a server that is meaningfully faster than the one you're on (at least 200 ms and 25 % faster), or when the current server fails its health check, so the wallet no longer flips between near-equal servers on every check.
 - Coinholder Polling's poll list no longer refreshes itself in the background while you're just browsing it; it now updates when you open the screen, return to it, or pull to refresh.
 - Vote submission is faster and more reliable over Tor: a slow or unresponsive vote-helper server no longer stalls the whole submission.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ### Changed:
 
-- Automatic server selection now switches only to a server that is meaningfully faster than the one you're on (at least 200 ms and 25 % faster), or when the current server fails its health check, so the wallet no longer flips between near-equal servers on every check.
+- Automatic server selection now switches only to a server that is meaningfully faster than the one you're on (at least 200 ms and 25 % faster), or when the current server fails its health check twice in a row, so the wallet no longer flips between near-equal or briefly slow servers. A switch is never followed by another within ten minutes, and the servers are re-checked at most once every ten minutes instead of on every return to the app.
 - Coinholder Polling's poll list no longer refreshes itself in the background while you're just browsing it; it now updates when you open the screen, return to it, or pull to refresh.
 - Vote submission is faster and more reliable over Tor: a slow or unresponsive vote-helper server no longer stalls the whole submission.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=ed11a76d1ff064950689a483f6f16881e8d4c396
+SDK_COMMIT_PIN=37bd2393ab3f206bc91e2b5fda9a9f4c85442afb
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=
+SDK_COMMIT_PIN=ba6d49acf1cb8a8c2d885fe618d9612799cdc309
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=6a30e60f3fb39c435893c00ef25e2334d1657110
+SDK_COMMIT_PIN=ed11a76d1ff064950689a483f6f16881e8d4c396
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/gradle.properties
+++ b/gradle.properties
@@ -109,7 +109,7 @@ ZCASH_GOOGLE_PLAY_DEPLOY_STATUS=draft
 # When blank, it pulls the SDK from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 SDK_INCLUDED_BUILD_PATH=
-# Optional commit hash on zcash/zcash-android-wallet-sdk. When set, CI checks out the SDK at
+# Optional commit hash on zodl-inc/zodl-android-wallet-sdk. When set, CI checks out the SDK at
 # this exact commit and builds against it (via SDK_INCLUDED_BUILD_PATH) instead of the
 # published Maven artifact — for co-developing an app change against unreleased SDK work,
 # without waiting on an SDK release. Locally this has no effect: set
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=ba6d49acf1cb8a8c2d885fe618d9612799cdc309
+SDK_COMMIT_PIN=6a30e60f3fb39c435893c00ef25e2334d1657110
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/gradle.properties
+++ b/gradle.properties
@@ -124,7 +124,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=37bd2393ab3f206bc91e2b5fda9a9f4c85442afb
+SDK_COMMIT_PIN=66701636e2ab9b28dd95807365135f7eb097e75f
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/fixture/MockSynchronizer.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/fixture/MockSynchronizer.kt
@@ -33,6 +33,7 @@ import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.HttpClientEngineConfig
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlin.time.Duration
 
 /**
  * Mocked Synchronizer that can be used instead of the production SdkSynchronizer e.g. for tests.
@@ -279,6 +280,19 @@ internal class MockSynchronizer(
         set(value) {}
 
     override suspend fun getFastestServers(servers: List<LightWalletEndpoint>): Flow<FastestServersResult> {
+        error("Intentionally not implemented in ${MockSynchronizer::class.simpleName} implementation.")
+    }
+
+    override suspend fun evaluateServerSwitch(
+        current: LightWalletEndpoint,
+        candidates: List<LightWalletEndpoint>,
+        fetchThreshold: Duration,
+        blocksToFetch: Int
+    ): LightWalletEndpoint? {
+        error("Intentionally not implemented in ${MockSynchronizer::class.simpleName} implementation.")
+    }
+
+    override suspend fun confirmServerSwitch(endpoint: LightWalletEndpoint) {
         error("Intentionally not implemented in ${MockSynchronizer::class.simpleName} implementation.")
     }
 

--- a/ui-lib/src/main/java/co/electriccoin/zcash/di/RepositoryModule.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/di/RepositoryModule.kt
@@ -10,6 +10,7 @@ import co.electriccoin.zcash.ui.common.repository.ConfigurationRepository
 import co.electriccoin.zcash.ui.common.repository.ConfigurationRepositoryImpl
 import co.electriccoin.zcash.ui.common.repository.EphemeralAddressRepository
 import co.electriccoin.zcash.ui.common.repository.EphemeralAddressRepositoryImpl
+import co.electriccoin.zcash.ui.common.repository.EvaluationInterval
 import co.electriccoin.zcash.ui.common.repository.ExchangeRateRepository
 import co.electriccoin.zcash.ui.common.repository.ExchangeRateRepositoryImpl
 import co.electriccoin.zcash.ui.common.repository.FlexaRepository
@@ -18,6 +19,7 @@ import co.electriccoin.zcash.ui.common.repository.HomeMessageCacheRepository
 import co.electriccoin.zcash.ui.common.repository.HomeMessageCacheRepositoryImpl
 import co.electriccoin.zcash.ui.common.repository.KeystoneProposalRepository
 import co.electriccoin.zcash.ui.common.repository.KeystoneProposalRepositoryImpl
+import co.electriccoin.zcash.ui.common.repository.MINIMUM_EVALUATION_INTERVAL
 import co.electriccoin.zcash.ui.common.repository.MockOrchardBalanceRepository
 import co.electriccoin.zcash.ui.common.repository.MockOrchardBalanceRepositoryImpl
 import co.electriccoin.zcash.ui.common.repository.SwapRepository
@@ -50,6 +52,7 @@ val repositoryModule =
         singleOf(::HomeMessageCacheRepositoryImpl) bind HomeMessageCacheRepository::class
         singleOf(::WalletSnapshotRepositoryImpl) bind WalletSnapshotRepository::class
         singleOf(::ApplicationStateRepositoryImpl) bind ApplicationStateRepository::class
+        single { EvaluationInterval(minimumInterval = MINIMUM_EVALUATION_INTERVAL) }
         singleOf(::AutomaticServerRepositoryImpl) bind AutomaticServerRepository::class
         singleOf(::SwapRepositoryImpl) bind SwapRepository::class
         singleOf(::EphemeralAddressRepositoryImpl) bind EphemeralAddressRepository::class

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -25,7 +26,12 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
 
 interface AutomaticServerRepository {
     val isServerAutomatic: Flow<Boolean>
@@ -46,6 +52,8 @@ class AutomaticServerRepositoryImpl(
     private val isServerSelectionAutomaticProvider: IsServerSelectionAutomaticProvider,
 ) : AutomaticServerRepository {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    private val evaluationInterval = EvaluationInterval(MINIMUM_EVALUATION_INTERVAL)
 
     private val isAppInTransactionState: Boolean
         get() =
@@ -94,21 +102,41 @@ class AutomaticServerRepositoryImpl(
         )
     }
 
+    override fun init() {
+        observeSwitchCandidates(applicationStateProvider.observeOnForeground()).launchIn(scope)
+    }
+
     /**
-     * Subscribes to the app-foreground signal. Every foreground edge benchmarks the bundled servers through
-     * the SDK's hysteresis policy, and a newer edge cancels an in-flight evaluation. A switch candidate is
-     * applied only once the first local balance snapshot exists: a different endpoint rebuilds the
-     * Synchronizer, and UI consumers retain that snapshot through the replacement.
+     * The automatic-selection lane. Every foreground edge benchmarks the bundled servers through the SDK's
+     * hysteresis policy, and a newer edge cancels an in-flight evaluation. A switch candidate is applied
+     * only once the first local balance snapshot exists: a different endpoint rebuilds the Synchronizer,
+     * and UI consumers retain that snapshot through the replacement.
+     *
+     * Nothing here may throw out of the flow. This lane is launched once for the lifetime of the process on
+     * a scope with no exception handler, so a single failure - an unreachable server, a prefs read, a
+     * rejected argument - would otherwise take automatic selection down until the next process start, and
+     * reach the thread's uncaught handler on its way out.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    override fun init() {
-        applicationStateProvider
-            .observeOnForeground()
-            .mapLatest { resolveSwitchCandidate() }
+    internal fun observeSwitchCandidates(foregroundEdges: Flow<Unit>): Flow<LightWalletEndpoint> =
+        foregroundEdges
+            .filter { evaluationInterval.hasElapsed() }
+            .mapLatest { guarded("evaluate a server switch") { resolveSwitchCandidate() } }
             .filterNotNull()
-            .onEach { applyServerSwitch(it) }
-            .launchIn(scope)
-    }
+            .onEach { candidate ->
+                guarded("switch to ${candidate.host}:${candidate.port}") { applyServerSwitch(candidate) }
+            }
+
+    private suspend fun <T> guarded(
+        what: String,
+        block: suspend () -> T
+    ): T? =
+        runCatching { block() }
+            .getOrElse {
+                if (it is CancellationException) throw it
+                Twig.error(it) { "Automatic server: failed to $what" }
+                null
+            }
 
     internal suspend fun resolveSwitchCandidate(): LightWalletEndpoint? =
         evaluateServerSwitch()?.also { walletBalances.filterNotNull().first() }
@@ -120,12 +148,15 @@ class AutomaticServerRepositoryImpl(
         val candidates = lightWalletEndpointProvider.getEndpoints()
         if (candidates.isEmpty()) return null
         val synchronizer = synchronizerProvider.getSynchronizerOrNull() ?: return null
-        return synchronizer.evaluateServerSwitch(
-            current = current,
-            candidates = candidates,
-            fetchThreshold = 5.seconds,
-            blocksToFetch = 1
-        )
+        val candidate =
+            synchronizer.evaluateServerSwitch(
+                current = current,
+                candidates = candidates,
+                fetchThreshold = 5.seconds,
+                blocksToFetch = 1
+            )
+        evaluationInterval.markCompleted()
+        return candidate
     }
 
     private suspend fun applyServerSwitch(candidate: LightWalletEndpoint) {
@@ -135,3 +166,23 @@ class AutomaticServerRepositoryImpl(
         walletRepository.updateWalletEndpoint(candidate)
     }
 }
+
+/**
+ * Rate limit for the automatic-selection lane. `observeOnForeground()` fires on every foreground edge and a
+ * full evaluation opens a connection to every bundled host, so an app the user keeps switching in and out
+ * of would otherwise re-benchmark the whole list each time, for a decision that is almost always "stay".
+ */
+internal class EvaluationInterval(
+    private val minimumInterval: Duration,
+    private val timeSource: TimeSource = TimeSource.Monotonic
+) {
+    private var lastCompletedAt: TimeMark? = null
+
+    fun hasElapsed(): Boolean = lastCompletedAt?.let { it.elapsedNow() >= minimumInterval } ?: true
+
+    fun markCompleted() {
+        lastCompletedAt = timeSource.markNow()
+    }
+}
+
+private val MINIMUM_EVALUATION_INTERVAL = 10.minutes

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
@@ -214,6 +214,7 @@ class EvaluationInterval(
     private val minimumInterval: Duration,
     private val timeSource: TimeSource = ElapsedRealtimeTimeSource
 ) {
+    @Volatile
     private var lastAttemptAt: TimeMark? = null
 
     fun hasElapsed(): Boolean = lastAttemptAt?.let { it.elapsedNow() >= minimumInterval } ?: true

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
@@ -1,5 +1,7 @@
 package co.electriccoin.zcash.ui.common.repository
 
+import android.os.SystemClock
+import cash.z.ecc.android.sdk.Synchronizer
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
 import co.electriccoin.zcash.spackle.Twig
 import co.electriccoin.zcash.ui.common.datasource.resolveIsServerSelectionAutomatic
@@ -15,6 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
@@ -26,8 +29,10 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeMark
@@ -50,10 +55,9 @@ class AutomaticServerRepositoryImpl(
     private val persistableWalletProvider: PersistableWalletProvider,
     private val lightWalletEndpointProvider: LightWalletEndpointProvider,
     private val isServerSelectionAutomaticProvider: IsServerSelectionAutomaticProvider,
+    private val evaluationInterval: EvaluationInterval,
 ) : AutomaticServerRepository {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-
-    private val evaluationInterval = EvaluationInterval(MINIMUM_EVALUATION_INTERVAL)
 
     private val isAppInTransactionState: Boolean
         get() =
@@ -112,14 +116,15 @@ class AutomaticServerRepositoryImpl(
      * only once the first local balance snapshot exists: a different endpoint rebuilds the Synchronizer,
      * and UI consumers retain that snapshot through the replacement.
      *
-     * Nothing here may throw out of the flow. This lane is launched once for the lifetime of the process on
-     * a scope with no exception handler, so a single failure - an unreachable server, a prefs read, a
-     * rejected argument - would otherwise take automatic selection down until the next process start, and
-     * reach the thread's uncaught handler on its way out.
+     * Nothing here may throw out of the flow, the upstream foreground signal included. This lane is
+     * launched once for the lifetime of the process on a scope with no exception handler, so a single
+     * failure - an unreachable server, a prefs read, a rejected argument - would otherwise take automatic
+     * selection down until the next process start, and reach the thread's uncaught handler on its way out.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     internal fun observeSwitchCandidates(foregroundEdges: Flow<Unit>): Flow<LightWalletEndpoint> =
         foregroundEdges
+            .catch { Twig.error(it) { "Automatic server: the foreground signal failed" } }
             .filter { evaluationInterval.hasElapsed() }
             .mapLatest { guarded("evaluate a server switch") { resolveSwitchCandidate() } }
             .filterNotNull()
@@ -138,8 +143,25 @@ class AutomaticServerRepositoryImpl(
                 null
             }
 
-    internal suspend fun resolveSwitchCandidate(): LightWalletEndpoint? =
-        evaluateServerSwitch()?.also { walletBalances.filterNotNull().first() }
+    /**
+     * Waits for the first local balance snapshot before releasing a candidate, but not indefinitely. In the
+     * unhealthy case the wallet's current server has already failed two evaluations and is plausibly the
+     * reason no snapshot exists, so the failover that matters most cannot be gated forever on the sync it
+     * is meant to repair.
+     */
+    internal suspend fun resolveSwitchCandidate(): LightWalletEndpoint? {
+        val candidate = evaluateServerSwitch() ?: return null
+        val balances = withTimeoutOrNull(BALANCE_SNAPSHOT_TIMEOUT) { walletBalances.filterNotNull().first() }
+        if (balances == null) {
+            Twig.warn {
+                "Automatic server: no local balance snapshot within $BALANCE_SNAPSHOT_TIMEOUT, applying the " +
+                    "switch to ${candidate.host}:${candidate.port} anyway"
+            }
+        } else {
+            Twig.info { "Automatic server: local balance snapshot present, applying the switch" }
+        }
+        return candidate
+    }
 
     @Suppress("ReturnCount")
     internal suspend fun evaluateServerSwitch(): LightWalletEndpoint? {
@@ -148,22 +170,34 @@ class AutomaticServerRepositoryImpl(
         val candidates = lightWalletEndpointProvider.getEndpoints()
         if (candidates.isEmpty()) return null
         val synchronizer = synchronizerProvider.getSynchronizerOrNull() ?: return null
-        val candidate =
+        return try {
             synchronizer.evaluateServerSwitch(
                 current = current,
                 candidates = candidates,
                 fetchThreshold = 5.seconds,
                 blocksToFetch = 1
             )
-        evaluationInterval.markCompleted()
-        return candidate
+        } finally {
+            evaluationInterval.markAttempted()
+        }
     }
 
+    /**
+     * The SDK is told about the switch only once it has actually been applied: a declined or failed switch
+     * that confirmed anyway would clear the SDK's consecutive-failure count and start its cooldown, leaving
+     * a wallet on a dead server to earn its way out from scratch.
+     *
+     * The Synchronizer is taken before the endpoint is written, because writing it tears the current
+     * Synchronizer down and rebuilds it. Which instance receives the confirmation does not matter - the
+     * hysteresis state it updates is process-wide and outlives any single Synchronizer.
+     */
     private suspend fun applyServerSwitch(candidate: LightWalletEndpoint) {
         if (!isServerAutomatic() || isAppInTransactionState) return
         if (candidate !in lightWalletEndpointProvider.getEndpoints()) return
+        val synchronizer: Synchronizer? = synchronizerProvider.getSynchronizerOrNull()
         Twig.info { "Automatic server: switching to ${candidate.host}:${candidate.port}" }
         walletRepository.updateWalletEndpoint(candidate)
+        synchronizer?.confirmServerSwitch(candidate)
     }
 }
 
@@ -171,18 +205,43 @@ class AutomaticServerRepositoryImpl(
  * Rate limit for the automatic-selection lane. `observeOnForeground()` fires on every foreground edge and a
  * full evaluation opens a connection to every bundled host, so an app the user keeps switching in and out
  * of would otherwise re-benchmark the whole list each time, for a decision that is almost always "stay".
+ *
+ * What is marked is the attempt, not the success. An evaluation that throws or is cancelled by the next
+ * foreground edge did the network work all the same, and a user toggling foreground faster than an
+ * evaluation completes would otherwise never let one finish and never be rate limited at all.
  */
-internal class EvaluationInterval(
+class EvaluationInterval(
     private val minimumInterval: Duration,
-    private val timeSource: TimeSource = TimeSource.Monotonic
+    private val timeSource: TimeSource = ElapsedRealtimeTimeSource
 ) {
-    private var lastCompletedAt: TimeMark? = null
+    private var lastAttemptAt: TimeMark? = null
 
-    fun hasElapsed(): Boolean = lastCompletedAt?.let { it.elapsedNow() >= minimumInterval } ?: true
+    fun hasElapsed(): Boolean = lastAttemptAt?.let { it.elapsedNow() >= minimumInterval } ?: true
 
-    fun markCompleted() {
-        lastCompletedAt = timeSource.markNow()
+    fun markAttempted() {
+        lastAttemptAt = timeSource.markNow()
     }
 }
 
-private val MINIMUM_EVALUATION_INTERVAL = 10.minutes
+/**
+ * `TimeSource.Monotonic` is `System.nanoTime()`, which does not advance while the device is in deep sleep:
+ * a phone asleep overnight accrues almost no elapsed time, so the morning foreground edge would still be
+ * inside the evaluation interval and automatic selection would sit out the whole morning.
+ * `SystemClock.elapsedRealtime()` counts sleep, which is what this wall-clock rate limit needs.
+ */
+object ElapsedRealtimeTimeSource : TimeSource {
+    override fun markNow(): TimeMark = ElapsedRealtimeMark(SystemClock.elapsedRealtime())
+}
+
+private class ElapsedRealtimeMark(
+    private val startedAt: Long
+) : TimeMark {
+    override fun elapsedNow(): Duration = (SystemClock.elapsedRealtime() - startedAt).milliseconds
+}
+
+internal val MINIMUM_EVALUATION_INTERVAL = 10.minutes
+
+/**
+ * Cap on the wait for the first local balance snapshot before a switch is applied.
+ */
+private val BALANCE_SNAPSHOT_TIMEOUT = 30.seconds

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
@@ -1,24 +1,28 @@
 package co.electriccoin.zcash.ui.common.repository
 
+import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
+import co.electriccoin.zcash.spackle.Twig
 import co.electriccoin.zcash.ui.common.datasource.resolveIsServerSelectionAutomatic
 import co.electriccoin.zcash.ui.common.provider.ApplicationStateProvider
 import co.electriccoin.zcash.ui.common.provider.IsServerSelectionAutomaticProvider
 import co.electriccoin.zcash.ui.common.provider.LightWalletEndpointProvider
 import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
+import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
+import kotlin.time.Duration.Companion.seconds
 
 interface AutomaticServerRepository {
     val isServerAutomatic: Flow<Boolean>
@@ -36,6 +40,7 @@ class AutomaticServerRepositoryImpl(
     private val persistableWalletProvider: PersistableWalletProvider,
     private val lightWalletEndpointProvider: LightWalletEndpointProvider,
     private val isServerSelectionAutomaticProvider: IsServerSelectionAutomaticProvider,
+    private val synchronizerProvider: SynchronizerProvider,
 ) : AutomaticServerRepository {
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
@@ -82,27 +87,33 @@ class AutomaticServerRepositoryImpl(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun init() {
-        isServerAutomatic
-            .flatMapLatest { isAutomatic ->
-                if (isAutomatic) {
-                    walletRepository.fastestEndpoints
-                        .filter { !it.isLoading }
-                        .mapNotNull { it.servers?.firstOrNull() }
-                } else {
-                    emptyFlow()
-                }
-            }.onEach { fastestServer ->
-                if (!isAppInTransactionState) {
-                    walletRepository.updateWalletEndpoint(fastestServer)
-                }
-            }.launchIn(scope)
-
         applicationStateProvider
             .observeOnForeground()
-            .onEach {
-                if (isServerAutomatic() && !isAppInTransactionState) {
-                    walletRepository.refreshFastestServers()
-                }
-            }.launchIn(scope)
+            .mapLatest { evaluateServerSwitch() }
+            .filterNotNull()
+            .onEach { applyServerSwitch(it) }
+            .launchIn(scope)
+    }
+
+    @Suppress("ReturnCount")
+    internal suspend fun evaluateServerSwitch(): LightWalletEndpoint? {
+        if (!isServerAutomatic() || isAppInTransactionState) return null
+        val current = persistableWalletProvider.getPersistableWallet()?.endpoint ?: return null
+        val candidates = lightWalletEndpointProvider.getEndpoints()
+        if (candidates.isEmpty()) return null
+        val synchronizer = synchronizerProvider.getSynchronizerOrNull() ?: return null
+        return synchronizer.evaluateServerSwitch(
+            current = current,
+            candidates = candidates,
+            fetchThreshold = 5.seconds,
+            blocksToFetch = 1
+        )
+    }
+
+    private suspend fun applyServerSwitch(candidate: LightWalletEndpoint) {
+        if (!isServerAutomatic() || isAppInTransactionState) return
+        if (candidate !in lightWalletEndpointProvider.getEndpoints()) return
+        Twig.info { "Automatic server: switching to ${candidate.host}:${candidate.port}" }
+        walletRepository.updateWalletEndpoint(candidate)
     }
 }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepositoryTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepositoryTest.kt
@@ -15,6 +15,8 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.launchIn
@@ -25,6 +27,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TestTimeSource
 
 /**
  * Repository-level resolution of Automatic vs Manual server selection (MOB-1144), including the
@@ -75,6 +78,8 @@ class AutomaticServerRepositoryTest {
 
     private val walletRepository = mockk<WalletRepository>(relaxed = true)
 
+    private val timeSource = TestTimeSource()
+
     private val repository =
         AutomaticServerRepositoryImpl(
             walletRepository = walletRepository,
@@ -84,7 +89,8 @@ class AutomaticServerRepositoryTest {
             synchronizerProvider = synchronizerProvider,
             persistableWalletProvider = persistableWalletProvider,
             lightWalletEndpointProvider = lightWalletEndpointProvider,
-            isServerSelectionAutomaticProvider = isAutomaticProvider
+            isServerSelectionAutomaticProvider = isAutomaticProvider,
+            evaluationInterval = EvaluationInterval(MINIMUM_EVALUATION_INTERVAL, timeSource)
         )
 
     @Test
@@ -187,6 +193,10 @@ class AutomaticServerRepositoryTest {
             }
         }
 
+    /**
+     * The wait is bounded, so this only pins that a snapshot which has not arrived yet still holds the
+     * switch back - [switchIsAppliedAnywayWhenTheLocalBalanceSnapshotNeverArrives] pins the other end.
+     */
     @Test
     fun switchCandidateWaitsForTheLocalBalanceSnapshot() =
         runTest {
@@ -201,6 +211,87 @@ class AutomaticServerRepositoryTest {
             stubSwitchDecision(balances = emptyMap())
 
             assertEquals(known.last(), repository.resolveSwitchCandidate())
+        }
+
+    @Test
+    fun switchIsAppliedAnywayWhenTheLocalBalanceSnapshotNeverArrives() =
+        runTest {
+            stubSwitchDecision(balances = null)
+
+            assertEquals(known.last(), repository.resolveSwitchCandidate())
+        }
+
+    @Test
+    fun anAppliedSwitchIsConfirmedToTheSdk() =
+        runTest {
+            stubSwitchDecision(balances = emptyMap())
+
+            val foregroundEdges = MutableSharedFlow<Unit>()
+            repository.observeSwitchCandidates(foregroundEdges).launchIn(backgroundScope)
+            runCurrent()
+
+            foregroundEdges.emit(Unit)
+            runCurrent()
+
+            coVerify(exactly = 1) { walletRepository.updateWalletEndpoint(known.last()) }
+            coVerify(exactly = 1) { synchronizer.confirmServerSwitch(known.last()) }
+        }
+
+    @Test
+    fun aDeclinedSwitchIsNotConfirmedToTheSdk() =
+        runTest {
+            stubSwitchDecision(balances = emptyMap())
+            coEvery { synchronizer.evaluateServerSwitch(any(), any(), any(), any()) } returns
+                endpoint("no.longer.offered")
+
+            val foregroundEdges = MutableSharedFlow<Unit>()
+            repository.observeSwitchCandidates(foregroundEdges).launchIn(backgroundScope)
+            runCurrent()
+
+            foregroundEdges.emit(Unit)
+            runCurrent()
+
+            coVerify(exactly = 0) { walletRepository.updateWalletEndpoint(any()) }
+            coVerify(exactly = 0) { synchronizer.confirmServerSwitch(any()) }
+        }
+
+    @Test
+    fun aCancelledEvaluationAppliesNothing() =
+        runTest {
+            stubSwitchDecision(balances = emptyMap())
+            coEvery {
+                synchronizer.evaluateServerSwitch(any(), any(), any(), any())
+            } coAnswers { awaitCancellation() }
+
+            val foregroundEdges = MutableSharedFlow<Unit>()
+            val lane = repository.observeSwitchCandidates(foregroundEdges).launchIn(backgroundScope)
+            runCurrent()
+
+            foregroundEdges.emit(Unit)
+            runCurrent()
+            lane.cancelAndJoin()
+
+            coVerify(exactly = 0) { walletRepository.updateWalletEndpoint(any()) }
+            coVerify(exactly = 0) { synchronizer.confirmServerSwitch(any()) }
+        }
+
+    @Test
+    fun aFailedEvaluationStillCountsAgainstTheEvaluationInterval() =
+        runTest {
+            stubSwitchDecision(balances = emptyMap())
+            coEvery { synchronizer.evaluateServerSwitch(any(), any(), any(), any()) } throws
+                IllegalStateException("benchmark failed")
+
+            val foregroundEdges = MutableSharedFlow<Unit>()
+            repository.observeSwitchCandidates(foregroundEdges).launchIn(backgroundScope)
+            runCurrent()
+
+            foregroundEdges.emit(Unit)
+            runCurrent()
+            foregroundEdges.emit(Unit)
+            runCurrent()
+
+            coVerify(exactly = 1) { synchronizer.evaluateServerSwitch(any(), any(), any(), any()) }
         }
 
     @Test
@@ -220,6 +311,7 @@ class AutomaticServerRepositoryTest {
             coVerify(exactly = 0) { walletRepository.updateWalletEndpoint(any()) }
 
             coEvery { synchronizer.evaluateServerSwitch(any(), any(), any(), any()) } returns known.last()
+            timeSource += MINIMUM_EVALUATION_INTERVAL
             foregroundEdges.emit(Unit)
             runCurrent()
 

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepositoryTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepositoryTest.kt
@@ -14,7 +14,11 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.test.Test
@@ -28,12 +32,14 @@ import kotlin.time.Duration.Companion.seconds
  * wallet points at a custom, non-bundled endpoint, and Automatic otherwise.
  *
  * Also covers the app-side half of the server switch hysteresis (MOB-1832): the guards and the arguments
- * handed to the SDK's `evaluateServerSwitch`, which owns the thresholds themselves.
+ * handed to the SDK's `evaluateServerSwitch`, which owns the thresholds themselves, plus the resilience of
+ * the foreground lane itself.
  *
- * Note: the foreground trigger pipeline lives in `init()`, which launches on an internal
- * `Dispatchers.IO` scope; it is exercised by the `ChooseServerSelectionTest` instrumentation test
- * rather than here, since deterministic unit coverage would require injecting that scope.
+ * Note: `init()` launches the lane on an internal `Dispatchers.IO` scope, so the tests drive
+ * `observeSwitchCandidates` - the lane `init()` launches - on the test scope instead. Wiring `init()` to
+ * the real foreground signal is exercised by the `ChooseServerSelectionTest` instrumentation test.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class AutomaticServerRepositoryTest {
     private val default = endpoint("zec.rocks")
     private val known = listOf(default, endpoint("na.zec.rocks"))
@@ -67,9 +73,11 @@ class AutomaticServerRepositoryTest {
             every { submitState } returns MutableStateFlow<SubmitProposalState?>(null)
         }
 
+    private val walletRepository = mockk<WalletRepository>(relaxed = true)
+
     private val repository =
         AutomaticServerRepositoryImpl(
-            walletRepository = mockk(relaxed = true),
+            walletRepository = walletRepository,
             zashiProposalRepository = zashiProposalRepository,
             keystoneProposalRepository = keystoneProposalRepository,
             applicationStateProvider = mockk(relaxed = true),
@@ -193,6 +201,63 @@ class AutomaticServerRepositoryTest {
             stubSwitchDecision(balances = emptyMap())
 
             assertEquals(known.last(), repository.resolveSwitchCandidate())
+        }
+
+    @Test
+    fun theLaneSurvivesAFailedEvaluationAndKeepsServingTheNextEdge() =
+        runTest {
+            stubSwitchDecision(balances = emptyMap())
+            coEvery { synchronizer.evaluateServerSwitch(any(), any(), any(), any()) } throws
+                IllegalStateException("benchmark failed")
+
+            val foregroundEdges = MutableSharedFlow<Unit>()
+            repository.observeSwitchCandidates(foregroundEdges).launchIn(backgroundScope)
+            runCurrent()
+
+            foregroundEdges.emit(Unit)
+            runCurrent()
+
+            coVerify(exactly = 0) { walletRepository.updateWalletEndpoint(any()) }
+
+            coEvery { synchronizer.evaluateServerSwitch(any(), any(), any(), any()) } returns known.last()
+            foregroundEdges.emit(Unit)
+            runCurrent()
+
+            coVerify(exactly = 1) { walletRepository.updateWalletEndpoint(known.last()) }
+        }
+
+    @Test
+    fun theLaneSurvivesAFailureToApplyTheSwitch() =
+        runTest {
+            stubSwitchDecision(balances = emptyMap())
+            coEvery { walletRepository.updateWalletEndpoint(any()) } throws IllegalStateException("prefs failed")
+
+            val foregroundEdges = MutableSharedFlow<Unit>()
+            repository.observeSwitchCandidates(foregroundEdges).launchIn(backgroundScope)
+            runCurrent()
+
+            foregroundEdges.emit(Unit)
+            runCurrent()
+
+            coVerify(exactly = 1) { walletRepository.updateWalletEndpoint(known.last()) }
+        }
+
+    @Test
+    fun aSecondForegroundEdgeInsideTheEvaluationIntervalIsNotEvaluated() =
+        runTest {
+            stubSwitchDecision(balances = emptyMap())
+            coEvery { synchronizer.evaluateServerSwitch(any(), any(), any(), any()) } returns null
+
+            val foregroundEdges = MutableSharedFlow<Unit>()
+            repository.observeSwitchCandidates(foregroundEdges).launchIn(backgroundScope)
+            runCurrent()
+
+            foregroundEdges.emit(Unit)
+            runCurrent()
+            foregroundEdges.emit(Unit)
+            runCurrent()
+
+            coVerify(exactly = 1) { synchronizer.evaluateServerSwitch(any(), any(), any(), any()) }
         }
 
     private fun stubSwitchDecision(balances: Map<AccountUuid, AccountBalance>?) {

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepositoryTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepositoryTest.kt
@@ -1,23 +1,33 @@
 package co.electriccoin.zcash.ui.common.repository
 
+import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.model.PersistableWallet
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
+import co.electriccoin.zcash.ui.common.datasource.TransactionProposal
 import co.electriccoin.zcash.ui.common.provider.IsServerSelectionAutomaticProvider
 import co.electriccoin.zcash.ui.common.provider.LightWalletEndpointProvider
 import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
+import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Repository-level resolution of Automatic vs Manual server selection (MOB-1144), including the
  * migration rule: a null preference (wallets from before the setting existed) is Manual only when the
  * wallet points at a custom, non-bundled endpoint, and Automatic otherwise.
  *
- * Note: the automatic endpoint-switching pipeline lives in `init()`, which launches on an internal
+ * Also covers the app-side half of the server switch hysteresis (MOB-1832): the guards and the arguments
+ * handed to the SDK's `evaluateServerSwitch`, which owns the thresholds themselves.
+ *
+ * Note: the foreground trigger pipeline lives in `init()`, which launches on an internal
  * `Dispatchers.IO` scope; it is exercised by the `ChooseServerSelectionTest` instrumentation test
  * rather than here, since deterministic unit coverage would require injecting that scope.
  */
@@ -29,16 +39,37 @@ class AutomaticServerRepositoryTest {
     private val persistableWalletProvider = mockk<PersistableWalletProvider>(relaxed = true)
     private val lightWalletEndpointProvider =
         mockk<LightWalletEndpointProvider>(relaxed = true) { every { getEndpoints() } returns known }
+    private val synchronizer = mockk<Synchronizer>(relaxed = true)
+    private val synchronizerProvider =
+        mockk<SynchronizerProvider>(relaxed = true).also {
+            coEvery { it.getSynchronizerOrNull() } returns synchronizer
+        }
+
+    /**
+     * A relaxed mock hands back a non-null value for `.value`, which the repository would read as
+     * "a transaction is in flight", so both proposal repositories are stubbed with explicit empty state.
+     */
+    private val zashiProposalRepository =
+        mockk<ZashiProposalRepository>(relaxed = true) {
+            every { transactionProposal } returns MutableStateFlow<TransactionProposal?>(null)
+            every { submitState } returns MutableStateFlow<SubmitProposalState?>(null)
+        }
+    private val keystoneProposalRepository =
+        mockk<KeystoneProposalRepository>(relaxed = true) {
+            every { transactionProposal } returns MutableStateFlow<TransactionProposal?>(null)
+            every { submitState } returns MutableStateFlow<SubmitProposalState?>(null)
+        }
 
     private val repository =
         AutomaticServerRepositoryImpl(
             walletRepository = mockk(relaxed = true),
-            zashiProposalRepository = mockk(relaxed = true),
-            keystoneProposalRepository = mockk(relaxed = true),
+            zashiProposalRepository = zashiProposalRepository,
+            keystoneProposalRepository = keystoneProposalRepository,
             applicationStateProvider = mockk(relaxed = true),
             persistableWalletProvider = persistableWalletProvider,
             lightWalletEndpointProvider = lightWalletEndpointProvider,
-            isServerSelectionAutomaticProvider = isAutomaticProvider
+            isServerSelectionAutomaticProvider = isAutomaticProvider,
+            synchronizerProvider = synchronizerProvider
         )
 
     @Test
@@ -81,6 +112,64 @@ class AutomaticServerRepositoryTest {
             coEvery { persistableWalletProvider.getPersistableWallet() } returns null
 
             assertEquals(true, repository.isServerAutomatic())
+        }
+
+    @Test
+    fun manualSelectionSkipsTheSdkBenchmark() =
+        runTest {
+            coEvery { isAutomaticProvider.get() } returns false
+
+            assertNull(repository.evaluateServerSwitch())
+            coVerify(exactly = 0) { synchronizer.evaluateServerSwitch(any(), any(), any(), any()) }
+        }
+
+    @Test
+    fun inTransactionStateSkipsTheSdkBenchmark() =
+        runTest {
+            coEvery { isAutomaticProvider.get() } returns true
+            every { zashiProposalRepository.submitState } returns MutableStateFlow(SubmitProposalState.Submitting)
+
+            assertNull(repository.evaluateServerSwitch())
+            coVerify(exactly = 0) { synchronizer.evaluateServerSwitch(any(), any(), any(), any()) }
+        }
+
+    @Test
+    fun sdkDecisionToStayIsPassedThrough() =
+        runTest {
+            coEvery { isAutomaticProvider.get() } returns true
+            coEvery { persistableWalletProvider.getPersistableWallet() } returns wallet(known.first())
+            coEvery { synchronizer.evaluateServerSwitch(any(), any(), any(), any()) } returns null
+
+            assertNull(repository.evaluateServerSwitch())
+        }
+
+    @Test
+    fun sdkDecisionToSwitchIsPassedThrough() =
+        runTest {
+            coEvery { isAutomaticProvider.get() } returns true
+            coEvery { persistableWalletProvider.getPersistableWallet() } returns wallet(known.first())
+            coEvery { synchronizer.evaluateServerSwitch(any(), any(), any(), any()) } returns known.last()
+
+            assertEquals(known.last(), repository.evaluateServerSwitch())
+        }
+
+    @Test
+    fun sdkIsCalledWithTheCurrentEndpointAndEveryKnownCandidate() =
+        runTest {
+            coEvery { isAutomaticProvider.get() } returns true
+            coEvery { persistableWalletProvider.getPersistableWallet() } returns wallet(known.first())
+            coEvery { synchronizer.evaluateServerSwitch(any(), any(), any(), any()) } returns null
+
+            repository.evaluateServerSwitch()
+
+            coVerify(exactly = 1) {
+                synchronizer.evaluateServerSwitch(
+                    current = known.first(),
+                    candidates = known,
+                    fetchThreshold = 5.seconds,
+                    blocksToFetch = 1
+                )
+            }
         }
 
     private fun wallet(walletEndpoint: LightWalletEndpoint) =

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/EvaluationIntervalTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/EvaluationIntervalTest.kt
@@ -9,7 +9,8 @@ import kotlin.time.TestTimeSource
 
 /**
  * The rate limit the automatic-selection lane applies to the SDK benchmark (MOB-1832), since the app
- * foreground signal it is driven by has no throttle of its own.
+ * foreground signal it is driven by has no throttle of its own. What restarts the interval is an attempt,
+ * not a success - see [EvaluationInterval].
  */
 class EvaluationIntervalTest {
     private val interval = 10.minutes
@@ -24,7 +25,7 @@ class EvaluationIntervalTest {
         val timeSource = TestTimeSource()
         val evaluationInterval = EvaluationInterval(interval, timeSource)
 
-        evaluationInterval.markCompleted()
+        evaluationInterval.markAttempted()
         timeSource += interval - 1.seconds
 
         assertFalse(evaluationInterval.hasElapsed())
@@ -35,20 +36,20 @@ class EvaluationIntervalTest {
         val timeSource = TestTimeSource()
         val evaluationInterval = EvaluationInterval(interval, timeSource)
 
-        evaluationInterval.markCompleted()
+        evaluationInterval.markAttempted()
         timeSource += interval
 
         assertTrue(evaluationInterval.hasElapsed())
     }
 
     @Test
-    fun everyCompletedEvaluationRestartsTheInterval() {
+    fun everyAttemptedEvaluationRestartsTheInterval() {
         val timeSource = TestTimeSource()
         val evaluationInterval = EvaluationInterval(interval, timeSource)
 
-        evaluationInterval.markCompleted()
+        evaluationInterval.markAttempted()
         timeSource += interval
-        evaluationInterval.markCompleted()
+        evaluationInterval.markAttempted()
         timeSource += interval - 1.seconds
 
         assertFalse(evaluationInterval.hasElapsed())

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/EvaluationIntervalTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/EvaluationIntervalTest.kt
@@ -1,0 +1,56 @@
+package co.electriccoin.zcash.ui.common.repository
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TestTimeSource
+
+/**
+ * The rate limit the automatic-selection lane applies to the SDK benchmark (MOB-1832), since the app
+ * foreground signal it is driven by has no throttle of its own.
+ */
+class EvaluationIntervalTest {
+    private val interval = 10.minutes
+
+    @Test
+    fun theFirstEvaluationIsAllowed() {
+        assertTrue(EvaluationInterval(interval, TestTimeSource()).hasElapsed())
+    }
+
+    @Test
+    fun anEvaluationInsideTheIntervalIsSkipped() {
+        val timeSource = TestTimeSource()
+        val evaluationInterval = EvaluationInterval(interval, timeSource)
+
+        evaluationInterval.markCompleted()
+        timeSource += interval - 1.seconds
+
+        assertFalse(evaluationInterval.hasElapsed())
+    }
+
+    @Test
+    fun anEvaluationOnceTheIntervalElapsedIsAllowed() {
+        val timeSource = TestTimeSource()
+        val evaluationInterval = EvaluationInterval(interval, timeSource)
+
+        evaluationInterval.markCompleted()
+        timeSource += interval
+
+        assertTrue(evaluationInterval.hasElapsed())
+    }
+
+    @Test
+    fun everyCompletedEvaluationRestartsTheInterval() {
+        val timeSource = TestTimeSource()
+        val evaluationInterval = EvaluationInterval(interval, timeSource)
+
+        evaluationInterval.markCompleted()
+        timeSource += interval
+        evaluationInterval.markCompleted()
+        timeSource += interval - 1.seconds
+
+        assertFalse(evaluationInterval.hasElapsed())
+    }
+}


### PR DESCRIPTION
## Summary

App half of the server-switch hysteresis for automatic server selection, tracked in [MOB-1832](https://linear.app/zodl/issue/MOB-1832/add-hysteresis-to-automatic-server-selection-to-prevent-flip-flopping) and mirroring iOS (zodl-ios #2049). Companion SDK PR: https://github.com/zodl-inc/zodl-android-wallet-sdk/pull/14 (this branch pins it via `SDK_COMMIT_PIN`).

- `AutomaticServerRepositoryImpl.init()` is now a single lane: every foreground edge (including the first real foreground on launch) calls the SDK's `evaluateServerSwitch(current, allBundledEndpoints, 5 s, 1 block)`; a new edge cancels an in-flight benchmark (`mapLatest`). A non-null answer is re-validated (automatic still on, no transaction in flight, candidate still bundled) and applied through the existing `updateWalletEndpoint` pipeline. A `null` answer changes nothing.
- Previously any benchmark winner that differed from the persisted endpoint triggered a Synchronizer rebuild, even one measured 5 ms faster. Now a switch needs ≥ 200 ms and ≥ 25 % improvement, or an unhealthy current server (policy and thresholds live in the SDK).
- The settings-screen benchmark and the manual "Automatic" save path (plain winner, no hysteresis) are unchanged.

Merged with `maint/v3.10.x` after #2489 (MOB-1723) landed: its balance-snapshot gate now lives inside the hysteresis pipeline, so a switch candidate waits for the first local balance snapshot (inside the cancellable `mapLatest` block) before it is applied; `resolveAutomaticServerCandidate` went away with the `fastestEndpoints` lane it gated. Shipping on 3.10.x requires an SDK release from `maint/v3.1.x` first, then clearing `SDK_COMMIT_PIN` and bumping `ZCASH_SDK_VERSION`.

## Test plan

- [x] `AutomaticServerRepositoryTest` (12 tests): automatic off → no SDK call; in-transaction state → no SDK call; SDK null/endpoint passed through; SDK called with current endpoint, every bundled candidate, 5 s and 1 block; candidate waits for / is released by the local balance snapshot
- [x] `./gradlew :zashi-android:ktlint :zashi-android:detektAll` clean (from the task-workspace root)
- [x] `./gradlew :zashi-android:app:assembleZcashmainnetStoreDebug` against the pinned SDK branch
- [ ] Device check: background/foreground the app, confirm one `Server Switch:` log line per foreground and no wallet reconnect when the decision is "stay"

<!-- Write any additional comments here when opening the pull request -->

> **Note**
>This code review checklist is intended to serve as a starting point for the author and reviewer, although it may not be appropriate for all types of changes (e.g. fixing a spelling typo in documentation).  For more in-depth discussion of how we think about code review, please see [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md).

# Author
<!-- NOTE: Do not modify these when initially opening the pull request.  This is a checklist template that you tick off AFTER the pull request is created. -->

- [ ] **Self-review** your own code in GitHub's web interface[^1]
- [ ] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing)[^2] as appropriate
- [ ] Check the **code coverage**[^3] report for the automated tests
- [ ] Update **documentation** as appropriate (e.g [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), [**CHANGELOG.md**](../blob/main/CHANGELOG.md), etc.)
- [ ] **Run the app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer[^4]

> **Note**
> It is good practice to provide before and after UI  **screenshots** in the description of this PR. This is only applicable for changes that modify the UI.

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**[^5]
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**, [**README.md**](../blob/main/README.md), [**Architecture.md**](../blob/main/docs/Architecture.md), etc. as appropriate
- [ ] **Run the app** and try the changes[^6]

[^1]: _Code often looks different when reviewing the diff in a browser, making it easier to spot potential bugs._
[^2]: _While we aim for automated testing of the application, some aspects require manual testing. If you had to manually test something during development of this pull request, write those steps down._
[^3]: _While we are not looking for perfect coverage, the tool can point out potential cases that have been missed. Code coverage can be generated with: `./gradlew check` for Kotlin modules and `./gradlew connectedCheck -PIS_ANDROID_INSTRUMENTATION_TEST_COVERAGE_ENABLED=true` for Android modules._
[^4]: _Having your code up to date and squashed will make it easier for others to review. Use best judgement when squashing commits, as some changes (such as refactoring) might be easier to review as a separate commit._
[^5]: _In addition to a first pass using the code review guidelines, do a second pass using your best judgement and experience which may identify additional questions or comments. Research shows that code review is most effective when done in multiple passes, where reviewers look for different things through each pass._
[^6]: _While the CI server runs the app to look for build failures or crashes, humans running the app are more likely to notice unexpected log messages, UI inconsistencies, or bad output data. Perform this step last, after verifying the code changes are safe to run locally._
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYn1vxkynZJHRJQWVSkvtE
