### PR TITLE
fix(detekt): keep isServerCustom under the ReturnCount limit

### DIFF
--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt
@@ -87,8 +87,8 @@ class AutomaticServerRepositoryImpl(
     // one of our own bundled servers — see resolveIsEndpointCustom.
     override suspend fun isServerCustom(): Boolean {
         if (isServerAutomatic()) return false
-        val endpoint = persistableWalletProvider.getPersistableWallet()?.endpoint ?: return false
-        return resolveIsEndpointCustom(endpoint, lightWalletEndpointProvider.getEndpoints())
+        val endpoint = persistableWalletProvider.getPersistableWallet()?.endpoint
+        return endpoint != null && resolveIsEndpointCustom(endpoint, lightWalletEndpointProvider.getEndpoints())
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
`./gradlew detektAll` has been failing on `main` since #2448 merged (2026-08-19):

```
ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/AutomaticServerRepository.kt:88:26: Function isServerCustom has 3 return statements which exceeds the limit of 2. [ReturnCount]
```

Because `pull_request` runs build the merge commit, every PR targeting `main` since then shows a red `static_analysis_detekt` check regardless of its own content (#2430, #2455, #2457, #2462, #2488).

This folds the `?: return false` on the endpoint into the final boolean expression. Evaluation order and result are unchanged: automatic mode still short-circuits before the wallet is read, and a missing endpoint still yields `false`.

Verified locally with `./gradlew detektAll` (green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ALk8No4AemVzm2PcV5WrWS
