### PR TITLE
MOB-1836: Return to onboarding after the encrypted store is wiped; retry and quarantine instead of delete (MOB-1565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 - Support/error reports for a failed transaction no longer claim a fake `gRPC: false, code: -1` status when the failure actually happened before submission (e.g. a Sapling parameter download failure); such reports now correctly identify the real exception instead.
 - Opening Send immediately after a cold start no longer falls back to a loading screen while automatic server selection reconnects the wallet. The automatic winner waits for the local balance snapshot, which remains visible while the new server connection settles.
 - Fixed a crash loop some wallets hit at startup when the SDK reported the stored seed as no longer relevant to its database. The app now recovers automatically by clearing the mismatched local data and rescanning, instead of crashing repeatedly.
+- The app returns to onboarding so you can restore from your recovery phrase when its secret store is found empty while it still believes a
+  wallet was set up, instead of opening a home screen with no wallet behind it.
+- Opening the encrypted secret store is retried a few times before it is declared unreadable, and an unreadable store is set aside on the
+  device instead of being deleted.
 
 ## [3.10.1 (2512)] - 2026-08-25
 

--- a/app/src/main/java/co/electriccoin/zcash/app/ZcashApplication.kt
+++ b/app/src/main/java/co/electriccoin/zcash/app/ZcashApplication.kt
@@ -170,4 +170,7 @@ class ZcashApplication : CoroutineApplication() {
     }
 }
 
+/**
+ * Kept in sync with `GlobalCrashReporter`'s own copy of this suffix — see [isCrashProcess].
+ */
 private const val CRASH_PROCESS_NAME_SUFFIX = ":crash"

--- a/app/src/main/java/co/electriccoin/zcash/app/ZcashApplication.kt
+++ b/app/src/main/java/co/electriccoin/zcash/app/ZcashApplication.kt
@@ -17,6 +17,7 @@ import co.electriccoin.zcash.di.viewModelModule
 import co.electriccoin.zcash.migration.di.featureMigrationModule
 import co.electriccoin.zcash.spackle.StrictModeCompat
 import co.electriccoin.zcash.spackle.Twig
+import co.electriccoin.zcash.spackle.process.ProcessNameCompat
 import co.electriccoin.zcash.ui.common.provider.CrashReportingStorageProvider
 import co.electriccoin.zcash.ui.common.provider.MigrationNotifier
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
@@ -59,6 +60,11 @@ class ZcashApplication : CoroutineApplication() {
         super.onCreate()
 
         configureLogging()
+
+        if (isCrashProcess()) {
+            Twig.info { "Skipping app initialization in the crash-reporting process" }
+            return
+        }
 
         preloadSdkNativeLibrary()
 
@@ -133,6 +139,15 @@ class ZcashApplication : CoroutineApplication() {
         }
     }
 
+    /**
+     * The `:crash` secondary process only hosts `ExceptionReceiver` and the crash content
+     * provider, which are Koin-free — everything below this check assumes Koin is started.
+     * [co.electriccoin.zcash.crash.android.GlobalCrashReporter.register] has its own copy of the
+     * same `:crash` suffix check, using a constant `internal` to crash-android-lib, so the literal
+     * is deliberately repeated here rather than shared.
+     */
+    private fun isCrashProcess() = ProcessNameCompat.getProcessName(this).endsWith(CRASH_PROCESS_NAME_SUFFIX)
+
     private fun configureStrictMode() {
         if (BuildConfig.DEBUG) {
             StrictModeCompat.enableStrictMode(BuildConfig.IS_STRICT_MODE_CRASH_ENABLED)
@@ -154,3 +169,5 @@ class ZcashApplication : CoroutineApplication() {
         }
     }
 }
+
+private const val CRASH_PROCESS_NAME_SUFFIX = ":crash"

--- a/preference-impl-android-lib/build.gradle.kts
+++ b/preference-impl-android-lib/build.gradle.kts
@@ -21,6 +21,10 @@ android {
             execution = "ANDROIDX_TEST_ORCHESTRATOR"
         }
     }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 dependencies {

--- a/preference-impl-android-lib/src/androidTest/java/co/electriccoin/zcash/preference/EncryptedPreferenceProviderTest.kt
+++ b/preference-impl-android-lib/src/androidTest/java/co/electriccoin/zcash/preference/EncryptedPreferenceProviderTest.kt
@@ -127,6 +127,7 @@ class EncryptedPreferenceProviderTest {
 
             assertFalse(sharedPrefsBakFile(context, RECOVERY_FILENAME).exists())
             assertTrue(androidKeyStoreAlias().containsAlias(MasterKey.DEFAULT_MASTER_KEY_ALIAS))
+            assertFalse(recreatedMarkerFile(quarantineDirectory(context), RECOVERY_FILENAME).exists())
         }
 
     @Test
@@ -169,6 +170,7 @@ class EncryptedPreferenceProviderTest {
             assertEquals(1, quarantined.size)
 
             assertTrue(androidKeyStoreAlias().containsAlias(MasterKey.DEFAULT_MASTER_KEY_ALIAS))
+            assertFalse(recreatedMarkerFile(quarantineDirectory(context), D2D_FILENAME).exists())
 
             val expectedValue = StringDefaultPreferenceFixture.DEFAULT_VALUE + "restored"
             restoredProvider.putString(StringDefaultPreferenceFixture.KEY, expectedValue)
@@ -200,13 +202,13 @@ class EncryptedPreferenceProviderTest {
         private fun sharedPrefsBakFile(
             context: Context,
             filename: String
-        ) = File(File(context.filesDir.parent, "shared_prefs"), "$filename.xml.bak")
+        ) = encryptedPreferencesBackupFile(sharedPreferencesDirectory(context), filename)
 
         private fun quarantinedFiles(
             context: Context,
             filename: String
         ): List<File> {
-            val quarantineDir = File(context.noBackupFilesDir, QUARANTINE_DIRECTORY)
+            val quarantineDir = quarantineDirectory(context)
             return quarantineDir
                 .listFiles { file -> file.name.startsWith("$filename-") && file.name.endsWith(".xml") }
                 ?.toList()

--- a/preference-impl-android-lib/src/androidTest/java/co/electriccoin/zcash/preference/EncryptedPreferenceProviderTest.kt
+++ b/preference-impl-android-lib/src/androidTest/java/co/electriccoin/zcash/preference/EncryptedPreferenceProviderTest.kt
@@ -115,12 +115,18 @@ class EncryptedPreferenceProviderTest {
                 .putString(VALUE_KEYSET, "corrupted_keyset_data")
                 .commit()
 
-            // Should NOT throw — fix catches the parse/decryption exception and recreates fresh prefs
             val restoredProvider =
                 AndroidPreferenceProvider.newEncrypted(context, RECOVERY_FILENAME)
 
             // Prefs are empty: user will re-enter seed phrase to recover wallet
             assertFalse(restoredProvider.hasKey(StringDefaultPreferenceFixture.KEY))
+
+            val quarantined = quarantinedFiles(context, RECOVERY_FILENAME)
+            assertEquals(1, quarantined.size)
+            assertTrue(quarantined.single().readText().contains("corrupted_keyset_data"))
+
+            assertFalse(sharedPrefsBakFile(context, RECOVERY_FILENAME).exists())
+            assertTrue(androidKeyStoreAlias().containsAlias(MasterKey.DEFAULT_MASTER_KEY_ALIAS))
         }
 
     @Test
@@ -154,11 +160,19 @@ class EncryptedPreferenceProviderTest {
                 deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
             }
 
-            // Should NOT throw — the orphaned file is provably undecryptable, so it is recreated
             val restoredProvider = AndroidPreferenceProvider.newEncrypted(context, D2D_FILENAME)
 
             // Prefs are empty: user will re-enter seed phrase to recover wallet
             assertFalse(restoredProvider.hasKey(StringDefaultPreferenceFixture.KEY))
+
+            val quarantined = quarantinedFiles(context, D2D_FILENAME)
+            assertEquals(1, quarantined.size)
+
+            assertTrue(androidKeyStoreAlias().containsAlias(MasterKey.DEFAULT_MASTER_KEY_ALIAS))
+
+            val expectedValue = StringDefaultPreferenceFixture.DEFAULT_VALUE + "restored"
+            restoredProvider.putString(StringDefaultPreferenceFixture.KEY, expectedValue)
+            assertEquals(expectedValue, StringDefaultPreferenceFixture.new().getValue(restoredProvider))
         }
 
     companion object {
@@ -179,5 +193,24 @@ class EncryptedPreferenceProviderTest {
                 ApplicationProvider.getApplicationContext(),
                 FILENAME
             )
+
+        private fun androidKeyStoreAlias(): KeyStore =
+            KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+
+        private fun sharedPrefsBakFile(
+            context: Context,
+            filename: String
+        ) = File(File(context.filesDir.parent, "shared_prefs"), "$filename.xml.bak")
+
+        private fun quarantinedFiles(
+            context: Context,
+            filename: String
+        ): List<File> {
+            val quarantineDir = File(context.noBackupFilesDir, QUARANTINE_DIRECTORY)
+            return quarantineDir
+                .listFiles { file -> file.name.startsWith("$filename-") && file.name.endsWith(".xml") }
+                ?.toList()
+                .orEmpty()
+        }
     }
 }

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
@@ -282,22 +282,30 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
      * Sets the corrupted file aside instead of deleting it. `<filename>.xml` and its `.xml.bak`
      * sibling both move into the quarantine directory; taking the `.bak` along is mandatory,
      * because `SharedPreferencesImpl.loadFromDisk` restores a leftover `.bak` over a fresh file on
-     * the next process start, which would silently resurrect the corrupted data. If the move
-     * itself fails, both files are deleted instead so recovery still completes.
+     * the next process start, which would silently resurrect the corrupted data. A failing move
+     * rethrows out of here and out of [createEncryptedPreferencesWithRecovery], leaving the
+     * original files untouched for a later attempt — see
+     * [quarantineEncryptedPreferencesFilesAndMarkRecreated] for why deleting them instead would be
+     * worse than not recovering at all.
      *
-     * The [recreatedMarkerFile] guard is written next, right after the move, so a crash before the
-     * caller's post-quarantine retry still leaves the guard in place — see [openEncrypted] for
-     * when it is cleared again. Android's in-memory `SharedPreferences` cache is then cleared so
-     * the retry gets a clean instance instead of the cached corrupted one, which has to happen
-     * after the move or it would quarantine an empty file. That clear commits an empty
-     * `<filename>.xml` back to the now-vacated original path, so the file is removed again
-     * immediately: a retry that fails afterwards would otherwise leave a stray empty file behind
-     * for the next launch to quarantine, instead of the marker guard rethrowing.
+     * The [recreatedMarkerFile] guard is written by that same call, and only once the move
+     * succeeded: a crash before the caller's post-quarantine retry still leaves the guard in
+     * place — see [openEncrypted] for when it is cleared again. Android's in-memory
+     * `SharedPreferences` cache is then cleared so the retry gets a clean instance instead of the
+     * cached corrupted one, which has to happen after the move or it would quarantine an empty
+     * file. That clear commits an empty `<filename>.xml` back to the now-vacated original path, so
+     * the file is removed again immediately: a retry that fails afterwards would otherwise leave a
+     * stray empty file behind for the next launch to quarantine, instead of the marker guard
+     * rethrowing.
      *
      * The Keystore master-key alias is deleted last, and only for [isMasterKeyFailure]:
      * `MasterKey.Builder.build()` reuses an existing alias, so a data-level failure keeps the key
      * and the quarantined file stays decryptable by this device if the classification was ever
-     * wrong.
+     * wrong. That guarantee does not hold for an `InvalidKeyException` without the transient
+     * Keystore marker: [isUnrecoverableCorruption] reads it as corruption and [isMasterKeyFailure]
+     * reads it as a dead key, so the file is quarantined and the key deleted in this same call, and
+     * the quarantined file becomes permanently undecryptable on this device regardless of whether
+     * the classification was correct.
      */
     private fun quarantineCorruptedEncryptedPreferences(
         context: Context,
@@ -307,24 +315,11 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
         val sharedPrefsDir = sharedPreferencesDirectory(context)
         val quarantineDir = quarantineDirectory(context)
 
-        runCatching {
-            quarantineEncryptedPreferencesFiles(
-                sharedPrefsDir = sharedPrefsDir,
-                quarantineDir = quarantineDir,
-                filename = filename,
-            )
-        }.onFailure { failure ->
-            Twig.error(failure) { "Quarantining encrypted preferences $filename failed; deleting instead" }
-            runCatching { deleteEncryptedPreferencesFiles(sharedPrefsDir, filename) }
-        }
-
-        runCatching {
-            quarantineDir.mkdirs()
-            val markerCreated = recreatedMarkerFile(quarantineDir, filename).createNewFile()
-            if (!markerCreated) {
-                Twig.error { "Creating the recreated-marker for $filename returned false" }
-            }
-        }
+        quarantineEncryptedPreferencesFilesAndMarkRecreated(
+            sharedPrefsDir = sharedPrefsDir,
+            quarantineDir = quarantineDir,
+            filename = filename,
+        )
 
         runCatching {
             context
@@ -349,6 +344,26 @@ private fun androidKeyStore(): KeyStore =
         .getInstance(ANDROID_KEYSTORE)
         .apply { load(null) }
 
+private fun causeChain(exception: Exception): List<Throwable> =
+    generateSequence<Throwable>(exception) { it.cause }
+        .take(CAUSE_CHAIN_LIMIT)
+        .toList()
+
+/**
+ * True when [chain] carries Android's `android.security.KeyStoreException` (which extends
+ * `java.lang.Exception`, not [java.security.KeyStoreException] — matched here by simple name since
+ * the Android framework class isn't a JVM dependency). AOSP wraps a transient HAL error as
+ * `InvalidKeyException("Keystore operation failed")` carrying that marker, so a chain holding it
+ * says the Keystore daemon was wedged, not that anything is permanently broken.
+ *
+ * Both [isUnrecoverableCorruption] and [isMasterKeyFailure] veto on it, and deliberately share
+ * this one implementation: a shape only one of them vetoed would still be acted upon by the other,
+ * and either action — quarantining the store or deleting the shared master key — is irreversible
+ * for data the Keystore was about to be able to read again.
+ */
+private fun hasTransientAndroidKeyStoreMarker(chain: List<Throwable>): Boolean =
+    chain.any { it !is KeyStoreException && it.javaClass.simpleName == "KeyStoreException" }
+
 /**
  * True only for failures that are deterministic for the stored ciphertext or this device's
  * Keystore: an AEAD/padding authentication failure, a Tink keyset that no longer decodes
@@ -361,17 +376,22 @@ private fun androidKeyStore(): KeyStore =
  * is verifiably gone on this device. Other Keystore and general IO failures are excluded because
  * they can be transient — [createEncryptedPreferencesWithRecovery] retries before this
  * classification runs.
+ *
+ * A chain carrying the [hasTransientAndroidKeyStoreMarker] shape is never corruption, whatever
+ * else it holds: quarantining moves the seed somewhere no screen can reach it, while rethrowing
+ * leaves the store readable again as soon as the Keystore settles.
  */
-internal fun isUnrecoverableCorruption(exception: Exception): Boolean =
-    generateSequence<Throwable>(exception) { it.cause }
-        .take(CAUSE_CHAIN_LIMIT)
-        .any {
-            it is BadPaddingException ||
-                it is CharConversionException ||
-                it is KeyStoreException ||
-                it is InvalidKeyException ||
-                it.javaClass.simpleName == "InvalidProtocolBufferException"
-        }
+internal fun isUnrecoverableCorruption(exception: Exception): Boolean {
+    val chain = causeChain(exception)
+    if (hasTransientAndroidKeyStoreMarker(chain)) return false
+    return chain.any {
+        it is BadPaddingException ||
+            it is CharConversionException ||
+            it is KeyStoreException ||
+            it is InvalidKeyException ||
+            it.javaClass.simpleName == "InvalidProtocolBufferException"
+    }
+}
 
 /**
  * True for failures that mean the Keystore key itself is unusable, as opposed to the stored
@@ -380,13 +400,10 @@ internal fun isUnrecoverableCorruption(exception: Exception): Boolean =
  * [createEncryptedPreferencesWithRecovery] has exhausted its retry ladder, so anything reaching
  * this classification already survived [ENCRYPTED_PREFERENCES_OPEN_ATTEMPTS] attempts.
  *
- * AOSP wraps a transient HAL error as `InvalidKeyException("Keystore operation failed")` whose
- * cause chain contains Android's `android.security.KeyStoreException` (which extends
- * `java.lang.Exception`, not [java.security.KeyStoreException] — matched here by simple name since
- * the Android framework class isn't a JVM dependency). A chain carrying that marker is never a
- * master-key failure, whatever else it holds, or [quarantineCorruptedEncryptedPreferences] would
- * delete the shared master key over a transient error and permanently orphan both the quarantined
- * file and the SDK's own encrypted store.
+ * A chain carrying the [hasTransientAndroidKeyStoreMarker] shape is never a master-key failure,
+ * whatever else it holds, or [quarantineCorruptedEncryptedPreferences] would delete the shared
+ * master key over a transient error and permanently orphan both the quarantined file and the SDK's
+ * own encrypted store.
  *
  * The residual assumption is that a [java.security.KeyStoreException] without that marker is
  * permanent. Tink's `AndroidKeystoreKmsClient.validateAead()` folds the failure it caught into the
@@ -395,10 +412,8 @@ internal fun isUnrecoverableCorruption(exception: Exception): Boolean =
  * broken Keystore; the retry ladder is the only mitigation for that case.
  */
 internal fun isMasterKeyFailure(exception: Exception): Boolean {
-    val chain = generateSequence<Throwable>(exception) { it.cause }.take(CAUSE_CHAIN_LIMIT).toList()
-    val hasAndroidKeyStoreFailure =
-        chain.any { it !is KeyStoreException && it.javaClass.simpleName == "KeyStoreException" }
-    if (hasAndroidKeyStoreFailure) return false
+    val chain = causeChain(exception)
+    if (hasTransientAndroidKeyStoreMarker(chain)) return false
     return chain.any { it is KeyStoreException || it is InvalidKeyException }
 }
 

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.CharConversionException
-import java.io.File
 import java.security.InvalidKeyException
 import java.security.KeyStore
 import java.security.KeyStoreException
@@ -181,6 +180,14 @@ interface AndroidPreferenceFactory {
     suspend fun newStandard(context: Context, filename: String): PreferenceProvider
 
     suspend fun newEncrypted(context: Context, filename: String): PreferenceProvider
+
+    /**
+     * Runs the same open-with-recovery ladder as [newEncrypted] against [filename] without
+     * caching a provider for it, repairing the file in place if it is corrupted. Used by the app
+     * to repair the SDK's own `cash.z.ecc.android.sdk.encrypted` store, which shares this app's
+     * Keystore master key but has no corruption recovery of its own.
+     */
+    suspend fun ensureEncryptedReadable(context: Context, filename: String)
 }
 
 /**
@@ -194,14 +201,6 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
     private val standardCache = PreferenceProviderCache()
     private val encryptedCache = PreferenceProviderCache()
 
-    /**
-     * Filenames already quarantined and recreated once in this process. Bounds recovery to one
-     * recreate per process per filename: if the freshly recreated store still fails to open,
-     * later callers rethrow instead of re-running the ladder and quarantining the fresh store
-     * again.
-     */
-    private val recreatedFilenames = mutableSetOf<String>()
-
     override suspend fun newStandard(context: Context, filename: String): PreferenceProvider =
         standardCache.getOrCreate(filename) {
             val dispatcher = Dispatchers.IO.limitedParallelism(1)
@@ -214,61 +213,43 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
             AndroidPreferenceProvider(sharedPreferences, dispatcher)
         }
 
+    override suspend fun newEncrypted(context: Context, filename: String): PreferenceProvider =
+        encryptedCache.getOrCreate(filename) {
+            val dispatcher = Dispatchers.IO.limitedParallelism(1)
+
+            val sharedPreferences = withContext(dispatcher) { openEncrypted(context, filename) }
+
+            AndroidPreferenceProvider(sharedPreferences, dispatcher)
+        }
+
+    override suspend fun ensureEncryptedReadable(context: Context, filename: String) {
+        withContext(Dispatchers.IO) { openEncrypted(context, filename) }
+    }
+
     /**
      * Android Keystore keys are hardware-bound and not transferred during device-to-device
      * migration, so the encrypted prefs file arrives on the new device but cannot be decrypted.
      * Opening is retried [ENCRYPTED_PREFERENCES_OPEN_ATTEMPTS] times before any failure is
      * classified, since a transient Keystore operation error can look identical to real
-     * corruption on the first attempt. Only failures that provably mean the stored data can never
-     * be decrypted again then trigger [quarantineCorruptedEncryptedPreferences] and a fresh start:
-     * the master key being verifiably absent while the file exists ([isEncryptedFileOrphaned]), or
-     * a deterministic decryption or keyset-parse failure ([isUnrecoverableCorruption]). Every
-     * other failure is logged and rethrown, because misclassifying it as corruption would
-     * irreversibly destroy the stored secrets.
+     * corruption on the first attempt. Only a deterministic decryption or keyset-parse failure
+     * ([isUnrecoverableCorruption]) then triggers [quarantineCorruptedEncryptedPreferences] and a
+     * fresh start, and only once per filename until that fresh store opens successfully — the
+     * persisted [recreatedMarkerFile] guard is what bounds that, surviving across process
+     * restarts unlike an in-memory set. Every other failure is logged and rethrown, because
+     * misclassifying it as corruption would irreversibly destroy the stored secrets.
      */
-    override suspend fun newEncrypted(context: Context, filename: String): PreferenceProvider =
-        encryptedCache.getOrCreate(filename) {
-            val dispatcher = Dispatchers.IO.limitedParallelism(1)
-
-            val sharedPreferences =
-                withContext(dispatcher) {
-                    val isOrphaned = isEncryptedFileOrphaned(context, filename)
-                    createEncryptedPreferencesWithRecovery(
-                        filename = filename,
-                        isOrphaned = isOrphaned,
-                        isRecreateAllowed = filename !in recreatedFilenames,
-                        create = { createEncryptedSharedPreferences(context, filename) },
-                        quarantine = { cause ->
-                            recreatedFilenames += filename
-                            quarantineCorruptedEncryptedPreferences(context, filename, cause)
-                        },
-                    )
-                }
-
-            AndroidPreferenceProvider(sharedPreferences, dispatcher)
-        }
-
-    /**
-     * The device-to-device migration signature: the encrypted preferences file exists, but a
-     * working Keystore definitively reports the master key absent, so nothing can ever decrypt
-     * the file. The query is retried once so that a momentary Keystore hiccup does not disguise
-     * a genuinely orphaned file as healthy; a Keystore that still cannot be queried yields false —
-     * an unknown Keystore state must never authorize deleting the stored secrets.
-     *
-     * Must be evaluated before attempting [createEncryptedSharedPreferences]: a failed attempt has
-     * already recreated the master key alias via [MasterKey.Builder.build], so querying the
-     * Keystore afterwards would always report the alias present and never detect the orphan.
-     */
-    private fun isEncryptedFileOrphaned(
+    private suspend fun openEncrypted(
         context: Context,
         filename: String
-    ): Boolean {
-        if (!encryptedPreferencesFile(context, filename).exists()) {
-            return false
-        }
-        return retryOnceOrDefault(false) {
-            !androidKeyStore().containsAlias(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
-        }
+    ): SharedPreferences {
+        val marker = recreatedMarkerFile(quarantineDirectory(context), filename)
+
+        return createEncryptedPreferencesWithRecovery(
+            filename = filename,
+            isRecreateAllowed = !marker.exists(),
+            create = { createEncryptedSharedPreferences(context, filename) },
+            quarantine = { cause -> quarantineCorruptedEncryptedPreferences(context, filename, cause) },
+        ).also { marker.delete() }
     }
 
     private fun createEncryptedSharedPreferences(
@@ -296,29 +277,39 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
      *    `.bak` over a fresh file on the next process start, which would silently resurrect the
      *    corrupted data. If the move itself fails, both files are deleted instead so recovery
      *    still completes.
-     * 2. Clear the in-memory `SharedPreferences` cache, so the retry gets a clean instance instead
+     * 2. Create the [recreatedMarkerFile] guard on disk, right after the move so a crash before
+     *    the caller's post-quarantine retry still leaves the guard in place — see [openEncrypted]
+     *    for when it is cleared again.
+     * 3. Clear the in-memory `SharedPreferences` cache, so the retry gets a clean instance instead
      *    of the cached corrupted one — done after the move, otherwise it would quarantine an empty
      *    file.
-     * 3. Delete the Keystore master-key alias, but only for [isMasterKeyFailure]: `MasterKey.Builder.build()`
+     * 4. Delete the Keystore master-key alias, but only for [isMasterKeyFailure]: `MasterKey.Builder.build()`
      *    reuses an existing alias, so a data-level failure keeps the key and the quarantined file
-     *    stays decryptable by this device if the classification was ever wrong. Orphaned files
-     *    need no deletion — the alias was already recreated by the first attempt.
+     *    stays decryptable by this device if the classification was ever wrong.
      */
     private fun quarantineCorruptedEncryptedPreferences(
         context: Context,
         filename: String,
         cause: Exception
     ) {
+        val sharedPrefsDir = sharedPreferencesDirectory(context)
+        val quarantineDir = quarantineDirectory(context)
+
         runCatching {
             quarantineEncryptedPreferencesFiles(
-                sharedPrefsDir = sharedPreferencesDirectory(context),
-                quarantineDir = File(context.noBackupFilesDir, QUARANTINE_DIRECTORY),
+                sharedPrefsDir = sharedPrefsDir,
+                quarantineDir = quarantineDir,
                 filename = filename,
             )
         }.onFailure { failure ->
             Twig.error(failure) { "Quarantining encrypted preferences $filename failed; deleting instead" }
-            runCatching { encryptedPreferencesFile(context, filename).delete() }
-            runCatching { File(sharedPreferencesDirectory(context), "$filename.xml.bak").delete() }
+            runCatching { encryptedPreferencesFile(sharedPrefsDir, filename).delete() }
+            runCatching { encryptedPreferencesBackupFile(sharedPrefsDir, filename).delete() }
+        }
+
+        runCatching {
+            quarantineDir.mkdirs()
+            recreatedMarkerFile(quarantineDir, filename).createNewFile()
         }
 
         runCatching {
@@ -333,13 +324,6 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
             runCatching { androidKeyStore().deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS) }
         }
     }
-
-    private fun encryptedPreferencesFile(
-        context: Context,
-        filename: String
-    ) = File(sharedPreferencesDirectory(context), "$filename.xml")
-
-    private fun sharedPreferencesDirectory(context: Context) = File(context.filesDir.parent, "shared_prefs")
 }
 
 private const val ANDROID_KEYSTORE = "AndroidKeyStore"
@@ -357,12 +341,11 @@ private fun androidKeyStore(): KeyStore =
  * malformed-proto one), Tink's Keystore self-test failure ([KeyStoreException] — as of tink-android
  * 1.20.0, `AndroidKeystoreKmsClient` throws it from `validateAead()` when a post-key-creation AEAD
  * encrypt/decrypt round-trip of a random message doesn't match; a permanent condition on devices
- * with a buggy hardware Keystore), or [InvalidKeyException], the failure
- * [createEncryptedSharedPreferences] actually throws for a genuinely device-to-device-orphaned
- * file when [isEncryptedFileOrphaned]'s Keystore query itself failed twice (see
- * [retryOnceOrDefault]) and so could not flag the orphan first — this is the second line of
- * defense for that case. Other Keystore and general IO failures are excluded because they can be
- * transient — [createEncryptedPreferencesWithRecovery] retries before this classification runs.
+ * with a buggy hardware Keystore), or [InvalidKeyException] — the failure
+ * [createEncryptedSharedPreferences] throws for a device-to-device-orphaned file, whose master key
+ * is verifiably gone on this device. Other Keystore and general IO failures are excluded because
+ * they can be transient — [createEncryptedPreferencesWithRecovery] retries before this
+ * classification runs.
  */
 internal fun isUnrecoverableCorruption(exception: Exception): Boolean =
     generateSequence<Throwable>(exception) { it.cause }
@@ -377,25 +360,21 @@ internal fun isUnrecoverableCorruption(exception: Exception): Boolean =
 
 /**
  * True for failures that mean the Keystore key itself is unusable, as opposed to the stored
- * ciphertext being unreadable. [MasterKey.Builder.build] reuses an existing alias, so these are
- * the only failures for which [quarantineCorruptedEncryptedPreferences] must delete it and force a
- * fresh key on the next attempt.
+ * ciphertext being unreadable or a transient Keystore-daemon hiccup. AOSP wraps a transient HAL
+ * error as `InvalidKeyException("Keystore operation failed")` whose cause chain contains Android's
+ * `android.security.KeyStoreException` (which extends `java.lang.Exception`, not
+ * [java.security.KeyStoreException] — matched here by simple name since the Android framework class
+ * isn't a JVM dependency); such a chain must NOT be treated as a master-key failure, or
+ * [quarantineCorruptedEncryptedPreferences] would delete the shared master key over a transient
+ * error and permanently orphan both the quarantined file and the SDK's own encrypted store.
  */
-internal fun isMasterKeyFailure(exception: Exception): Boolean =
-    generateSequence<Throwable>(exception) { it.cause }
-        .take(CAUSE_CHAIN_LIMIT)
-        .any { it is KeyStoreException || it is InvalidKeyException }
-
-/**
- * Runs [block], retrying once if it throws; returns [default] when both attempts throw.
- */
-internal fun <T> retryOnceOrDefault(
-    default: T,
-    block: () -> T
-): T =
-    runCatching(block)
-        .recoverCatching { block() }
-        .getOrDefault(default)
+internal fun isMasterKeyFailure(exception: Exception): Boolean {
+    val chain = generateSequence<Throwable>(exception) { it.cause }.take(CAUSE_CHAIN_LIMIT).toList()
+    if (chain.any { it is KeyStoreException }) return true
+    val hasAndroidKeyStoreFailure =
+        chain.any { it !is KeyStoreException && it.javaClass.simpleName == "KeyStoreException" }
+    return chain.any { it is InvalidKeyException } && !hasAndroidKeyStoreFailure
+}
 
 internal const val ENCRYPTED_PREFERENCES_OPEN_ATTEMPTS = 3
 
@@ -408,14 +387,13 @@ internal fun encryptedPreferencesOpenBackoff(attempt: Int): Duration = 200.milli
  * is [delay], kept outside the try/catch so a coroutine cancellation always propagates instead of
  * being caught by the broad `Exception` handling here.
  *
- * After [maxAttempts] failures, [quarantine] runs only when [isRecreateAllowed] and either
- * [isOrphaned] or the last failure is [isUnrecoverableCorruption]; otherwise the last failure is
- * rethrown, keeping the stored data intact for a later retry.
+ * After [maxAttempts] failures, [quarantine] runs only when [isRecreateAllowed] and the last
+ * failure is [isUnrecoverableCorruption]; otherwise the last failure is rethrown, keeping the
+ * stored data intact for a later retry.
  */
 @Suppress("TooGenericExceptionCaught", "ReturnCount")
 internal suspend fun <T> createEncryptedPreferencesWithRecovery(
     filename: String,
-    isOrphaned: Boolean,
     isRecreateAllowed: Boolean = true,
     maxAttempts: Int = ENCRYPTED_PREFERENCES_OPEN_ATTEMPTS,
     backoff: (attempt: Int) -> Duration = ::encryptedPreferencesOpenBackoff,
@@ -442,7 +420,7 @@ internal suspend fun <T> createEncryptedPreferencesWithRecovery(
 
     val cause = checkNotNull(lastFailure) { "maxAttempts must be at least 1" }
 
-    return if (isRecreateAllowed && (isOrphaned || isUnrecoverableCorruption(cause))) {
+    return if (isRecreateAllowed && isUnrecoverableCorruption(cause)) {
         Twig.error(cause) { "Encrypted preferences $filename can never be decrypted again; quarantining them" }
         quarantine(cause)
         create()

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
@@ -186,6 +186,14 @@ interface AndroidPreferenceFactory {
      * caching a provider for it, repairing the file in place if it is corrupted. Used by the app
      * to repair the SDK's own `cash.z.ecc.android.sdk.encrypted` store, which shares this app's
      * Keystore master key but has no corruption recovery of its own.
+     *
+     * Caching no provider is deliberate: the opened store is never handed out, so no second
+     * [AndroidPreferenceProvider] — and therefore no second serializing dispatcher — is ever
+     * created for a file the SDK opens itself. The ordering that makes that safe is the caller's
+     * to keep: this must complete before anything else opens [filename]. The app's only caller,
+     * the wallet-less self-heal in `WalletRepositoryImpl.init`, awaits it before
+     * `Synchronizer.erase` and runs only on the path where no wallet is stored, so no synchronizer
+     * exists yet to be holding the SDK store open.
      */
     suspend fun ensureEncryptedReadable(context: Context, filename: String)
 }
@@ -271,21 +279,25 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
     }
 
     /**
-     * Sets the corrupted file aside instead of deleting it, in this order:
-     * 1. Move `<filename>.xml` and its `.xml.bak` sibling into the quarantine directory. The
-     *    `.bak` file is mandatory: `SharedPreferencesImpl.loadFromDisk` restores a leftover
-     *    `.bak` over a fresh file on the next process start, which would silently resurrect the
-     *    corrupted data. If the move itself fails, both files are deleted instead so recovery
-     *    still completes.
-     * 2. Create the [recreatedMarkerFile] guard on disk, right after the move so a crash before
-     *    the caller's post-quarantine retry still leaves the guard in place — see [openEncrypted]
-     *    for when it is cleared again.
-     * 3. Clear the in-memory `SharedPreferences` cache, so the retry gets a clean instance instead
-     *    of the cached corrupted one — done after the move, otherwise it would quarantine an empty
-     *    file.
-     * 4. Delete the Keystore master-key alias, but only for [isMasterKeyFailure]: `MasterKey.Builder.build()`
-     *    reuses an existing alias, so a data-level failure keeps the key and the quarantined file
-     *    stays decryptable by this device if the classification was ever wrong.
+     * Sets the corrupted file aside instead of deleting it. `<filename>.xml` and its `.xml.bak`
+     * sibling both move into the quarantine directory; taking the `.bak` along is mandatory,
+     * because `SharedPreferencesImpl.loadFromDisk` restores a leftover `.bak` over a fresh file on
+     * the next process start, which would silently resurrect the corrupted data. If the move
+     * itself fails, both files are deleted instead so recovery still completes.
+     *
+     * The [recreatedMarkerFile] guard is written next, right after the move, so a crash before the
+     * caller's post-quarantine retry still leaves the guard in place — see [openEncrypted] for
+     * when it is cleared again. Android's in-memory `SharedPreferences` cache is then cleared so
+     * the retry gets a clean instance instead of the cached corrupted one, which has to happen
+     * after the move or it would quarantine an empty file. That clear commits an empty
+     * `<filename>.xml` back to the now-vacated original path, so the file is removed again
+     * immediately: a retry that fails afterwards would otherwise leave a stray empty file behind
+     * for the next launch to quarantine, instead of the marker guard rethrowing.
+     *
+     * The Keystore master-key alias is deleted last, and only for [isMasterKeyFailure]:
+     * `MasterKey.Builder.build()` reuses an existing alias, so a data-level failure keeps the key
+     * and the quarantined file stays decryptable by this device if the classification was ever
+     * wrong.
      */
     private fun quarantineCorruptedEncryptedPreferences(
         context: Context,
@@ -303,8 +315,7 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
             )
         }.onFailure { failure ->
             Twig.error(failure) { "Quarantining encrypted preferences $filename failed; deleting instead" }
-            runCatching { encryptedPreferencesFile(sharedPrefsDir, filename).delete() }
-            runCatching { encryptedPreferencesBackupFile(sharedPrefsDir, filename).delete() }
+            runCatching { deleteEncryptedPreferencesFiles(sharedPrefsDir, filename) }
         }
 
         runCatching {
@@ -318,6 +329,7 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
                 .edit()
                 .clear()
                 .commit()
+            deleteEncryptedPreferencesFiles(sharedPrefsDir, filename)
         }
 
         if (isMasterKeyFailure(cause)) {
@@ -360,20 +372,31 @@ internal fun isUnrecoverableCorruption(exception: Exception): Boolean =
 
 /**
  * True for failures that mean the Keystore key itself is unusable, as opposed to the stored
- * ciphertext being unreadable or a transient Keystore-daemon hiccup. AOSP wraps a transient HAL
- * error as `InvalidKeyException("Keystore operation failed")` whose cause chain contains Android's
- * `android.security.KeyStoreException` (which extends `java.lang.Exception`, not
- * [java.security.KeyStoreException] — matched here by simple name since the Android framework class
- * isn't a JVM dependency); such a chain must NOT be treated as a master-key failure, or
- * [quarantineCorruptedEncryptedPreferences] would delete the shared master key over a transient
- * error and permanently orphan both the quarantined file and the SDK's own encrypted store.
+ * ciphertext being unreadable or a transient Keystore-daemon hiccup. Only ever consulted from
+ * [quarantineCorruptedEncryptedPreferences], which runs after
+ * [createEncryptedPreferencesWithRecovery] has exhausted its retry ladder, so anything reaching
+ * this classification already survived [ENCRYPTED_PREFERENCES_OPEN_ATTEMPTS] attempts.
+ *
+ * AOSP wraps a transient HAL error as `InvalidKeyException("Keystore operation failed")` whose
+ * cause chain contains Android's `android.security.KeyStoreException` (which extends
+ * `java.lang.Exception`, not [java.security.KeyStoreException] — matched here by simple name since
+ * the Android framework class isn't a JVM dependency). A chain carrying that marker is never a
+ * master-key failure, whatever else it holds, or [quarantineCorruptedEncryptedPreferences] would
+ * delete the shared master key over a transient error and permanently orphan both the quarantined
+ * file and the SDK's own encrypted store.
+ *
+ * The residual assumption is that a [java.security.KeyStoreException] without that marker is
+ * permanent. Tink's `AndroidKeystoreKmsClient.validateAead()` folds the failure it caught into the
+ * message of the [java.security.KeyStoreException] it throws rather than setting it as the cause,
+ * so a transient HAL error surfacing through it is indistinguishable by type from a genuinely
+ * broken Keystore; the retry ladder is the only mitigation for that case.
  */
 internal fun isMasterKeyFailure(exception: Exception): Boolean {
     val chain = generateSequence<Throwable>(exception) { it.cause }.take(CAUSE_CHAIN_LIMIT).toList()
-    if (chain.any { it is KeyStoreException }) return true
     val hasAndroidKeyStoreFailure =
         chain.any { it !is KeyStoreException && it.javaClass.simpleName == "KeyStoreException" }
-    return chain.any { it is InvalidKeyException } && !hasAndroidKeyStoreFailure
+    if (hasAndroidKeyStoreFailure) return false
+    return chain.any { it is KeyStoreException || it is InvalidKeyException }
 }
 
 internal const val ENCRYPTED_PREFERENCES_OPEN_ATTEMPTS = 3

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
@@ -426,6 +426,8 @@ internal suspend fun <T> createEncryptedPreferencesWithRecovery(
     create: () -> T,
     quarantine: (cause: Exception) -> Unit,
 ): T {
+    require(maxAttempts >= 1) { "maxAttempts must be at least 1" }
+
     var lastFailure: Exception? = null
 
     for (attempt in 1..maxAttempts) {
@@ -444,7 +446,7 @@ internal suspend fun <T> createEncryptedPreferencesWithRecovery(
         }
     }
 
-    val cause = checkNotNull(lastFailure) { "maxAttempts must be at least 1" }
+    val cause = checkNotNull(lastFailure)
 
     return if (isRecreateAllowed && isUnrecoverableCorruption(cause)) {
         Twig.error(cause) { "Encrypted preferences $filename can never be decrypted again; quarantining them" }

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
@@ -195,7 +195,7 @@ interface AndroidPreferenceFactory {
      * `Synchronizer.erase` and runs only on the path where no wallet is stored, so no synchronizer
      * exists yet to be holding the SDK store open.
      */
-    suspend fun ensureEncryptedReadable(context: Context, filename: String)
+    suspend fun ensureEncryptedReadable(context: Context, filename: String) = Unit
 }
 
 /**

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
@@ -425,6 +425,13 @@ private fun hasPermanentAndroidKeyStoreErrorCode(throwable: Throwable): Boolean 
  * Everything else is treated as not-permanent, including a Keystore failure this code cannot
  * classify at all: unsure means the veto holds and the store is rethrown for a later attempt,
  * never quarantined.
+ *
+ * Rethrowing an unclassifiable failure means the user sits on the (already-deferred) splash with
+ * no in-app recourse — Reset Zodl lives behind a normal boot the wedged store can't reach, and
+ * there is no `SecretState.ERROR` screen yet to say so. Relaunching once the Keystore settles is
+ * the only way through. That is the deliberate price of failing safe: it is a worse experience
+ * than quarantining or wiping, but neither of those is reversible if the failure turns out to have
+ * been transient after all.
  */
 private fun isPermanentAndroidKeyStoreFailure(throwable: Throwable): Boolean {
     if (isTransientPerAndroidKeyStore(throwable)) return false

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
@@ -349,20 +349,117 @@ private fun causeChain(exception: Exception): List<Throwable> =
         .take(CAUSE_CHAIN_LIMIT)
         .toList()
 
+private const val ANDROID_KEY_STORE_EXCEPTION_SIMPLE_NAME = "KeyStoreException"
+
 /**
- * True when [chain] carries Android's `android.security.KeyStoreException` (which extends
- * `java.lang.Exception`, not [java.security.KeyStoreException] — matched here by simple name since
- * the Android framework class isn't a JVM dependency). AOSP wraps a transient HAL error as
- * `InvalidKeyException("Keystore operation failed")` carrying that marker, so a chain holding it
- * says the Keystore daemon was wedged, not that anything is permanently broken.
+ * `android.security.KeyStoreException.ERROR_KEY_DOES_NOT_EXIST`. AOSP maps both
+ * `ResponseCode.KEY_NOT_FOUND` and `ResponseCode.KEY_PERMANENTLY_INVALIDATED` onto it, so it is the
+ * public code for "the alias this store was encrypted under is gone for good".
+ */
+private const val ANDROID_KEY_STORE_ERROR_KEY_DOES_NOT_EXIST = 6
+
+/**
+ * `android.security.KeyStoreException.ERROR_KEY_CORRUPTED`, AOSP's public code for
+ * `ResponseCode.VALUE_CORRUPTED`: the stored key blob no longer parses.
+ */
+private const val ANDROID_KEY_STORE_ERROR_KEY_CORRUPTED = 7
+
+private val PERMANENT_ANDROID_KEY_STORE_ERROR_CODES =
+    setOf(
+        ANDROID_KEY_STORE_ERROR_KEY_DOES_NOT_EXIST,
+        ANDROID_KEY_STORE_ERROR_KEY_CORRUPTED
+    )
+
+/**
+ * AOSP's own wording for the Keystore and KeyMint conditions under which this device can never read
+ * the stored ciphertext again: the first two come from `KeymasterDefs.sErrorCodeToString`
+ * (`KM_ERROR_VERIFICATION_FAILED`, `KM_ERROR_INVALID_KEY_BLOB`), the rest from the
+ * `ResponseCode` switch in `KeyStore2.getKeyStoreException` (`VALUE_CORRUPTED`, `KEY_NOT_FOUND`,
+ * `KEY_PERMANENTLY_INVALIDATED`). They are hard-coded, never localized, and identical in the legacy
+ * `KeyStore.getKeyStoreException` that devices below API 31 still use, which is what makes matching
+ * on them the one permanence signal available on every supported API level — the typed
+ * classification below arrived only in API 33.
+ */
+private val PERMANENT_ANDROID_KEY_STORE_MESSAGES =
+    setOf(
+        "Signature/MAC verification failed",
+        "Invalid key blob",
+        "Key blob corrupted",
+        "Key not found",
+        "Key permanently invalidated"
+    )
+
+/**
+ * AOSP's own verdict from `android.security.KeyStoreException.isTransientFailure()`, which exists
+ * only from API 33. Below that the method is absent and this reports false — "AOSP did not say it
+ * is transient", not "AOSP said it is permanent"; [isPermanentAndroidKeyStoreFailure] still has to
+ * find positive evidence of permanence before the veto is released.
+ */
+private fun isTransientPerAndroidKeyStore(throwable: Throwable): Boolean =
+    runCatching {
+        throwable.javaClass.getMethod("isTransientFailure").invoke(throwable) as Boolean
+    }.getOrDefault(false)
+
+/**
+ * True when `android.security.KeyStoreException.getNumericErrorCode()` (API 33 and up) names a key
+ * that is gone or unparseable. Reflective for the same reason the class itself is matched by simple
+ * name, and false whenever the method is missing.
+ */
+private fun hasPermanentAndroidKeyStoreErrorCode(throwable: Throwable): Boolean {
+    val numericErrorCode =
+        runCatching {
+            throwable.javaClass.getMethod("getNumericErrorCode").invoke(throwable) as Int
+        }.getOrNull()
+
+    return numericErrorCode != null && numericErrorCode in PERMANENT_ANDROID_KEY_STORE_ERROR_CODES
+}
+
+/**
+ * True only when the Keystore itself reports a condition this device can never recover from: the
+ * key is gone, its blob is unparseable, or the stored ciphertext does not authenticate under the
+ * key that exists now — the shape a device-to-device transfer leaves behind, where
+ * `MasterKey.Builder.build()` silently mints a new key under the old alias and every decrypt then
+ * fails with `AEADBadTagException` caused by
+ * `android.security.KeyStoreException: Signature/MAC verification failed`.
  *
- * Both [isUnrecoverableCorruption] and [isMasterKeyFailure] veto on it, and deliberately share
+ * Everything else is treated as not-permanent, including a Keystore failure this code cannot
+ * classify at all: unsure means the veto holds and the store is rethrown for a later attempt,
+ * never quarantined.
+ */
+private fun isPermanentAndroidKeyStoreFailure(throwable: Throwable): Boolean {
+    if (isTransientPerAndroidKeyStore(throwable)) return false
+
+    val message = throwable.message.orEmpty()
+
+    return PERMANENT_ANDROID_KEY_STORE_MESSAGES.any { message.startsWith(it) } ||
+        hasPermanentAndroidKeyStoreErrorCode(throwable)
+}
+
+/**
+ * True when [chain] carries an `android.security.KeyStoreException` that is not positively
+ * permanent. That class extends `java.lang.Exception` rather than [java.security.KeyStoreException]
+ * and is matched here by simple name, because the framework class is not a JVM dependency of this
+ * module. AOSP wraps a transient HAL error as `InvalidKeyException("Keystore operation failed")`
+ * carrying that marker, so such a chain says the Keystore daemon was wedged, not that anything is
+ * permanently broken.
+ *
+ * The marker alone is not enough to veto, because AOSP also raises it for failures that will never
+ * heal — [isPermanentAndroidKeyStoreFailure] is what separates the two. Vetoing on its mere
+ * presence stranded the device-to-device case this recovery exists for: the store could never be
+ * decrypted again, yet every launch classified it as transient, exhausted the retry ladder and
+ * rethrew, so onboarding was never reached.
+ *
+ * Both [isUnrecoverableCorruption] and [isMasterKeyFailure] veto on this, and deliberately share
  * this one implementation: a shape only one of them vetoed would still be acted upon by the other,
  * and either action — quarantining the store or deleting the shared master key — is irreversible
  * for data the Keystore was about to be able to read again.
  */
 private fun hasTransientAndroidKeyStoreMarker(chain: List<Throwable>): Boolean =
-    chain.any { it !is KeyStoreException && it.javaClass.simpleName == "KeyStoreException" }
+    chain.any {
+        it !is KeyStoreException &&
+            it.javaClass.simpleName == ANDROID_KEY_STORE_EXCEPTION_SIMPLE_NAME &&
+            !isPermanentAndroidKeyStoreFailure(it)
+    }
 
 /**
  * True only for failures that are deterministic for the stored ciphertext or this device's
@@ -371,15 +468,18 @@ private fun hasTransientAndroidKeyStoreMarker(chain: List<Throwable>): Boolean =
  * malformed-proto one), Tink's Keystore self-test failure ([KeyStoreException] — as of tink-android
  * 1.20.0, `AndroidKeystoreKmsClient` throws it from `validateAead()` when a post-key-creation AEAD
  * encrypt/decrypt round-trip of a random message doesn't match; a permanent condition on devices
- * with a buggy hardware Keystore), or [InvalidKeyException] — the failure
+ * with a buggy hardware Keystore), or [InvalidKeyException] — one of the failures
  * [createEncryptedSharedPreferences] throws for a device-to-device-orphaned file, whose master key
- * is verifiably gone on this device. Other Keystore and general IO failures are excluded because
- * they can be transient — [createEncryptedPreferencesWithRecovery] retries before this
- * classification runs.
+ * is verifiably gone on this device. (The other, seen on an emulator across API 31 and 35, is an
+ * `AEADBadTagException` carrying the Keystore's `Signature/MAC verification failed`.) Other
+ * Keystore and general IO failures are excluded because they can be transient —
+ * [createEncryptedPreferencesWithRecovery] retries before this classification runs.
  *
  * A chain carrying the [hasTransientAndroidKeyStoreMarker] shape is never corruption, whatever
  * else it holds: quarantining moves the seed somewhere no screen can reach it, while rethrowing
- * leaves the store readable again as soon as the Keystore settles.
+ * leaves the store readable again as soon as the Keystore settles. That veto is exactly as wide as
+ * the Keystore's own uncertainty — a Keystore failure that positively reports a gone, unparseable
+ * or unauthenticating key is not the shape, and is classified on its merits below.
  */
 internal fun isUnrecoverableCorruption(exception: Exception): Boolean {
     val chain = causeChain(exception)

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
@@ -13,6 +13,7 @@ import co.electriccoin.zcash.spackle.Twig
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.callbackFlow
@@ -28,6 +29,8 @@ import java.security.InvalidKeyException
 import java.security.KeyStore
 import java.security.KeyStoreException
 import javax.crypto.BadPaddingException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Provides an Android implementation of shared preferences.
@@ -191,6 +194,14 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
     private val standardCache = PreferenceProviderCache()
     private val encryptedCache = PreferenceProviderCache()
 
+    /**
+     * Filenames already quarantined and recreated once in this process. Bounds recovery to one
+     * recreate per process per filename: if the freshly recreated store still fails to open,
+     * later callers rethrow instead of re-running the ladder and quarantining the fresh store
+     * again.
+     */
+    private val recreatedFilenames = mutableSetOf<String>()
+
     override suspend fun newStandard(context: Context, filename: String): PreferenceProvider =
         standardCache.getOrCreate(filename) {
             val dispatcher = Dispatchers.IO.limitedParallelism(1)
@@ -206,14 +217,15 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
     /**
      * Android Keystore keys are hardware-bound and not transferred during device-to-device
      * migration, so the encrypted prefs file arrives on the new device but cannot be decrypted.
-     * Only failures that provably mean the stored data can never be decrypted again trigger
-     * [deleteCorruptedEncryptedPreferences] and a fresh start: the master key being verifiably
-     * absent while the file exists ([isEncryptedFileOrphaned]), or a deterministic decryption or
-     * keyset-parse failure ([isUnrecoverableCorruption]). Every other failure — for example a
-     * transient Keystore outage — is logged and rethrown, because misclassifying it as corruption
-     * would irreversibly destroy the stored secrets.
+     * Opening is retried [ENCRYPTED_PREFERENCES_OPEN_ATTEMPTS] times before any failure is
+     * classified, since a transient Keystore operation error can look identical to real
+     * corruption on the first attempt. Only failures that provably mean the stored data can never
+     * be decrypted again then trigger [quarantineCorruptedEncryptedPreferences] and a fresh start:
+     * the master key being verifiably absent while the file exists ([isEncryptedFileOrphaned]), or
+     * a deterministic decryption or keyset-parse failure ([isUnrecoverableCorruption]). Every
+     * other failure is logged and rethrown, because misclassifying it as corruption would
+     * irreversibly destroy the stored secrets.
      */
-    @Suppress("TooGenericExceptionCaught")
     override suspend fun newEncrypted(context: Context, filename: String): PreferenceProvider =
         encryptedCache.getOrCreate(filename) {
             val dispatcher = Dispatchers.IO.limitedParallelism(1)
@@ -221,22 +233,16 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
             val sharedPreferences =
                 withContext(dispatcher) {
                     val isOrphaned = isEncryptedFileOrphaned(context, filename)
-                    try {
-                        createEncryptedSharedPreferences(context, filename)
-                    } catch (e: Exception) {
-                        if (isOrphaned || isUnrecoverableCorruption(e)) {
-                            Twig.error(e) {
-                                "Encrypted preferences $filename can never be decrypted again; recreating them"
-                            }
-                            deleteCorruptedEncryptedPreferences(context, filename)
-                            createEncryptedSharedPreferences(context, filename)
-                        } else {
-                            Twig.error(e) {
-                                "Opening encrypted preferences $filename failed; keeping data intact for a retry"
-                            }
-                            throw e
-                        }
-                    }
+                    createEncryptedPreferencesWithRecovery(
+                        filename = filename,
+                        isOrphaned = isOrphaned,
+                        isRecreateAllowed = filename !in recreatedFilenames,
+                        create = { createEncryptedSharedPreferences(context, filename) },
+                        quarantine = { cause ->
+                            recreatedFilenames += filename
+                            quarantineCorruptedEncryptedPreferences(context, filename, cause)
+                        },
+                    )
                 }
 
             AndroidPreferenceProvider(sharedPreferences, dispatcher)
@@ -283,15 +289,38 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
         )
     }
 
-    private fun deleteCorruptedEncryptedPreferences(
+    /**
+     * Sets the corrupted file aside instead of deleting it, in this order:
+     * 1. Move `<filename>.xml` and its `.xml.bak` sibling into the quarantine directory. The
+     *    `.bak` file is mandatory: `SharedPreferencesImpl.loadFromDisk` restores a leftover
+     *    `.bak` over a fresh file on the next process start, which would silently resurrect the
+     *    corrupted data. If the move itself fails, both files are deleted instead so recovery
+     *    still completes.
+     * 2. Clear the in-memory `SharedPreferences` cache, so the retry gets a clean instance instead
+     *    of the cached corrupted one — done after the move, otherwise it would quarantine an empty
+     *    file.
+     * 3. Delete the Keystore master-key alias, but only for [isMasterKeyFailure]: `MasterKey.Builder.build()`
+     *    reuses an existing alias, so a data-level failure keeps the key and the quarantined file
+     *    stays decryptable by this device if the classification was ever wrong. Orphaned files
+     *    need no deletion — the alias was already recreated by the first attempt.
+     */
+    private fun quarantineCorruptedEncryptedPreferences(
         context: Context,
-        filename: String
+        filename: String,
+        cause: Exception
     ) {
         runCatching {
-            androidKeyStore().deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS)
+            quarantineEncryptedPreferencesFiles(
+                sharedPrefsDir = sharedPreferencesDirectory(context),
+                quarantineDir = File(context.noBackupFilesDir, QUARANTINE_DIRECTORY),
+                filename = filename,
+            )
+        }.onFailure { failure ->
+            Twig.error(failure) { "Quarantining encrypted preferences $filename failed; deleting instead" }
+            runCatching { encryptedPreferencesFile(context, filename).delete() }
+            runCatching { File(sharedPreferencesDirectory(context), "$filename.xml.bak").delete() }
         }
-        // Clear in-memory SharedPreferences cache so the retry gets a clean instance.
-        // Without this, Android returns the cached (corrupted) instance even after file deletion.
+
         runCatching {
             context
                 .getSharedPreferences(filename, Context.MODE_PRIVATE)
@@ -299,15 +328,18 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
                 .clear()
                 .commit()
         }
-        runCatching {
-            encryptedPreferencesFile(context, filename).delete()
+
+        if (isMasterKeyFailure(cause)) {
+            runCatching { androidKeyStore().deleteEntry(MasterKey.DEFAULT_MASTER_KEY_ALIAS) }
         }
     }
 
     private fun encryptedPreferencesFile(
         context: Context,
         filename: String
-    ) = File(context.filesDir.parent, "shared_prefs/$filename.xml")
+    ) = File(sharedPreferencesDirectory(context), "$filename.xml")
+
+    private fun sharedPreferencesDirectory(context: Context) = File(context.filesDir.parent, "shared_prefs")
 }
 
 private const val ANDROID_KEYSTORE = "AndroidKeyStore"
@@ -322,15 +354,15 @@ private fun androidKeyStore(): KeyStore =
  * True only for failures that are deterministic for the stored ciphertext or this device's
  * Keystore: an AEAD/padding authentication failure, a Tink keyset that no longer decodes
  * ([CharConversionException] is Tink's malformed-hex signature, InvalidProtocolBufferException its
- * malformed-proto one), Tink's Keystore self-test failure ([KeyStoreException] — in tink-android
- * 1.8.0, `AndroidKeystoreKmsClient` throws it from exactly one place, `validateAead()`, when a
- * post-key-creation AEAD encrypt/decrypt round-trip of a random message doesn't match; a
- * permanent condition on devices with a buggy hardware Keystore), or [InvalidKeyException], the
- * failure [createEncryptedSharedPreferences] actually throws for a genuinely
- * device-to-device-orphaned file when [isEncryptedFileOrphaned]'s Keystore query itself failed
- * twice (see [retryOnceOrDefault]) and so could not flag the orphan first — this is the second
- * line of defense for that case. Other Keystore and general IO failures are excluded because they
- * can be transient.
+ * malformed-proto one), Tink's Keystore self-test failure ([KeyStoreException] — as of tink-android
+ * 1.20.0, `AndroidKeystoreKmsClient` throws it from `validateAead()` when a post-key-creation AEAD
+ * encrypt/decrypt round-trip of a random message doesn't match; a permanent condition on devices
+ * with a buggy hardware Keystore), or [InvalidKeyException], the failure
+ * [createEncryptedSharedPreferences] actually throws for a genuinely device-to-device-orphaned
+ * file when [isEncryptedFileOrphaned]'s Keystore query itself failed twice (see
+ * [retryOnceOrDefault]) and so could not flag the orphan first — this is the second line of
+ * defense for that case. Other Keystore and general IO failures are excluded because they can be
+ * transient — [createEncryptedPreferencesWithRecovery] retries before this classification runs.
  */
 internal fun isUnrecoverableCorruption(exception: Exception): Boolean =
     generateSequence<Throwable>(exception) { it.cause }
@@ -344,6 +376,17 @@ internal fun isUnrecoverableCorruption(exception: Exception): Boolean =
         }
 
 /**
+ * True for failures that mean the Keystore key itself is unusable, as opposed to the stored
+ * ciphertext being unreadable. [MasterKey.Builder.build] reuses an existing alias, so these are
+ * the only failures for which [quarantineCorruptedEncryptedPreferences] must delete it and force a
+ * fresh key on the next attempt.
+ */
+internal fun isMasterKeyFailure(exception: Exception): Boolean =
+    generateSequence<Throwable>(exception) { it.cause }
+        .take(CAUSE_CHAIN_LIMIT)
+        .any { it is KeyStoreException || it is InvalidKeyException }
+
+/**
  * Runs [block], retrying once if it throws; returns [default] when both attempts throw.
  */
 internal fun <T> retryOnceOrDefault(
@@ -353,3 +396,58 @@ internal fun <T> retryOnceOrDefault(
     runCatching(block)
         .recoverCatching { block() }
         .getOrDefault(default)
+
+internal const val ENCRYPTED_PREFERENCES_OPEN_ATTEMPTS = 3
+
+internal fun encryptedPreferencesOpenBackoff(attempt: Int): Duration = 200.milliseconds * (1 shl (attempt - 1))
+
+/**
+ * Opens encrypted preferences with bounded retry before quarantine: the MOB-1452 Play trace showed
+ * an `AEADBadTagException` caused by a Keystore operation error, so a single failure is never
+ * enough to condemn the store. [create] is deliberately non-suspending — the only suspension point
+ * is [delay], kept outside the try/catch so a coroutine cancellation always propagates instead of
+ * being caught by the broad `Exception` handling here.
+ *
+ * After [maxAttempts] failures, [quarantine] runs only when [isRecreateAllowed] and either
+ * [isOrphaned] or the last failure is [isUnrecoverableCorruption]; otherwise the last failure is
+ * rethrown, keeping the stored data intact for a later retry.
+ */
+@Suppress("TooGenericExceptionCaught", "ReturnCount")
+internal suspend fun <T> createEncryptedPreferencesWithRecovery(
+    filename: String,
+    isOrphaned: Boolean,
+    isRecreateAllowed: Boolean = true,
+    maxAttempts: Int = ENCRYPTED_PREFERENCES_OPEN_ATTEMPTS,
+    backoff: (attempt: Int) -> Duration = ::encryptedPreferencesOpenBackoff,
+    create: () -> T,
+    quarantine: (cause: Exception) -> Unit,
+): T {
+    var lastFailure: Exception? = null
+
+    for (attempt in 1..maxAttempts) {
+        val failure =
+            try {
+                return create()
+            } catch (e: Exception) {
+                e
+            }
+
+        lastFailure = failure
+        Twig.warn(failure) { "Opening encrypted preferences $filename failed on attempt $attempt of $maxAttempts" }
+
+        if (attempt < maxAttempts) {
+            delay(backoff(attempt))
+        }
+    }
+
+    val cause = checkNotNull(lastFailure) { "maxAttempts must be at least 1" }
+
+    return if (isRecreateAllowed && (isOrphaned || isUnrecoverableCorruption(cause))) {
+        Twig.error(cause) { "Encrypted preferences $filename can never be decrypted again; quarantining them" }
+        quarantine(cause)
+        create()
+    } else {
+        Twig.error(cause) { "Opening encrypted preferences $filename failed; keeping data intact for a retry" }
+        throw cause
+    }
+}

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/AndroidPreferenceProvider.kt
@@ -320,7 +320,10 @@ private class AndroidPreferenceFactoryImpl : AndroidPreferenceFactory {
 
         runCatching {
             quarantineDir.mkdirs()
-            recreatedMarkerFile(quarantineDir, filename).createNewFile()
+            val markerCreated = recreatedMarkerFile(quarantineDir, filename).createNewFile()
+            if (!markerCreated) {
+                Twig.error { "Creating the recreated-marker for $filename returned false" }
+            }
         }
 
         runCatching {

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/EncryptedPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/EncryptedPreferenceProvider.kt
@@ -8,4 +8,6 @@ class EncryptedPreferenceProvider(
 ) : PreferenceHolder() {
     override suspend fun create(): PreferenceProvider =
         AndroidPreferenceProvider.newEncrypted(context, "co.electriccoin.zcash.encrypted")
+
+    suspend fun purgeQuarantine() = purgeEncryptedPreferencesQuarantine(context)
 }

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/EncryptedPreferenceProvider.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/EncryptedPreferenceProvider.kt
@@ -9,5 +9,5 @@ class EncryptedPreferenceProvider(
     override suspend fun create(): PreferenceProvider =
         AndroidPreferenceProvider.newEncrypted(context, "co.electriccoin.zcash.encrypted")
 
-    suspend fun purgeQuarantine() = purgeEncryptedPreferencesQuarantine(context)
+    suspend fun purgeQuarantine() = purgeEncryptedPreferencesQuarantine(quarantineDirectory(context))
 }

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantine.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantine.kt
@@ -133,10 +133,14 @@ private fun moveFile(
 }
 
 /**
- * Prunes this filename's `<filename>-*.xml` quarantine entries down to [keepNewest] of them: the
- * oldest entry unconditionally, plus the [keepNewest] - 1 latest ones. Everything between is
- * deleted, along with any `.bak` sibling. (The millisecond timestamps are fixed-width, so
- * lexicographic order matches chronological order.)
+ * Prunes this filename's quarantine entries down to [keepNewest] of them: the oldest entry
+ * unconditionally, plus the [keepNewest] - 1 latest ones. An entry is identified by its shared
+ * `<filename>-<millis>` base name rather than by its `.xml` file alone, so an entry that only has
+ * a `.xml.bak` — the `.xml` move having failed mid-commit — still counts and still gets pruned
+ * like any other, instead of sitting there forever because the `.xml`-only listing never saw it.
+ * Everything between the oldest and the kept newest is deleted, both the `.xml` and `.xml.bak` for
+ * that base name if present. (The millisecond timestamps are fixed-width, so lexicographic order
+ * matches chronological order.)
  *
  * Keeping the oldest is the whole point of the retention: only the first quarantine of a filename
  * can set aside a store that ever held a wallet, because the recovery that follows it recreates
@@ -145,7 +149,7 @@ private fun moveFile(
  * a handful of launches on flaky Keystore hardware, while keeping it costs a few KB of XML.
  *
  * Other filenames' entries, including this filename's [recreatedMarkerFile], are left untouched:
- * the marker is named `<filename>.recreated`, which never matches the `<filename>-*.xml` pattern.
+ * the marker is named `<filename>.recreated`, which never matches the `<filename>-*` pattern.
  */
 internal fun pruneQuarantine(
     quarantineDir: File,
@@ -153,19 +157,22 @@ internal fun pruneQuarantine(
     keepNewest: Int
 ) {
     val prefix = "$filename-"
-    val xmlFiles =
-        quarantineDir.listFiles { file -> file.name.startsWith(prefix) && file.name.endsWith(".xml") }
+    val entries =
+        quarantineDir
+            .listFiles { file ->
+                file.name.startsWith(prefix) && (file.name.endsWith(".xml") || file.name.endsWith(".xml.bak"))
+            }?.mapTo(mutableSetOf()) { it.name.removeSuffix(".bak").removeSuffix(".xml") }
             ?: return
 
-    val newestFirst = xmlFiles.sortedByDescending { it.name }
+    val newestFirst = entries.sortedByDescending { it }
     val oldest = newestFirst.lastOrNull()
 
     newestFirst
         .drop((keepNewest - 1).coerceAtLeast(0))
         .filterNot { it == oldest }
-        .forEach { xmlFile ->
-            xmlFile.delete()
-            File(quarantineDir, "${xmlFile.name}.bak").delete()
+        .forEach { baseName ->
+            File(quarantineDir, "$baseName.xml").delete()
+            File(quarantineDir, "$baseName.xml.bak").delete()
         }
 }
 

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantine.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantine.kt
@@ -1,6 +1,7 @@
 package co.electriccoin.zcash.preference
 
 import android.content.Context
+import co.electriccoin.zcash.spackle.Twig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -86,7 +87,9 @@ private fun moveFile(
 ) {
     if (!source.renameTo(destination)) {
         source.copyTo(destination, overwrite = true)
-        source.delete()
+        if (!source.delete()) {
+            Twig.error { "Failed to delete source file after copy: $source" }
+        }
     }
 }
 

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantine.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantine.kt
@@ -23,6 +23,19 @@ internal fun encryptedPreferencesBackupFile(
 ): File = File(sharedPrefsDir, "$filename.xml.bak")
 
 /**
+ * Removes `<filename>.xml` and its `.xml.bak` sibling from [sharedPrefsDir]: the fallback when
+ * quarantining them fails, and the cleanup for the empty file that clearing Android's in-memory
+ * `SharedPreferences` cache commits back to the vacated path. A missing file is a no-op.
+ */
+internal fun deleteEncryptedPreferencesFiles(
+    sharedPrefsDir: File,
+    filename: String
+) {
+    encryptedPreferencesFile(sharedPrefsDir, filename).delete()
+    encryptedPreferencesBackupFile(sharedPrefsDir, filename).delete()
+}
+
+/**
  * The persisted "already recreated once" guard for [filename]: its presence means a quarantine
  * already ran for this store and the recreated store has not yet opened successfully, so a later
  * launch must rethrow instead of quarantining again. See `AndroidPreferenceProvider.openEncrypted`.
@@ -104,11 +117,12 @@ internal fun pruneQuarantine(
 }
 
 /**
- * Deletes every quarantined encrypted preferences file. Used by "Reset Zodl" so wiping the wallet
- * also removes any set-aside ciphertext left behind by an earlier recovery.
+ * Empties [quarantineDir] wholesale — every filename's set-aside copies and every
+ * [recreatedMarkerFile] guard, not just the entries [pruneQuarantine] would age out. Used by
+ * "Reset Zodl" so wiping the wallet also removes any ciphertext left behind by an earlier recovery.
  */
-internal suspend fun purgeEncryptedPreferencesQuarantine(context: Context) {
+internal suspend fun purgeEncryptedPreferencesQuarantine(quarantineDir: File) {
     withContext(Dispatchers.IO) {
-        quarantineDirectory(context).deleteRecursively()
+        quarantineDir.deleteRecursively()
     }
 }

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantine.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantine.kt
@@ -1,0 +1,90 @@
+package co.electriccoin.zcash.preference
+
+import android.content.Context
+import java.io.File
+
+internal const val QUARANTINE_DIRECTORY = "encrypted_prefs_quarantine"
+internal const val QUARANTINE_KEEP_NEWEST = 3
+
+/**
+ * Moves `<filename>.xml` and its `<filename>.xml.bak` sibling (if present) out of
+ * [sharedPrefsDir] into [quarantineDir], timestamped as `<filename>-<nowMillis>.xml[.bak]`, then
+ * prunes older quarantined copies of this filename down to [keepNewest]. Returns the quarantined
+ * `.xml` destination, or the `.bak` destination when only the backup existed, or null when
+ * neither file was present.
+ */
+internal fun quarantineEncryptedPreferencesFiles(
+    sharedPrefsDir: File,
+    quarantineDir: File,
+    filename: String,
+    nowMillis: Long = System.currentTimeMillis(),
+    keepNewest: Int = QUARANTINE_KEEP_NEWEST,
+): File? {
+    val xmlFile = File(sharedPrefsDir, "$filename.xml")
+    val bakFile = File(sharedPrefsDir, "$filename.xml.bak")
+
+    if (!xmlFile.exists() && !bakFile.exists()) {
+        return null
+    }
+
+    quarantineDir.mkdirs()
+
+    val quarantinedXml = File(quarantineDir, "$filename-$nowMillis.xml")
+    val quarantinedBak = File(quarantineDir, "$filename-$nowMillis.xml.bak")
+
+    var result: File? = null
+    if (xmlFile.exists()) {
+        moveFile(xmlFile, quarantinedXml)
+        result = quarantinedXml
+    }
+    if (bakFile.exists()) {
+        moveFile(bakFile, quarantinedBak)
+        result = result ?: quarantinedBak
+    }
+
+    pruneQuarantine(quarantineDir, filename, keepNewest)
+
+    return result
+}
+
+private fun moveFile(
+    source: File,
+    destination: File
+) {
+    if (!source.renameTo(destination)) {
+        source.copyTo(destination, overwrite = true)
+        source.delete()
+    }
+}
+
+/**
+ * Keeps the [keepNewest] lexicographically-latest `<filename>-*.xml` quarantine entries (their
+ * millisecond timestamps are fixed-width, so lexicographic order matches chronological order) and
+ * deletes the rest, along with any `.bak` sibling. Other filenames' entries are left untouched.
+ */
+internal fun pruneQuarantine(
+    quarantineDir: File,
+    filename: String,
+    keepNewest: Int
+) {
+    val prefix = "$filename-"
+    val xmlFiles =
+        quarantineDir.listFiles { file -> file.name.startsWith(prefix) && file.name.endsWith(".xml") }
+            ?: return
+
+    xmlFiles
+        .sortedByDescending { it.name }
+        .drop(keepNewest)
+        .forEach { xmlFile ->
+            xmlFile.delete()
+            File(quarantineDir, "${xmlFile.name}.bak").delete()
+        }
+}
+
+/**
+ * Deletes every quarantined encrypted preferences file. Used by "Reset Zodl" so wiping the wallet
+ * also removes any set-aside ciphertext left behind by an earlier recovery.
+ */
+fun purgeEncryptedPreferencesQuarantine(context: Context) {
+    File(context.noBackupFilesDir, QUARANTINE_DIRECTORY).deleteRecursively()
+}

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantine.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantine.kt
@@ -1,3 +1,5 @@
+@file:Suppress("TooManyFunctions")
+
 package co.electriccoin.zcash.preference
 
 import android.content.Context
@@ -24,9 +26,9 @@ internal fun encryptedPreferencesBackupFile(
 ): File = File(sharedPrefsDir, "$filename.xml.bak")
 
 /**
- * Removes `<filename>.xml` and its `.xml.bak` sibling from [sharedPrefsDir]: the fallback when
- * quarantining them fails, and the cleanup for the empty file that clearing Android's in-memory
- * `SharedPreferences` cache commits back to the vacated path. A missing file is a no-op.
+ * Removes `<filename>.xml` and its `.xml.bak` sibling from [sharedPrefsDir]: the cleanup for the
+ * empty file that clearing Android's in-memory `SharedPreferences` cache commits back to the
+ * vacated path, once the real content is safely quarantined. A missing file is a no-op.
  */
 internal fun deleteEncryptedPreferencesFiles(
     sharedPrefsDir: File,
@@ -81,6 +83,43 @@ internal fun quarantineEncryptedPreferencesFiles(
     pruneQuarantine(quarantineDir, filename, keepNewest)
 }
 
+/**
+ * Runs [quarantineEncryptedPreferencesFiles] and writes the [recreatedMarkerFile] guard only once
+ * it has succeeded, so a store that was never set aside is still allowed to recover on the next
+ * launch.
+ *
+ * A failing quarantine is rethrown rather than falling back to deleting the original files.
+ * [moveFile] degrades to copy-then-delete when `renameTo` fails, and a copy that throws mid-write —
+ * low disk being the obvious trigger, and also a plausible reason `renameTo` failed — would leave a
+ * truncated copy in quarantine; deleting the original on top of that turns a recoverable failure
+ * into unrecoverable loss of the only ciphertext holding the seed. Rethrowing propagates out of
+ * `AndroidPreferenceProvider.createEncryptedPreferencesWithRecovery` instead, leaving the store
+ * exactly where it is for a later attempt.
+ */
+internal fun quarantineEncryptedPreferencesFilesAndMarkRecreated(
+    sharedPrefsDir: File,
+    quarantineDir: File,
+    filename: String,
+    nowMillis: Long = System.currentTimeMillis(),
+    keepNewest: Int = QUARANTINE_KEEP_NEWEST,
+) {
+    quarantineEncryptedPreferencesFiles(
+        sharedPrefsDir = sharedPrefsDir,
+        quarantineDir = quarantineDir,
+        filename = filename,
+        nowMillis = nowMillis,
+        keepNewest = keepNewest,
+    )
+
+    runCatching {
+        quarantineDir.mkdirs()
+        val markerCreated = recreatedMarkerFile(quarantineDir, filename).createNewFile()
+        if (!markerCreated) {
+            Twig.error { "Creating the recreated-marker for $filename returned false" }
+        }
+    }
+}
+
 private fun moveFile(
     source: File,
     destination: File
@@ -94,11 +133,19 @@ private fun moveFile(
 }
 
 /**
- * Keeps the [keepNewest] lexicographically-latest `<filename>-*.xml` quarantine entries (their
- * millisecond timestamps are fixed-width, so lexicographic order matches chronological order) and
- * deletes the rest, along with any `.bak` sibling. Other filenames' entries, including this
- * filename's [recreatedMarkerFile], are left untouched: the marker is named `<filename>.recreated`,
- * which never matches the `<filename>-*.xml` pattern.
+ * Prunes this filename's `<filename>-*.xml` quarantine entries down to [keepNewest] of them: the
+ * oldest entry unconditionally, plus the [keepNewest] - 1 latest ones. Everything between is
+ * deleted, along with any `.bak` sibling. (The millisecond timestamps are fixed-width, so
+ * lexicographic order matches chronological order.)
+ *
+ * Keeping the oldest is the whole point of the retention: only the first quarantine of a filename
+ * can set aside a store that ever held a wallet, because the recovery that follows it recreates
+ * that store empty, so every later quarantine of the same filename sets aside an empty or
+ * near-empty file. Deleting oldest-first would therefore drop the only copy holding the seed after
+ * a handful of launches on flaky Keystore hardware, while keeping it costs a few KB of XML.
+ *
+ * Other filenames' entries, including this filename's [recreatedMarkerFile], are left untouched:
+ * the marker is named `<filename>.recreated`, which never matches the `<filename>-*.xml` pattern.
  */
 internal fun pruneQuarantine(
     quarantineDir: File,
@@ -110,9 +157,12 @@ internal fun pruneQuarantine(
         quarantineDir.listFiles { file -> file.name.startsWith(prefix) && file.name.endsWith(".xml") }
             ?: return
 
-    xmlFiles
-        .sortedByDescending { it.name }
-        .drop(keepNewest)
+    val newestFirst = xmlFiles.sortedByDescending { it.name }
+    val oldest = newestFirst.lastOrNull()
+
+    newestFirst
+        .drop((keepNewest - 1).coerceAtLeast(0))
+        .filterNot { it == oldest }
         .forEach { xmlFile ->
             xmlFile.delete()
             File(quarantineDir, "${xmlFile.name}.bak").delete()

--- a/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantine.kt
+++ b/preference-impl-android-lib/src/main/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantine.kt
@@ -1,17 +1,42 @@
 package co.electriccoin.zcash.preference
 
 import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.io.File
 
 internal const val QUARANTINE_DIRECTORY = "encrypted_prefs_quarantine"
 internal const val QUARANTINE_KEEP_NEWEST = 3
 
+internal fun quarantineDirectory(context: Context): File = File(context.noBackupFilesDir, QUARANTINE_DIRECTORY)
+
+internal fun sharedPreferencesDirectory(context: Context): File = File(context.filesDir.parent, "shared_prefs")
+
+internal fun encryptedPreferencesFile(
+    sharedPrefsDir: File,
+    filename: String
+): File = File(sharedPrefsDir, "$filename.xml")
+
+internal fun encryptedPreferencesBackupFile(
+    sharedPrefsDir: File,
+    filename: String
+): File = File(sharedPrefsDir, "$filename.xml.bak")
+
+/**
+ * The persisted "already recreated once" guard for [filename]: its presence means a quarantine
+ * already ran for this store and the recreated store has not yet opened successfully, so a later
+ * launch must rethrow instead of quarantining again. See `AndroidPreferenceProvider.openEncrypted`.
+ */
+internal fun recreatedMarkerFile(
+    quarantineDir: File,
+    filename: String
+): File = File(quarantineDir, "$filename.recreated")
+
 /**
  * Moves `<filename>.xml` and its `<filename>.xml.bak` sibling (if present) out of
  * [sharedPrefsDir] into [quarantineDir], timestamped as `<filename>-<nowMillis>.xml[.bak]`, then
- * prunes older quarantined copies of this filename down to [keepNewest]. Returns the quarantined
- * `.xml` destination, or the `.bak` destination when only the backup existed, or null when
- * neither file was present.
+ * prunes older quarantined copies of this filename down to [keepNewest]. A no-op when neither
+ * file is present.
  */
 internal fun quarantineEncryptedPreferencesFiles(
     sharedPrefsDir: File,
@@ -19,12 +44,12 @@ internal fun quarantineEncryptedPreferencesFiles(
     filename: String,
     nowMillis: Long = System.currentTimeMillis(),
     keepNewest: Int = QUARANTINE_KEEP_NEWEST,
-): File? {
-    val xmlFile = File(sharedPrefsDir, "$filename.xml")
-    val bakFile = File(sharedPrefsDir, "$filename.xml.bak")
+) {
+    val xmlFile = encryptedPreferencesFile(sharedPrefsDir, filename)
+    val bakFile = encryptedPreferencesBackupFile(sharedPrefsDir, filename)
 
     if (!xmlFile.exists() && !bakFile.exists()) {
-        return null
+        return
     }
 
     quarantineDir.mkdirs()
@@ -32,19 +57,14 @@ internal fun quarantineEncryptedPreferencesFiles(
     val quarantinedXml = File(quarantineDir, "$filename-$nowMillis.xml")
     val quarantinedBak = File(quarantineDir, "$filename-$nowMillis.xml.bak")
 
-    var result: File? = null
     if (xmlFile.exists()) {
         moveFile(xmlFile, quarantinedXml)
-        result = quarantinedXml
     }
     if (bakFile.exists()) {
         moveFile(bakFile, quarantinedBak)
-        result = result ?: quarantinedBak
     }
 
     pruneQuarantine(quarantineDir, filename, keepNewest)
-
-    return result
 }
 
 private fun moveFile(
@@ -60,7 +80,9 @@ private fun moveFile(
 /**
  * Keeps the [keepNewest] lexicographically-latest `<filename>-*.xml` quarantine entries (their
  * millisecond timestamps are fixed-width, so lexicographic order matches chronological order) and
- * deletes the rest, along with any `.bak` sibling. Other filenames' entries are left untouched.
+ * deletes the rest, along with any `.bak` sibling. Other filenames' entries, including this
+ * filename's [recreatedMarkerFile], are left untouched: the marker is named `<filename>.recreated`,
+ * which never matches the `<filename>-*.xml` pattern.
  */
 internal fun pruneQuarantine(
     quarantineDir: File,
@@ -85,6 +107,8 @@ internal fun pruneQuarantine(
  * Deletes every quarantined encrypted preferences file. Used by "Reset Zodl" so wiping the wallet
  * also removes any set-aside ciphertext left behind by an earlier recovery.
  */
-fun purgeEncryptedPreferencesQuarantine(context: Context) {
-    File(context.noBackupFilesDir, QUARANTINE_DIRECTORY).deleteRecursively()
+internal suspend fun purgeEncryptedPreferencesQuarantine(context: Context) {
+    withContext(Dispatchers.IO) {
+        quarantineDirectory(context).deleteRecursively()
+    }
 }

--- a/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantineTest.kt
+++ b/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantineTest.kt
@@ -1,0 +1,97 @@
+package co.electriccoin.zcash.preference
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class EncryptedPreferenceQuarantineTest {
+    private lateinit var root: File
+    private lateinit var sharedPrefsDir: File
+    private lateinit var quarantineDir: File
+
+    @BeforeTest
+    fun setUp() {
+        root = Files.createTempDirectory("encrypted_prefs_quarantine_test").toFile()
+        sharedPrefsDir = File(root, "shared_prefs").apply { mkdirs() }
+        quarantineDir = File(root, QUARANTINE_DIRECTORY)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        root.deleteRecursively()
+    }
+
+    @Test
+    fun `moves the xml and bak files with timestamped names and preserved content`() {
+        File(sharedPrefsDir, "co.electriccoin.zcash.encrypted.xml").writeText("xml content")
+        File(sharedPrefsDir, "co.electriccoin.zcash.encrypted.xml.bak").writeText("bak content")
+
+        val result =
+            quarantineEncryptedPreferencesFiles(
+                sharedPrefsDir = sharedPrefsDir,
+                quarantineDir = quarantineDir,
+                filename = "co.electriccoin.zcash.encrypted",
+                nowMillis = 1_700_000_000_000L,
+            )
+
+        val quarantinedXml = File(quarantineDir, "co.electriccoin.zcash.encrypted-1700000000000.xml")
+        val quarantinedBak = File(quarantineDir, "co.electriccoin.zcash.encrypted-1700000000000.xml.bak")
+
+        assertEquals(quarantinedXml, result)
+        assertEquals("xml content", quarantinedXml.readText())
+        assertEquals("bak content", quarantinedBak.readText())
+        assertFalse(File(sharedPrefsDir, "co.electriccoin.zcash.encrypted.xml").exists())
+        assertFalse(File(sharedPrefsDir, "co.electriccoin.zcash.encrypted.xml.bak").exists())
+    }
+
+    @Test
+    fun `returns null when neither file exists`() {
+        val result =
+            quarantineEncryptedPreferencesFiles(
+                sharedPrefsDir = sharedPrefsDir,
+                quarantineDir = quarantineDir,
+                filename = "missing",
+                nowMillis = 1_700_000_000_000L,
+            )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `prune keeps only the newest entries for the filename and leaves others alone`() {
+        quarantineDir.mkdirs()
+        (1L..5L).forEach { millis ->
+            File(quarantineDir, "target-$millis.xml").writeText("v$millis")
+            File(quarantineDir, "target-$millis.xml.bak").writeText("v$millis-bak")
+        }
+        File(quarantineDir, "other-9.xml").writeText("other")
+
+        pruneQuarantine(quarantineDir, "target", keepNewest = 3)
+
+        val remaining =
+            quarantineDir
+                .listFiles()
+                ?.map { it.name }
+                ?.toSet()
+                .orEmpty()
+
+        assertEquals(
+            setOf(
+                "target-3.xml",
+                "target-3.xml.bak",
+                "target-4.xml",
+                "target-4.xml.bak",
+                "target-5.xml",
+                "target-5.xml.bak",
+                "other-9.xml"
+            ),
+            remaining
+        )
+    }
+}

--- a/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantineTest.kt
+++ b/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantineTest.kt
@@ -7,7 +7,6 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class EncryptedPreferenceQuarantineTest {
@@ -29,38 +28,35 @@ class EncryptedPreferenceQuarantineTest {
 
     @Test
     fun `moves the xml and bak files with timestamped names and preserved content`() {
-        File(sharedPrefsDir, "co.electriccoin.zcash.encrypted.xml").writeText("xml content")
-        File(sharedPrefsDir, "co.electriccoin.zcash.encrypted.xml.bak").writeText("bak content")
+        encryptedPreferencesFile(sharedPrefsDir, "co.electriccoin.zcash.encrypted").writeText("xml content")
+        encryptedPreferencesBackupFile(sharedPrefsDir, "co.electriccoin.zcash.encrypted").writeText("bak content")
 
-        val result =
-            quarantineEncryptedPreferencesFiles(
-                sharedPrefsDir = sharedPrefsDir,
-                quarantineDir = quarantineDir,
-                filename = "co.electriccoin.zcash.encrypted",
-                nowMillis = 1_700_000_000_000L,
-            )
+        quarantineEncryptedPreferencesFiles(
+            sharedPrefsDir = sharedPrefsDir,
+            quarantineDir = quarantineDir,
+            filename = "co.electriccoin.zcash.encrypted",
+            nowMillis = 1_700_000_000_000L,
+        )
 
         val quarantinedXml = File(quarantineDir, "co.electriccoin.zcash.encrypted-1700000000000.xml")
         val quarantinedBak = File(quarantineDir, "co.electriccoin.zcash.encrypted-1700000000000.xml.bak")
 
-        assertEquals(quarantinedXml, result)
         assertEquals("xml content", quarantinedXml.readText())
         assertEquals("bak content", quarantinedBak.readText())
-        assertFalse(File(sharedPrefsDir, "co.electriccoin.zcash.encrypted.xml").exists())
-        assertFalse(File(sharedPrefsDir, "co.electriccoin.zcash.encrypted.xml.bak").exists())
+        assertFalse(encryptedPreferencesFile(sharedPrefsDir, "co.electriccoin.zcash.encrypted").exists())
+        assertFalse(encryptedPreferencesBackupFile(sharedPrefsDir, "co.electriccoin.zcash.encrypted").exists())
     }
 
     @Test
-    fun `returns null when neither file exists`() {
-        val result =
-            quarantineEncryptedPreferencesFiles(
-                sharedPrefsDir = sharedPrefsDir,
-                quarantineDir = quarantineDir,
-                filename = "missing",
-                nowMillis = 1_700_000_000_000L,
-            )
+    fun `does nothing when neither file exists`() {
+        quarantineEncryptedPreferencesFiles(
+            sharedPrefsDir = sharedPrefsDir,
+            quarantineDir = quarantineDir,
+            filename = "missing",
+            nowMillis = 1_700_000_000_000L,
+        )
 
-        assertNull(result)
+        assertFalse(quarantineDir.exists())
     }
 
     @Test
@@ -93,5 +89,18 @@ class EncryptedPreferenceQuarantineTest {
             ),
             remaining
         )
+    }
+
+    @Test
+    fun `prune leaves the recreated marker for the filename untouched`() {
+        quarantineDir.mkdirs()
+        val marker = recreatedMarkerFile(quarantineDir, "target").apply { writeText("marker") }
+        (1L..5L).forEach { millis ->
+            File(quarantineDir, "target-$millis.xml").writeText("v$millis")
+        }
+
+        pruneQuarantine(quarantineDir, "target", keepNewest = 3)
+
+        assertTrue(marker.exists())
     }
 }

--- a/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantineTest.kt
+++ b/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantineTest.kt
@@ -1,5 +1,6 @@
 package co.electriccoin.zcash.preference
 
+import kotlinx.coroutines.test.runTest
 import java.io.File
 import java.nio.file.Files
 import kotlin.test.AfterTest
@@ -103,4 +104,61 @@ class EncryptedPreferenceQuarantineTest {
 
         assertTrue(marker.exists())
     }
+
+    /**
+     * The recovery sequence clears Android's in-memory `SharedPreferences` cache after the move,
+     * which commits an empty file back to the vacated path. When the recreate that follows fails,
+     * that file must already be gone, or the next launch would quarantine an empty file instead of
+     * letting the marker guard rethrow.
+     */
+    @Test
+    fun `the empty file left by clearing the cache is not quarantined on the next launch`() {
+        encryptedPreferencesFile(sharedPrefsDir, "target").writeText("corrupted")
+        encryptedPreferencesBackupFile(sharedPrefsDir, "target").writeText("corrupted bak")
+
+        quarantineEncryptedPreferencesFiles(
+            sharedPrefsDir = sharedPrefsDir,
+            quarantineDir = quarantineDir,
+            filename = "target",
+            nowMillis = 1_700_000_000_000L,
+        )
+        recreatedMarkerFile(quarantineDir, "target").createNewFile()
+        encryptedPreferencesFile(sharedPrefsDir, "target").writeText("<map />")
+
+        deleteEncryptedPreferencesFiles(sharedPrefsDir, "target")
+
+        quarantineEncryptedPreferencesFiles(
+            sharedPrefsDir = sharedPrefsDir,
+            quarantineDir = quarantineDir,
+            filename = "target",
+            nowMillis = 1_700_000_001_000L,
+        )
+
+        assertEquals(
+            setOf(
+                "target-1700000000000.xml",
+                "target-1700000000000.xml.bak",
+                "target.recreated"
+            ),
+            quarantineDir
+                .listFiles()
+                ?.map { it.name }
+                ?.toSet()
+                .orEmpty()
+        )
+    }
+
+    @Test
+    fun `purging removes every quarantined copy and every marker`() =
+        runTest {
+            quarantineDir.mkdirs()
+            File(quarantineDir, "target-1.xml").writeText("v1")
+            File(quarantineDir, "target-1.xml.bak").writeText("v1-bak")
+            File(quarantineDir, "other-9.xml").writeText("other")
+            recreatedMarkerFile(quarantineDir, "target").createNewFile()
+
+            purgeEncryptedPreferencesQuarantine(quarantineDir)
+
+            assertFalse(quarantineDir.exists())
+        }
 }

--- a/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantineTest.kt
+++ b/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantineTest.kt
@@ -132,6 +132,41 @@ class EncryptedPreferenceQuarantineTest {
         )
     }
 
+    /**
+     * A `.xml`-only entry listing would never see an entry whose `.xml` move failed mid-commit,
+     * leaving only its `.xml.bak` sibling — so it would never age out, growing the quarantine
+     * directory without bound. Identifying entries by base name closes that gap.
+     */
+    @Test
+    fun `prune counts and prunes an entry that has only a bak file`() {
+        quarantineDir.mkdirs()
+        (1L..5L).forEach { millis ->
+            File(quarantineDir, "target-$millis.xml").writeText("v$millis")
+            File(quarantineDir, "target-$millis.xml.bak").writeText("v$millis-bak")
+        }
+        File(quarantineDir, "target-6.xml.bak").writeText("bak only")
+
+        pruneQuarantine(quarantineDir, "target", keepNewest = 3)
+
+        val remaining =
+            quarantineDir
+                .listFiles()
+                ?.map { it.name }
+                ?.toSet()
+                .orEmpty()
+
+        assertEquals(
+            setOf(
+                "target-1.xml",
+                "target-1.xml.bak",
+                "target-5.xml",
+                "target-5.xml.bak",
+                "target-6.xml.bak"
+            ),
+            remaining
+        )
+    }
+
     @Test
     fun `prune leaves the recreated marker for the filename untouched`() {
         quarantineDir.mkdirs()

--- a/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantineTest.kt
+++ b/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceQuarantineTest.kt
@@ -2,11 +2,13 @@ package co.electriccoin.zcash.preference
 
 import kotlinx.coroutines.test.runTest
 import java.io.File
+import java.io.IOException
 import java.nio.file.Files
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -61,7 +63,7 @@ class EncryptedPreferenceQuarantineTest {
     }
 
     @Test
-    fun `prune keeps only the newest entries for the filename and leaves others alone`() {
+    fun `prune keeps the oldest and the newest entries for the filename and leaves others alone`() {
         quarantineDir.mkdirs()
         (1L..5L).forEach { millis ->
             File(quarantineDir, "target-$millis.xml").writeText("v$millis")
@@ -80,8 +82,8 @@ class EncryptedPreferenceQuarantineTest {
 
         assertEquals(
             setOf(
-                "target-3.xml",
-                "target-3.xml.bak",
+                "target-1.xml",
+                "target-1.xml.bak",
                 "target-4.xml",
                 "target-4.xml.bak",
                 "target-5.xml",
@@ -89,6 +91,44 @@ class EncryptedPreferenceQuarantineTest {
                 "other-9.xml"
             ),
             remaining
+        )
+    }
+
+    /**
+     * Only the first quarantine of a filename can set aside a store that ever held a wallet: the
+     * recovery that follows recreates it empty, so every later quarantine sets aside an empty file.
+     * Retention must therefore never age out the first entry, however many times the store is
+     * quarantined afterwards.
+     */
+    @Test
+    fun `repeated quarantines keep the first copy, the only one holding a wallet`() {
+        encryptedPreferencesFile(sharedPrefsDir, "target").writeText("seed ciphertext")
+
+        (1L..5L).forEach { launch ->
+            quarantineEncryptedPreferencesFiles(
+                sharedPrefsDir = sharedPrefsDir,
+                quarantineDir = quarantineDir,
+                filename = "target",
+                nowMillis = 1_700_000_000_000L + launch,
+            )
+            encryptedPreferencesFile(sharedPrefsDir, "target").writeText("<map />")
+        }
+
+        assertEquals(
+            "seed ciphertext",
+            File(quarantineDir, "target-1700000000001.xml").readText()
+        )
+        assertEquals(
+            setOf(
+                "target-1700000000001.xml",
+                "target-1700000000004.xml",
+                "target-1700000000005.xml"
+            ),
+            quarantineDir
+                .listFiles()
+                ?.map { it.name }
+                ?.toSet()
+                .orEmpty()
         )
     }
 
@@ -146,6 +186,56 @@ class EncryptedPreferenceQuarantineTest {
                 ?.toSet()
                 .orEmpty()
         )
+    }
+
+    /**
+     * A quarantine that throws mid-move must leave the original ciphertext where it is instead of
+     * deleting it, and must write no [recreatedMarkerFile] — the marker is what would stop the next
+     * launch from recovering, and there is nothing set aside yet to justify that.
+     */
+    @Test
+    fun `a failed quarantine keeps the original files and writes no marker`() {
+        encryptedPreferencesFile(sharedPrefsDir, "target").writeText("seed ciphertext")
+        encryptedPreferencesBackupFile(sharedPrefsDir, "target").writeText("seed ciphertext bak")
+        quarantineDir.writeText("a regular file where the quarantine directory should be")
+
+        assertFailsWith<IOException> {
+            quarantineEncryptedPreferencesFilesAndMarkRecreated(
+                sharedPrefsDir = sharedPrefsDir,
+                quarantineDir = quarantineDir,
+                filename = "target",
+                nowMillis = 1_700_000_000_000L,
+            )
+        }
+
+        assertEquals(
+            "seed ciphertext",
+            encryptedPreferencesFile(sharedPrefsDir, "target").readText()
+        )
+        assertEquals(
+            "seed ciphertext bak",
+            encryptedPreferencesBackupFile(sharedPrefsDir, "target").readText()
+        )
+        assertFalse(recreatedMarkerFile(quarantineDir, "target").exists())
+    }
+
+    @Test
+    fun `a successful quarantine writes the marker`() {
+        encryptedPreferencesFile(sharedPrefsDir, "target").writeText("seed ciphertext")
+
+        quarantineEncryptedPreferencesFilesAndMarkRecreated(
+            sharedPrefsDir = sharedPrefsDir,
+            quarantineDir = quarantineDir,
+            filename = "target",
+            nowMillis = 1_700_000_000_000L,
+        )
+
+        assertTrue(recreatedMarkerFile(quarantineDir, "target").exists())
+        assertEquals(
+            "seed ciphertext",
+            File(quarantineDir, "target-1700000000000.xml").readText()
+        )
+        assertFalse(encryptedPreferencesFile(sharedPrefsDir, "target").exists())
     }
 
     @Test

--- a/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceRecoveryTest.kt
+++ b/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceRecoveryTest.kt
@@ -16,12 +16,13 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
+import co.electriccoin.zcash.preference.androidsecurity.KeyStoreException as AndroidKeyStoreException
 
 /**
  * Pins the recovery heuristics of `AndroidPreferenceProvider.newEncrypted`: which failures are
- * allowed to trigger wipe-and-recreate of the encrypted preferences, and how the orphaned-file
- * Keystore query degrades when the Keystore itself misbehaves. Widening or narrowing either
- * behavior must be a deliberate change that shows up here.
+ * allowed to trigger wipe-and-recreate of the encrypted preferences, and which failures are
+ * allowed to delete the shared Keystore master key. Widening or narrowing either behavior must be
+ * a deliberate change that shows up here.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class EncryptedPreferenceRecoveryTest {
@@ -74,40 +75,29 @@ class EncryptedPreferenceRecoveryTest {
     }
 
     @Test
-    fun `retry recovers from a single transient failure`() {
-        var attempts = 0
-
-        val result =
-            retryOnceOrDefault(false) {
-                attempts++
-                if (attempts == 1) {
-                    error("transient Keystore failure")
-                }
-                true
-            }
-
-        assertTrue(result)
-        assertEquals(2, attempts)
+    fun `InvalidKeyException without an android Keystore cause is a master key failure`() {
+        assertTrue(isMasterKeyFailure(InvalidKeyException("Failed to unwrap key")))
+        assertTrue(isMasterKeyFailure(GeneralSecurityException(InvalidKeyException())))
     }
 
     @Test
-    fun `retry yields the default when the failure persists`() {
-        var attempts = 0
-
-        val result =
-            retryOnceOrDefault(false) {
-                attempts++
-                error("persistent Keystore failure")
-            }
-
-        assertFalse(result)
-        assertEquals(2, attempts)
+    fun `InvalidKeyException wrapping an android Keystore failure is not a master key failure`() {
+        assertFalse(
+            isMasterKeyFailure(
+                InvalidKeyException("Keystore operation failed", AndroidKeyStoreException())
+            )
+        )
     }
 
     @Test
-    fun `Keystore key failures are master key failures`() {
+    fun `java security KeyStoreException anywhere in the chain is a master key failure`() {
+        assertTrue(isMasterKeyFailure(KeyStoreException()))
         assertTrue(isMasterKeyFailure(GeneralSecurityException(KeyStoreException())))
-        assertTrue(isMasterKeyFailure(InvalidKeyException()))
+        assertTrue(
+            isMasterKeyFailure(
+                InvalidKeyException("Keystore operation failed", KeyStoreException())
+            )
+        )
     }
 
     @Test
@@ -133,7 +123,6 @@ class EncryptedPreferenceRecoveryTest {
             val result =
                 createEncryptedPreferencesWithRecovery(
                     filename = "test",
-                    isOrphaned = false,
                     create = {
                         attempts++
                         if (attempts == 1) error("transient Keystore failure")
@@ -158,7 +147,6 @@ class EncryptedPreferenceRecoveryTest {
                 assertFailsWith<IllegalStateException> {
                     createEncryptedPreferencesWithRecovery<String>(
                         filename = "test",
-                        isOrphaned = false,
                         create = {
                             attempts++
                             error("persistent Keystore failure")
@@ -182,7 +170,6 @@ class EncryptedPreferenceRecoveryTest {
             val result =
                 createEncryptedPreferencesWithRecovery(
                     filename = "test",
-                    isOrphaned = false,
                     create = {
                         attempts++
                         if (attempts <= ENCRYPTED_PREFERENCES_OPEN_ATTEMPTS) {
@@ -207,7 +194,6 @@ class EncryptedPreferenceRecoveryTest {
             val result =
                 createEncryptedPreferencesWithRecovery(
                     filename = "test",
-                    isOrphaned = false,
                     create = {
                         attempts++
                         if (attempts == 1) throw AEADBadTagException("decryption failed")
@@ -222,30 +208,6 @@ class EncryptedPreferenceRecoveryTest {
         }
 
     @Test
-    fun `an orphaned file with an unclassified failure is quarantined once then recreated`() =
-        runTest {
-            var attempts = 0
-            var quarantined = false
-
-            val result =
-                createEncryptedPreferencesWithRecovery(
-                    filename = "test",
-                    isOrphaned = true,
-                    create = {
-                        attempts++
-                        if (attempts <= ENCRYPTED_PREFERENCES_OPEN_ATTEMPTS) {
-                            throw IOException("disk error")
-                        }
-                        "fresh store"
-                    },
-                    quarantine = { quarantined = true },
-                )
-
-            assertEquals("fresh store", result)
-            assertTrue(quarantined)
-        }
-
-    @Test
     fun `recreate not allowed rethrows without quarantining`() =
         runTest {
             var quarantined = false
@@ -253,7 +215,6 @@ class EncryptedPreferenceRecoveryTest {
             assertFailsWith<AEADBadTagException> {
                 createEncryptedPreferencesWithRecovery<String>(
                     filename = "test",
-                    isOrphaned = false,
                     isRecreateAllowed = false,
                     create = { throw AEADBadTagException("decryption failed") },
                     quarantine = { quarantined = true },
@@ -271,7 +232,6 @@ class EncryptedPreferenceRecoveryTest {
             assertFailsWith<AEADBadTagException> {
                 createEncryptedPreferencesWithRecovery<String>(
                     filename = "test",
-                    isOrphaned = false,
                     create = { throw AEADBadTagException("decryption failed") },
                     quarantine = { quarantined = true },
                 )

--- a/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceRecoveryTest.kt
+++ b/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceRecoveryTest.kt
@@ -60,6 +60,31 @@ class EncryptedPreferenceRecoveryTest {
         assertTrue(isUnrecoverableCorruption(GeneralSecurityException(InvalidKeyException())))
     }
 
+    /**
+     * The AOSP-wrapped transient shape a wedged Keystore daemon throws. Classifying it as
+     * corruption would move the seed into quarantine, where no screen can reach it, over a failure
+     * that heals itself once the daemon settles; the veto must hold for both classifiers, not only
+     * for [isMasterKeyFailure].
+     */
+    @Test
+    fun `a failure wrapping an android Keystore failure is not corruption`() {
+        assertFalse(
+            isUnrecoverableCorruption(
+                InvalidKeyException("Keystore operation failed", AndroidKeyStoreException())
+            )
+        )
+        assertFalse(
+            isUnrecoverableCorruption(
+                KeyStoreException("cannot use Android Keystore", AndroidKeyStoreException())
+            )
+        )
+        assertFalse(
+            isUnrecoverableCorruption(
+                GeneralSecurityException(InvalidKeyException("Keystore operation failed", AndroidKeyStoreException()))
+            )
+        )
+    }
+
     @Test
     fun `corruption signature is found deep in the cause chain`() {
         val exception = RuntimeException(IOException(GeneralSecurityException(AEADBadTagException())))

--- a/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceRecoveryTest.kt
+++ b/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceRecoveryTest.kt
@@ -1,5 +1,8 @@
 package co.electriccoin.zcash.preference
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
 import java.io.CharConversionException
 import java.io.IOException
 import java.security.GeneralSecurityException
@@ -9,8 +12,10 @@ import javax.crypto.AEADBadTagException
 import javax.crypto.BadPaddingException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Pins the recovery heuristics of `AndroidPreferenceProvider.newEncrypted`: which failures are
@@ -18,6 +23,7 @@ import kotlin.test.assertTrue
  * Keystore query degrades when the Keystore itself misbehaves. Widening or narrowing either
  * behavior must be a deliberate change that shows up here.
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 class EncryptedPreferenceRecoveryTest {
     @Test
     fun `AEAD authentication failure is unrecoverable corruption`() {
@@ -97,6 +103,182 @@ class EncryptedPreferenceRecoveryTest {
         assertFalse(result)
         assertEquals(2, attempts)
     }
+
+    @Test
+    fun `Keystore key failures are master key failures`() {
+        assertTrue(isMasterKeyFailure(GeneralSecurityException(KeyStoreException())))
+        assertTrue(isMasterKeyFailure(InvalidKeyException()))
+    }
+
+    @Test
+    fun `data level failures are not master key failures`() {
+        assertFalse(isMasterKeyFailure(AEADBadTagException()))
+        assertFalse(isMasterKeyFailure(CharConversionException()))
+        assertFalse(isMasterKeyFailure(IOException()))
+    }
+
+    @Test
+    fun `backoff doubles starting at 200 milliseconds`() {
+        assertEquals(200.milliseconds, encryptedPreferencesOpenBackoff(1))
+        assertEquals(400.milliseconds, encryptedPreferencesOpenBackoff(2))
+        assertEquals(800.milliseconds, encryptedPreferencesOpenBackoff(3))
+    }
+
+    @Test
+    fun `a transient failure then success requires two attempts and no quarantine`() =
+        runTest {
+            var attempts = 0
+            var quarantined = false
+
+            val result =
+                createEncryptedPreferencesWithRecovery(
+                    filename = "test",
+                    isOrphaned = false,
+                    create = {
+                        attempts++
+                        if (attempts == 1) error("transient Keystore failure")
+                        "opened"
+                    },
+                    quarantine = { quarantined = true },
+                )
+
+            assertEquals("opened", result)
+            assertEquals(2, attempts)
+            assertFalse(quarantined)
+            assertEquals(200, currentTime)
+        }
+
+    @Test
+    fun `a persistent transient failure is rethrown after three attempts without quarantine`() =
+        runTest {
+            var attempts = 0
+            var quarantined = false
+
+            val exception =
+                assertFailsWith<IllegalStateException> {
+                    createEncryptedPreferencesWithRecovery<String>(
+                        filename = "test",
+                        isOrphaned = false,
+                        create = {
+                            attempts++
+                            error("persistent Keystore failure")
+                        },
+                        quarantine = { quarantined = true },
+                    )
+                }
+
+            assertEquals("persistent Keystore failure", exception.message)
+            assertEquals(3, attempts)
+            assertFalse(quarantined)
+            assertEquals(600, currentTime)
+        }
+
+    @Test
+    fun `AEAD failure on every attempt quarantines once then recreates`() =
+        runTest {
+            var attempts = 0
+            var quarantineCause: Exception? = null
+
+            val result =
+                createEncryptedPreferencesWithRecovery(
+                    filename = "test",
+                    isOrphaned = false,
+                    create = {
+                        attempts++
+                        if (attempts <= ENCRYPTED_PREFERENCES_OPEN_ATTEMPTS) {
+                            throw AEADBadTagException("decryption failed")
+                        }
+                        "fresh store"
+                    },
+                    quarantine = { cause -> quarantineCause = cause },
+                )
+
+            assertEquals("fresh store", result)
+            assertEquals(ENCRYPTED_PREFERENCES_OPEN_ATTEMPTS + 1, attempts)
+            assertTrue(quarantineCause is AEADBadTagException)
+        }
+
+    @Test
+    fun `AEAD failure once then success is not quarantined`() =
+        runTest {
+            var attempts = 0
+            var quarantined = false
+
+            val result =
+                createEncryptedPreferencesWithRecovery(
+                    filename = "test",
+                    isOrphaned = false,
+                    create = {
+                        attempts++
+                        if (attempts == 1) throw AEADBadTagException("decryption failed")
+                        "opened"
+                    },
+                    quarantine = { quarantined = true },
+                )
+
+            assertEquals("opened", result)
+            assertEquals(2, attempts)
+            assertFalse(quarantined)
+        }
+
+    @Test
+    fun `an orphaned file with an unclassified failure is quarantined once then recreated`() =
+        runTest {
+            var attempts = 0
+            var quarantined = false
+
+            val result =
+                createEncryptedPreferencesWithRecovery(
+                    filename = "test",
+                    isOrphaned = true,
+                    create = {
+                        attempts++
+                        if (attempts <= ENCRYPTED_PREFERENCES_OPEN_ATTEMPTS) {
+                            throw IOException("disk error")
+                        }
+                        "fresh store"
+                    },
+                    quarantine = { quarantined = true },
+                )
+
+            assertEquals("fresh store", result)
+            assertTrue(quarantined)
+        }
+
+    @Test
+    fun `recreate not allowed rethrows without quarantining`() =
+        runTest {
+            var quarantined = false
+
+            assertFailsWith<AEADBadTagException> {
+                createEncryptedPreferencesWithRecovery<String>(
+                    filename = "test",
+                    isOrphaned = false,
+                    isRecreateAllowed = false,
+                    create = { throw AEADBadTagException("decryption failed") },
+                    quarantine = { quarantined = true },
+                )
+            }
+
+            assertFalse(quarantined)
+        }
+
+    @Test
+    fun `a recreate failure after quarantine propagates`() =
+        runTest {
+            var quarantined = false
+
+            assertFailsWith<AEADBadTagException> {
+                createEncryptedPreferencesWithRecovery<String>(
+                    filename = "test",
+                    isOrphaned = false,
+                    create = { throw AEADBadTagException("decryption failed") },
+                    quarantine = { quarantined = true },
+                )
+            }
+
+            assertTrue(quarantined)
+        }
 }
 
 /**

--- a/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceRecoveryTest.kt
+++ b/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceRecoveryTest.kt
@@ -101,6 +101,11 @@ class EncryptedPreferenceRecoveryTest {
     }
 
     @Test
+    fun `java security KeyStoreException wrapping an android Keystore failure is not a master key failure`() {
+        assertFalse(isMasterKeyFailure(KeyStoreException("cannot use Android Keystore", AndroidKeyStoreException())))
+    }
+
+    @Test
     fun `data level failures are not master key failures`() {
         assertFalse(isMasterKeyFailure(AEADBadTagException()))
         assertFalse(isMasterKeyFailure(CharConversionException()))

--- a/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceRecoveryTest.kt
+++ b/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/EncryptedPreferenceRecoveryTest.kt
@@ -17,6 +17,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import co.electriccoin.zcash.preference.androidsecurity.KeyStoreException as AndroidKeyStoreException
+import co.electriccoin.zcash.preference.androidsecurity.legacy.KeyStoreException as LegacyAndroidKeyStoreException
 
 /**
  * Pins the recovery heuristics of `AndroidPreferenceProvider.newEncrypted`: which failures are
@@ -81,6 +82,120 @@ class EncryptedPreferenceRecoveryTest {
         assertFalse(
             isUnrecoverableCorruption(
                 GeneralSecurityException(InvalidKeyException("Keystore operation failed", AndroidKeyStoreException()))
+            )
+        )
+    }
+
+    /**
+     * The shape a device-to-device transfer actually leaves behind, reproduced on an emulator on
+     * both API 31 and API 35: `MasterKey.Builder.build()` mints a replacement key under the old
+     * alias, so the stored ciphertext no longer authenticates and the Keystore says so. The marker
+     * is present, but the failure will never heal — vetoing on the marker alone stranded the store
+     * on every launch instead of quarantining it and returning the user to onboarding.
+     */
+    @Test
+    fun `a Keystore failure that cannot authenticate the stored ciphertext is corruption`() {
+        assertTrue(
+            isUnrecoverableCorruption(
+                aeadFailureCausedBy(
+                    AndroidKeyStoreException(
+                        "Signature/MAC verification failed (internal Keystore code: -30)",
+                        numericErrorCode = AndroidKeyStoreException.ERROR_KEYMINT_FAILURE
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `a Keystore failure reporting a missing key is corruption and a master key failure`() {
+        val keyNotFound =
+            InvalidKeyException(
+                "Keystore operation failed",
+                AndroidKeyStoreException(
+                    "Key not found",
+                    numericErrorCode = AndroidKeyStoreException.ERROR_KEY_DOES_NOT_EXIST
+                )
+            )
+
+        assertTrue(isUnrecoverableCorruption(keyNotFound))
+        assertTrue(isMasterKeyFailure(keyNotFound))
+    }
+
+    @Test
+    fun `a Keystore failure reporting a permanently invalidated key is corruption and a master key failure`() {
+        val permanentlyInvalidated =
+            InvalidKeyException(
+                "Keystore operation failed",
+                AndroidKeyStoreException(
+                    "Key permanently invalidated",
+                    numericErrorCode = AndroidKeyStoreException.ERROR_KEY_DOES_NOT_EXIST
+                )
+            )
+
+        assertTrue(isUnrecoverableCorruption(permanentlyInvalidated))
+        assertTrue(isMasterKeyFailure(permanentlyInvalidated))
+    }
+
+    /**
+     * AOSP falls back to the bare error code as the message for a condition it has no wording for,
+     * so the API 33 classification has to stand on its own.
+     */
+    @Test
+    fun `the API 33 error code identifies a lost key without a recognizable message`() {
+        assertTrue(
+            isUnrecoverableCorruption(
+                aeadFailureCausedBy(
+                    AndroidKeyStoreException(
+                        "7",
+                        numericErrorCode = AndroidKeyStoreException.ERROR_KEY_CORRUPTED
+                    )
+                )
+            )
+        )
+    }
+
+    /**
+     * Devices below API 33 carry no classification methods at all, so the message AOSP hard-codes
+     * for the condition is the only permanence signal there.
+     */
+    @Test
+    fun `a pre API 33 Keystore failure is classified from its message alone`() {
+        assertTrue(
+            isUnrecoverableCorruption(
+                aeadFailureCausedBy(LegacyAndroidKeyStoreException("Signature/MAC verification failed"))
+            )
+        )
+        assertFalse(
+            isUnrecoverableCorruption(
+                InvalidKeyException("Keystore operation failed", LegacyAndroidKeyStoreException("System error"))
+            )
+        )
+    }
+
+    @Test
+    fun `a Keystore failure AOSP itself calls transient is never permanent`() {
+        val secureHardwareBusy =
+            InvalidKeyException(
+                "Keystore operation failed",
+                AndroidKeyStoreException("Secure hardware busy", isTransientFailure = true)
+            )
+
+        assertFalse(isUnrecoverableCorruption(secureHardwareBusy))
+        assertFalse(isMasterKeyFailure(secureHardwareBusy))
+    }
+
+    /**
+     * The retry verdict AOSP gives outranks the wording, so a Keystore that is merely wedged can
+     * never be read as permanent however its message happens to read.
+     */
+    @Test
+    fun `a transient verdict outranks a permanent sounding message`() {
+        assertFalse(
+            isUnrecoverableCorruption(
+                aeadFailureCausedBy(
+                    AndroidKeyStoreException("Signature/MAC verification failed", isTransientFailure = true)
+                )
             )
         )
     }
@@ -270,6 +385,13 @@ class EncryptedPreferenceRecoveryTest {
             assertTrue(quarantined)
         }
 }
+
+/**
+ * The AEAD failure a Keystore raises through `AndroidKeyStoreCipherSpiBase.engineDoFinal`, which
+ * chains the Keystore exception as the cause rather than passing it to a constructor.
+ */
+private fun aeadFailureCausedBy(cause: Throwable): AEADBadTagException =
+    AEADBadTagException("decryption failed").apply { initCause(cause) }
 
 /**
  * Stand-in matching Tink's shaded `InvalidProtocolBufferException` by simple name, which is how

--- a/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/androidsecurity/KeyStoreException.kt
+++ b/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/androidsecurity/KeyStoreException.kt
@@ -4,6 +4,25 @@ package co.electriccoin.zcash.preference.androidsecurity
  * Stand-in matching Android's `android.security.KeyStoreException` by simple name (that class
  * extends `java.lang.Exception`, unlike [java.security.KeyStoreException]), used by
  * [co.electriccoin.zcash.preference.EncryptedPreferenceRecoveryTest] to simulate an AOSP-wrapped
- * Keystore-daemon failure in a JVM unit test without depending on the Android framework class.
+ * Keystore failure in a JVM unit test without depending on the Android framework class.
+ *
+ * [numericErrorCode] and [isTransientFailure] reproduce the API 33 classification the production
+ * code reads reflectively; Kotlin names their getters `getNumericErrorCode()` and
+ * `isTransientFailure()`, exactly as AOSP does. The defaults are AOSP's own fallback for an
+ * unmapped KeyMint error — non-transient, [ERROR_KEYMINT_FAILURE] — which is the shape a wedged
+ * Keystore reports, and which the production code must refuse to read as permanent.
+ *
+ * See [co.electriccoin.zcash.preference.androidsecurity.legacy.KeyStoreException] for the pre-API
+ * 33 counterpart that carries no classification at all.
  */
-class KeyStoreException : Exception()
+class KeyStoreException(
+    message: String? = null,
+    val numericErrorCode: Int = ERROR_KEYMINT_FAILURE,
+    val isTransientFailure: Boolean = false
+) : Exception(message) {
+    companion object {
+        const val ERROR_KEY_DOES_NOT_EXIST = 6
+        const val ERROR_KEY_CORRUPTED = 7
+        const val ERROR_KEYMINT_FAILURE = 10
+    }
+}

--- a/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/androidsecurity/KeyStoreException.kt
+++ b/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/androidsecurity/KeyStoreException.kt
@@ -1,0 +1,9 @@
+package co.electriccoin.zcash.preference.androidsecurity
+
+/**
+ * Stand-in matching Android's `android.security.KeyStoreException` by simple name (that class
+ * extends `java.lang.Exception`, unlike [java.security.KeyStoreException]), used by
+ * [co.electriccoin.zcash.preference.EncryptedPreferenceRecoveryTest] to simulate an AOSP-wrapped
+ * Keystore-daemon failure in a JVM unit test without depending on the Android framework class.
+ */
+class KeyStoreException : Exception()

--- a/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/androidsecurity/legacy/KeyStoreException.kt
+++ b/preference-impl-android-lib/src/test/java/co/electriccoin/zcash/preference/androidsecurity/legacy/KeyStoreException.kt
@@ -1,0 +1,11 @@
+package co.electriccoin.zcash.preference.androidsecurity.legacy
+
+/**
+ * Stand-in for `android.security.KeyStoreException` as it exists below API 33: the same simple
+ * name and the same messages, but none of the classification methods the production code probes
+ * for reflectively. Devices on API 27 to 32 raise exactly this, so the message is the only
+ * permanence signal available there.
+ */
+class KeyStoreException(
+    message: String? = null
+) : Exception(message)

--- a/ui-lib/src/main/java/co/electriccoin/zcash/di/ProviderModule.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/di/ProviderModule.kt
@@ -43,6 +43,8 @@ import co.electriccoin.zcash.ui.common.provider.PreferredFiatProvider
 import co.electriccoin.zcash.ui.common.provider.PreferredFiatProviderImpl
 import co.electriccoin.zcash.ui.common.provider.RestoreTimestampStorageProvider
 import co.electriccoin.zcash.ui.common.provider.RestoreTimestampStorageProviderImpl
+import co.electriccoin.zcash.ui.common.provider.SdkEncryptedPreferenceRecoveryProvider
+import co.electriccoin.zcash.ui.common.provider.SdkEncryptedPreferenceRecoveryProviderImpl
 import co.electriccoin.zcash.ui.common.provider.SelectedAccountUUIDProvider
 import co.electriccoin.zcash.ui.common.provider.SelectedAccountUUIDProviderImpl
 import co.electriccoin.zcash.ui.common.provider.ShieldFundsInfoProvider
@@ -118,4 +120,5 @@ val providerModule =
         factoryOf(::KeystoneSDKProviderImpl) bind KeystoneSDKProvider::class
         singleOf(::LastNetworkActivityStorageProviderImpl) bind LastNetworkActivityStorageProvider::class
         factoryOf(::IsBackgroundExecutionAvailableProvider)
+        singleOf(::SdkEncryptedPreferenceRecoveryProviderImpl) bind SdkEncryptedPreferenceRecoveryProvider::class
     }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SdkEncryptedPreferenceRecoveryProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SdkEncryptedPreferenceRecoveryProvider.kt
@@ -15,7 +15,7 @@ interface SdkEncryptedPreferenceRecoveryProvider {
     suspend fun ensureReadable()
 }
 
-class SdkEncryptedPreferenceRecoveryProviderImpl(
+internal class SdkEncryptedPreferenceRecoveryProviderImpl(
     private val context: Context
 ) : SdkEncryptedPreferenceRecoveryProvider {
     override suspend fun ensureReadable() =

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SdkEncryptedPreferenceRecoveryProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SdkEncryptedPreferenceRecoveryProvider.kt
@@ -4,16 +4,17 @@ import android.content.Context
 import co.electriccoin.zcash.preference.AndroidPreferenceProvider
 
 interface SdkEncryptedPreferenceRecoveryProvider {
+    /**
+     * The SDK's encrypted store (`cash.z.ecc.android.sdk.encrypted`) shares this app's Keystore
+     * master key, but the SDK has no corruption recovery of its own, and both
+     * `Synchronizer.erase` and `Synchronizer.new` open it unguarded. So after the app's own
+     * encrypted store had to be recreated, the SDK store must be repaired the same way, or a
+     * restore attempt that reaches it crash-loops instead of self-healing. Callers must await this
+     * before anything else opens the SDK store.
+     */
     suspend fun ensureReadable()
 }
 
-/**
- * The SDK's encrypted store ([SDK_ENCRYPTED_PREFERENCES_FILENAME]) shares this app's Keystore
- * master key, but the SDK has no corruption recovery of its own, and both
- * `Synchronizer.erase` and `Synchronizer.new` open it unguarded. So after the app's own encrypted
- * store had to be recreated, the SDK store must be repaired the same way, or a restore attempt
- * that reaches it crash-loops instead of self-healing.
- */
 class SdkEncryptedPreferenceRecoveryProviderImpl(
     private val context: Context
 ) : SdkEncryptedPreferenceRecoveryProvider {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SdkEncryptedPreferenceRecoveryProvider.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/provider/SdkEncryptedPreferenceRecoveryProvider.kt
@@ -1,0 +1,24 @@
+package co.electriccoin.zcash.ui.common.provider
+
+import android.content.Context
+import co.electriccoin.zcash.preference.AndroidPreferenceProvider
+
+interface SdkEncryptedPreferenceRecoveryProvider {
+    suspend fun ensureReadable()
+}
+
+/**
+ * The SDK's encrypted store ([SDK_ENCRYPTED_PREFERENCES_FILENAME]) shares this app's Keystore
+ * master key, but the SDK has no corruption recovery of its own, and both
+ * `Synchronizer.erase` and `Synchronizer.new` open it unguarded. So after the app's own encrypted
+ * store had to be recreated, the SDK store must be repaired the same way, or a restore attempt
+ * that reaches it crash-loops instead of self-healing.
+ */
+class SdkEncryptedPreferenceRecoveryProviderImpl(
+    private val context: Context
+) : SdkEncryptedPreferenceRecoveryProvider {
+    override suspend fun ensureReadable() =
+        AndroidPreferenceProvider.ensureEncryptedReadable(context, SDK_ENCRYPTED_PREFERENCES_FILENAME)
+}
+
+private const val SDK_ENCRYPTED_PREFERENCES_FILENAME = "cash.z.ecc.android.sdk.encrypted"

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/WalletRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/WalletRepository.kt
@@ -1,6 +1,9 @@
 package co.electriccoin.zcash.ui.common.repository
 
 import android.app.Application
+import androidx.annotation.RestrictTo
+import androidx.annotation.VisibleForTesting
+import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.WalletInitMode
 import cash.z.ecc.android.sdk.model.BlockHeight
 import cash.z.ecc.android.sdk.model.FastestServersResult
@@ -83,7 +86,15 @@ class WalletRepositoryImpl(
     private val walletBackupFlagStorageProvider: WalletBackupFlagStorageProvider,
     private val isIronwoodAnnouncementShownStorageProvider: IsIronwoodAnnouncementShownStorageProvider,
 ) : WalletRepository {
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val sharingScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    /**
+     * Scope the repository's fire-and-forget jobs run on. A test seam: unit tests replace it
+     * with a test dispatcher before invoking any method.
+     */
+    @set:RestrictTo(RestrictTo.Scope.TESTS)
+    @VisibleForTesting
+    internal var scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     private val refreshFastestServersRequest = MutableSharedFlow<Unit>()
 
@@ -96,21 +107,28 @@ class WalletRepositoryImpl(
             )
         }
 
+    /**
+     * READY additionally requires a stored wallet ([resolveSecretState]), because the plain
+     * onboarding flag and the encrypted wallet store can diverge when the encrypted store is
+     * recreated after provable corruption (MOB-1836). This flow never catches: a transient
+     * Keystore failure surfacing here is left to crash the sharing coroutine, the same terminal
+     * outcome the app already reaches today via [co.electriccoin.zcash.ui.common.provider.SynchronizerProvider]
+     * collecting the same underlying store, rather than misrouting an intact-but-unreadable store
+     * to onboarding.
+     */
     override val secretState: StateFlow<SecretState> =
-        combine(configurationRepository.configurationFlow, onboardingState) { config, onboardingState ->
-            if (config == null) {
-                SecretState.LOADING
-            } else {
-                when (onboardingState) {
-                    OnboardingState.NEEDS_WARN,
-                    OnboardingState.NEEDS_BACKUP,
-                    OnboardingState.NONE -> SecretState.NONE
-
-                    OnboardingState.READY -> SecretState.READY
-                }
-            }
+        combine(
+            configurationRepository.configurationFlow,
+            onboardingState,
+            persistableWalletProvider.persistableWallet
+        ) { config, onboardingState, wallet ->
+            resolveSecretState(
+                isConfigurationLoaded = config != null,
+                onboardingState = onboardingState,
+                hasWallet = wallet != null
+            )
         }.stateIn(
-            scope = scope,
+            scope = sharingScope,
             started = SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
             initialValue = SecretState.LOADING
         )
@@ -119,7 +137,7 @@ class WalletRepositoryImpl(
         isIronwoodAnnouncementShownStorageProvider
             .observe()
             .stateIn(
-                scope = scope,
+                scope = sharingScope,
                 started = SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
                 initialValue = null
             )
@@ -183,7 +201,7 @@ class WalletRepositoryImpl(
             }.onEach {
                 previousFastestEndpoints = it
             }.stateIn(
-                scope = scope,
+                scope = sharingScope,
                 started = SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
                 initialValue = FastestServersState(servers = emptyList(), isLoading = true)
             )
@@ -192,7 +210,7 @@ class WalletRepositoryImpl(
         walletRestoringStateProvider
             .observe()
             .stateIn(
-                scope = scope,
+                scope = sharingScope,
                 started = SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT),
                 initialValue = WalletRestoringState.NONE
             )
@@ -202,8 +220,9 @@ class WalletRepositoryImpl(
         scope.launch {
             try {
                 migrateDecommissionedEndpointIfNeeded()
+                resetOnboardingIfWalletMissing()
             } catch (e: Exception) {
-                Twig.error(e) { "Decommissioned endpoint migration failed; will retry on next launch" }
+                Twig.error(e) { "Startup wallet consistency checks failed; will retry on next launch" }
             }
         }
     }
@@ -213,6 +232,24 @@ class WalletRepositoryImpl(
         if (wallet.endpoint.host in lightWalletEndpointProvider.getDecommissionedHosts()) {
             persistWalletInternal(wallet.copy(endpoint = lightWalletEndpointProvider.getDefaultEndpoint()))
         }
+    }
+
+    /**
+     * Self-heals a wallet-less READY state (MOB-1836): the onboarding flag and the encrypted
+     * wallet store live in separate preference files and can diverge when the encrypted store is
+     * recreated after provable corruption. Erases any stale SDK databases directly, since no
+     * synchronizer exists yet at this point to route through the usual delete-and-restore paths.
+     */
+    private suspend fun resetOnboardingIfWalletMissing() {
+        val currentOnboardingState =
+            OnboardingState.fromNumber(StandardPreferenceKeys.ONBOARDING_STATE.getValue(standardPreferenceProvider()))
+        if (currentOnboardingState != OnboardingState.READY) return
+        if (persistableWalletProvider.getPersistableWallet() != null) return
+
+        Twig.warn { "Onboarding state is READY but no wallet is stored; returning to onboarding" }
+        runCatching { Synchronizer.erase(application, ZcashNetwork.fromResources(application)) }
+            .onFailure { Twig.error(it) { "Erasing stale wallet data failed; continuing" } }
+        persistOnboardingStateInternal(OnboardingState.NONE)
     }
 
     override suspend fun updateWalletEndpoint(endpoint: LightWalletEndpoint) {
@@ -228,7 +265,6 @@ class WalletRepositoryImpl(
 
     override fun createNewWallet() {
         scope.launch {
-            persistOnboardingStateInternal(OnboardingState.READY)
             val zcashNetwork = ZcashNetwork.fromResources(application)
             val newWallet =
                 PersistableWallet.new(
@@ -239,6 +275,7 @@ class WalletRepositoryImpl(
                 )
             persistWalletInternal(newWallet)
             walletRestoringStateProvider.store(WalletRestoringState.INITIATING)
+            persistOnboardingStateInternal(OnboardingState.READY)
         }
     }
 
@@ -283,3 +320,19 @@ class WalletRepositoryImpl(
         }
     }
 }
+
+/**
+ * READY requires both the plain onboarding flag and a stored wallet, because the two live in
+ * separate preference files and can diverge when the encrypted store is recreated after provable
+ * corruption (MOB-1836).
+ */
+internal fun resolveSecretState(
+    isConfigurationLoaded: Boolean,
+    onboardingState: OnboardingState,
+    hasWallet: Boolean,
+): SecretState =
+    when {
+        !isConfigurationLoaded -> SecretState.LOADING
+        onboardingState == OnboardingState.READY && hasWallet -> SecretState.READY
+        else -> SecretState.NONE
+    }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/WalletRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/WalletRepository.kt
@@ -13,6 +13,7 @@ import cash.z.ecc.android.sdk.model.ZcashNetwork
 import cash.z.ecc.sdk.ANDROID_STATE_FLOW_TIMEOUT
 import cash.z.ecc.sdk.type.fromResources
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
+import co.electriccoin.zcash.crash.android.GlobalCrashReporter
 import co.electriccoin.zcash.preference.StandardPreferenceProvider
 import co.electriccoin.zcash.spackle.Twig
 import co.electriccoin.zcash.ui.common.datasource.RestoreTimestampDataSource
@@ -288,6 +289,10 @@ class WalletRepositoryImpl(
      * wallet is nevertheless re-read immediately before the erase: that erase destroys databases
      * for good, and a wallet stored outside those two paths while the SDK secret store was being
      * repaired must not be erased under it.
+     *
+     * A failed erase is reported to [GlobalCrashReporter] as well as logged: "the erase failed and
+     * we carried on anyway" leaves exactly the half-reset state MOB-1836 was reported for, and a
+     * log line alone never reaches us from a user's device.
      */
     private suspend fun resetOnboardingIfWalletMissing(
         wallet: PersistableWallet?,
@@ -307,7 +312,10 @@ class WalletRepositoryImpl(
         }
 
         runCatching { Synchronizer.erase(application, ZcashNetwork.fromResources(application)) }
-            .onFailure { Twig.error(it) { "Erasing stale wallet data failed; continuing" } }
+            .onFailure {
+                Twig.error(it) { "Erasing stale wallet data failed; continuing" }
+                GlobalCrashReporter.reportCaughtException(it)
+            }
     }
 
     override suspend fun updateWalletEndpoint(endpoint: LightWalletEndpoint) {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/WalletRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/WalletRepository.kt
@@ -92,7 +92,13 @@ class WalletRepositoryImpl(
     private val isIronwoodAnnouncementShownStorageProvider: IsIronwoodAnnouncementShownStorageProvider,
     private val sdkEncryptedPreferenceRecoveryProvider: SdkEncryptedPreferenceRecoveryProvider,
 ) : WalletRepository {
-    private val sharingScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    /**
+     * Scope the repository's `stateIn`-shared flows run on. Captured by those flows at
+     * construction time, so unlike [scope] it is never reassigned for tests — only exposed so
+     * test teardown can cancel it too.
+     */
+    @VisibleForTesting
+    internal val sharingScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     /**
      * Serializes the startup self-heal ([init]) against wallet creation and restore, so the erase

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/WalletRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/WalletRepository.kt
@@ -50,6 +50,8 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 interface WalletRepository {
     val secretState: StateFlow<SecretState>
@@ -91,6 +93,13 @@ class WalletRepositoryImpl(
     private val sdkEncryptedPreferenceRecoveryProvider: SdkEncryptedPreferenceRecoveryProvider,
 ) : WalletRepository {
     private val sharingScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    /**
+     * Serializes the startup self-heal ([init]) against wallet creation and restore, so the erase
+     * in [resetOnboardingIfWalletMissing] can never interleave with a wallet those paths are in
+     * the middle of storing.
+     */
+    private val walletMutation = Mutex()
 
     /**
      * Scope the repository's fire-and-forget jobs run on. A test seam: unit tests replace it
@@ -238,9 +247,12 @@ class WalletRepositoryImpl(
     override fun init() {
         scope.launch {
             try {
-                val wallet = persistableWalletProvider.getPersistableWallet()
-                migrateDecommissionedEndpointIfNeeded(wallet)
-                resetOnboardingIfWalletMissing(wallet)
+                walletMutation.withLock {
+                    val wallet = persistableWalletProvider.getPersistableWallet()
+                    val onboarding = onboardingState.first()
+                    migrateDecommissionedEndpointIfNeeded(wallet)
+                    resetOnboardingIfWalletMissing(wallet = wallet, onboardingState = onboarding)
+                }
             } catch (e: Exception) {
                 Twig.error(e) { "Startup wallet consistency checks failed; will retry on next launch" }
             }
@@ -264,16 +276,30 @@ class WalletRepositoryImpl(
      * no corruption recovery of its own. Finally, any stale SDK databases are erased directly,
      * since no synchronizer exists yet at this point to route through the usual delete-and-restore
      * paths.
+     *
+     * [wallet] and [onboardingState] are both read by [init] under [walletMutation], which
+     * [createNewWallet] and [restoreWallet] hold too, so neither can interleave with this. The
+     * wallet is nevertheless re-read immediately before the erase: that erase destroys databases
+     * for good, and a wallet stored outside those two paths while the SDK secret store was being
+     * repaired must not be erased under it.
      */
-    private suspend fun resetOnboardingIfWalletMissing(wallet: PersistableWallet?) {
-        if (wallet != null) return
-        if (onboardingState.first() != OnboardingState.READY) return
+    private suspend fun resetOnboardingIfWalletMissing(
+        wallet: PersistableWallet?,
+        onboardingState: OnboardingState
+    ) {
+        if (wallet != null || onboardingState != OnboardingState.READY) return
 
         Twig.warn { "Onboarding state is READY but no wallet is stored; returning to onboarding" }
         persistOnboardingStateInternal(OnboardingState.NONE)
 
         runCatching { sdkEncryptedPreferenceRecoveryProvider.ensureReadable() }
             .onFailure { Twig.error(it) { "Repairing the SDK secret store failed; continuing" } }
+
+        if (persistableWalletProvider.getPersistableWallet() != null) {
+            Twig.warn { "A wallet was stored while self-healing; keeping its data instead of erasing" }
+            return
+        }
+
         runCatching { Synchronizer.erase(application, ZcashNetwork.fromResources(application)) }
             .onFailure { Twig.error(it) { "Erasing stale wallet data failed; continuing" } }
     }
@@ -291,17 +317,19 @@ class WalletRepositoryImpl(
 
     override fun createNewWallet() {
         scope.launch {
-            val zcashNetwork = ZcashNetwork.fromResources(application)
-            val newWallet =
-                PersistableWallet.new(
-                    application = application,
-                    zcashNetwork = zcashNetwork,
-                    endpoint = lightWalletEndpointProvider.getDefaultEndpoint(),
-                    walletInitMode = WalletInitMode.NewWallet,
-                )
-            persistWalletInternal(newWallet)
-            walletRestoringStateProvider.store(WalletRestoringState.INITIATING)
-            persistOnboardingStateInternal(OnboardingState.READY)
+            walletMutation.withLock {
+                val zcashNetwork = ZcashNetwork.fromResources(application)
+                val newWallet =
+                    PersistableWallet.new(
+                        application = application,
+                        zcashNetwork = zcashNetwork,
+                        endpoint = lightWalletEndpointProvider.getDefaultEndpoint(),
+                        walletInitMode = WalletInitMode.NewWallet,
+                    )
+                persistWalletInternal(newWallet)
+                walletRestoringStateProvider.store(WalletRestoringState.INITIATING)
+                persistOnboardingStateInternal(OnboardingState.READY)
+            }
         }
     }
 
@@ -330,19 +358,21 @@ class WalletRepositoryImpl(
         birthday: BlockHeight
     ) {
         scope.launch {
-            val restoredWallet =
-                PersistableWallet(
-                    network = network,
-                    birthday = birthday,
-                    endpoint = lightWalletEndpointProvider.getDefaultEndpoint(),
-                    seedPhrase = seedPhrase,
-                    walletInitMode = WalletInitMode.RestoreWallet,
-                )
-            persistWalletInternal(restoredWallet)
-            walletRestoringStateProvider.store(WalletRestoringState.RESTORING)
-            walletBackupFlagStorageProvider.store(true)
-            restoreTimestampDataSource.getOrCreate()
-            persistOnboardingStateInternal(OnboardingState.READY)
+            walletMutation.withLock {
+                val restoredWallet =
+                    PersistableWallet(
+                        network = network,
+                        birthday = birthday,
+                        endpoint = lightWalletEndpointProvider.getDefaultEndpoint(),
+                        seedPhrase = seedPhrase,
+                        walletInitMode = WalletInitMode.RestoreWallet,
+                    )
+                persistWalletInternal(restoredWallet)
+                walletRestoringStateProvider.store(WalletRestoringState.RESTORING)
+                walletBackupFlagStorageProvider.store(true)
+                restoreTimestampDataSource.getOrCreate()
+                persistOnboardingStateInternal(OnboardingState.READY)
+            }
         }
     }
 }
@@ -351,6 +381,12 @@ class WalletRepositoryImpl(
  * READY requires both the plain onboarding flag and a stored wallet, because the two live in
  * separate preference files and can diverge when the encrypted store is recreated after provable
  * corruption (MOB-1836).
+ *
+ * Every other [OnboardingState] resolves to [SecretState.NONE], a stored wallet notwithstanding.
+ * [OnboardingState.NEEDS_WARN] and [OnboardingState.NEEDS_BACKUP] are ordinals of an earlier
+ * onboarding flow that nothing writes any more — [WalletRepositoryImpl] only ever persists
+ * [OnboardingState.NONE] or [OnboardingState.READY] — and both mean onboarding never ran to
+ * completion, so routing a wallet found under them back to onboarding is the intended outcome.
  */
 internal fun resolveSecretState(
     isConfigurationLoaded: Boolean,

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/WalletRepository.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/repository/WalletRepository.kt
@@ -22,6 +22,7 @@ import co.electriccoin.zcash.ui.common.model.WalletRestoringState
 import co.electriccoin.zcash.ui.common.provider.IsIronwoodAnnouncementShownStorageProvider
 import co.electriccoin.zcash.ui.common.provider.LightWalletEndpointProvider
 import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
+import co.electriccoin.zcash.ui.common.provider.SdkEncryptedPreferenceRecoveryProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import co.electriccoin.zcash.ui.common.provider.WalletBackupFlagStorageProvider
 import co.electriccoin.zcash.ui.common.provider.WalletRestoringStateProvider
@@ -31,12 +32,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
@@ -85,6 +88,7 @@ class WalletRepositoryImpl(
     private val walletRestoringStateProvider: WalletRestoringStateProvider,
     private val walletBackupFlagStorageProvider: WalletBackupFlagStorageProvider,
     private val isIronwoodAnnouncementShownStorageProvider: IsIronwoodAnnouncementShownStorageProvider,
+    private val sdkEncryptedPreferenceRecoveryProvider: SdkEncryptedPreferenceRecoveryProvider,
 ) : WalletRepository {
     private val sharingScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
@@ -108,6 +112,22 @@ class WalletRepositoryImpl(
         }
 
     /**
+     * The encrypted wallet store is only awaited when [onboardingState] already claims a wallet
+     * exists; a fresh install with the flag at its default has nothing to read there, so its
+     * splash screen must not wait on the Keystore for [persistableWalletProvider]'s flow to first
+     * emit.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val onboardingWithWallet: Flow<Pair<OnboardingState, Boolean>> =
+        onboardingState.flatMapLatest { state ->
+            if (state == OnboardingState.READY) {
+                persistableWalletProvider.persistableWallet.map { state to (it != null) }
+            } else {
+                flowOf(state to false)
+            }
+        }
+
+    /**
      * READY additionally requires a stored wallet ([resolveSecretState]), because the plain
      * onboarding flag and the encrypted wallet store can diverge when the encrypted store is
      * recreated after provable corruption (MOB-1836). This flow never catches: a transient
@@ -119,13 +139,12 @@ class WalletRepositoryImpl(
     override val secretState: StateFlow<SecretState> =
         combine(
             configurationRepository.configurationFlow,
-            onboardingState,
-            persistableWalletProvider.persistableWallet
-        ) { config, onboardingState, wallet ->
+            onboardingWithWallet
+        ) { config, (onboardingState, hasWallet) ->
             resolveSecretState(
                 isConfigurationLoaded = config != null,
                 onboardingState = onboardingState,
-                hasWallet = wallet != null
+                hasWallet = hasWallet
             )
         }.stateIn(
             scope = sharingScope,
@@ -219,16 +238,17 @@ class WalletRepositoryImpl(
     override fun init() {
         scope.launch {
             try {
-                migrateDecommissionedEndpointIfNeeded()
-                resetOnboardingIfWalletMissing()
+                val wallet = persistableWalletProvider.getPersistableWallet()
+                migrateDecommissionedEndpointIfNeeded(wallet)
+                resetOnboardingIfWalletMissing(wallet)
             } catch (e: Exception) {
                 Twig.error(e) { "Startup wallet consistency checks failed; will retry on next launch" }
             }
         }
     }
 
-    private suspend fun migrateDecommissionedEndpointIfNeeded() {
-        val wallet = persistableWalletProvider.getPersistableWallet() ?: return
+    private suspend fun migrateDecommissionedEndpointIfNeeded(wallet: PersistableWallet?) {
+        if (wallet == null) return
         if (wallet.endpoint.host in lightWalletEndpointProvider.getDecommissionedHosts()) {
             persistWalletInternal(wallet.copy(endpoint = lightWalletEndpointProvider.getDefaultEndpoint()))
         }
@@ -237,19 +257,25 @@ class WalletRepositoryImpl(
     /**
      * Self-heals a wallet-less READY state (MOB-1836): the onboarding flag and the encrypted
      * wallet store live in separate preference files and can diverge when the encrypted store is
-     * recreated after provable corruption. Erases any stale SDK databases directly, since no
-     * synchronizer exists yet at this point to route through the usual delete-and-restore paths.
+     * recreated after provable corruption. The onboarding flag is written back to NONE first, so a
+     * Create/Restore the user completes while the SDK-store repair or the erase below is still
+     * running cannot be clobbered by this write landing afterwards. The SDK's own encrypted store
+     * is then repaired the same way (MOB-1836): it shares this app's Keystore master key but has
+     * no corruption recovery of its own. Finally, any stale SDK databases are erased directly,
+     * since no synchronizer exists yet at this point to route through the usual delete-and-restore
+     * paths.
      */
-    private suspend fun resetOnboardingIfWalletMissing() {
-        val currentOnboardingState =
-            OnboardingState.fromNumber(StandardPreferenceKeys.ONBOARDING_STATE.getValue(standardPreferenceProvider()))
-        if (currentOnboardingState != OnboardingState.READY) return
-        if (persistableWalletProvider.getPersistableWallet() != null) return
+    private suspend fun resetOnboardingIfWalletMissing(wallet: PersistableWallet?) {
+        if (wallet != null) return
+        if (onboardingState.first() != OnboardingState.READY) return
 
         Twig.warn { "Onboarding state is READY but no wallet is stored; returning to onboarding" }
+        persistOnboardingStateInternal(OnboardingState.NONE)
+
+        runCatching { sdkEncryptedPreferenceRecoveryProvider.ensureReadable() }
+            .onFailure { Twig.error(it) { "Repairing the SDK secret store failed; continuing" } }
         runCatching { Synchronizer.erase(application, ZcashNetwork.fromResources(application)) }
             .onFailure { Twig.error(it) { "Erasing stale wallet data failed; continuing" } }
-        persistOnboardingStateInternal(OnboardingState.NONE)
     }
 
     override suspend fun updateWalletEndpoint(endpoint: LightWalletEndpoint) {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/deletewallet/ResetZashiUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/deletewallet/ResetZashiUseCase.kt
@@ -1,11 +1,9 @@
 package co.electriccoin.zcash.ui.screen.deletewallet
 
-import android.app.Application
 import cash.z.ecc.android.sdk.CloseableSynchronizer
 import cash.z.ecc.android.sdk.WalletCoordinator
 import co.electriccoin.zcash.preference.EncryptedPreferenceProvider
 import co.electriccoin.zcash.preference.StandardPreferenceProvider
-import co.electriccoin.zcash.preference.purgeEncryptedPreferencesQuarantine
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.migration.MigrationAppHooks
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
@@ -24,7 +22,6 @@ import okhttp3.internal.closeQuietly
 import kotlin.time.Duration.Companion.seconds
 
 class ResetZashiUseCase(
-    private val application: Application,
     private val walletCoordinator: WalletCoordinator,
     private val flexaRepository: FlexaRepository,
     private val synchronizerProvider: SynchronizerProvider,
@@ -95,7 +92,7 @@ class ResetZashiUseCase(
     private suspend fun clearSharedPrefs() {
         standardPreferenceProvider().clearPreferences()
         encryptedPreferenceProvider().clearPreferences()
-        purgeEncryptedPreferencesQuarantine(application)
+        encryptedPreferenceProvider.purgeQuarantine()
     }
 
     private fun clearInMemoryData() {

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/deletewallet/ResetZashiUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/deletewallet/ResetZashiUseCase.kt
@@ -1,9 +1,11 @@
 package co.electriccoin.zcash.ui.screen.deletewallet
 
+import android.app.Application
 import cash.z.ecc.android.sdk.CloseableSynchronizer
 import cash.z.ecc.android.sdk.WalletCoordinator
 import co.electriccoin.zcash.preference.EncryptedPreferenceProvider
 import co.electriccoin.zcash.preference.StandardPreferenceProvider
+import co.electriccoin.zcash.preference.purgeEncryptedPreferencesQuarantine
 import co.electriccoin.zcash.ui.R
 import co.electriccoin.zcash.ui.common.migration.MigrationAppHooks
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
@@ -22,6 +24,7 @@ import okhttp3.internal.closeQuietly
 import kotlin.time.Duration.Companion.seconds
 
 class ResetZashiUseCase(
+    private val application: Application,
     private val walletCoordinator: WalletCoordinator,
     private val flexaRepository: FlexaRepository,
     private val synchronizerProvider: SynchronizerProvider,
@@ -92,6 +95,7 @@ class ResetZashiUseCase(
     private suspend fun clearSharedPrefs() {
         standardPreferenceProvider().clearPreferences()
         encryptedPreferenceProvider().clearPreferences()
+        purgeEncryptedPreferencesQuarantine(application)
     }
 
     private fun clearInMemoryData() {

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/WalletRepositoryImplTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/WalletRepositoryImplTest.kt
@@ -5,6 +5,7 @@ import cash.z.ecc.android.sdk.Synchronizer
 import cash.z.ecc.android.sdk.model.PersistableWallet
 import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
 import co.electriccoin.zcash.configuration.model.map.Configuration
+import co.electriccoin.zcash.crash.android.GlobalCrashReporter
 import co.electriccoin.zcash.preference.StandardPreferenceProvider
 import co.electriccoin.zcash.preference.api.PreferenceProvider
 import co.electriccoin.zcash.preference.model.entry.PreferenceKey
@@ -26,6 +27,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkAll
+import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
@@ -183,6 +185,61 @@ class WalletRepositoryImplTest {
 
             assertEquals(listOf("onboarding=0", "sdkRepair"), harness.events)
             coVerify(exactly = 0) { Synchronizer.erase(any(), any(), any()) }
+        }
+
+    /**
+     * The fail-safe hinge of the whole self-heal: "no wallet" must only ever mean "the store said
+     * there is no wallet", never "reading the store failed". Nothing in
+     * `PersistableWalletProviderImpl.getPersistableWallet` catches, so a read failure propagates
+     * out of [WalletRepositoryImpl.init] today — this pins that against a future well-meaning
+     * `runCatching` turning an unreadable store into a reset to onboarding and an erase.
+     */
+    @Test
+    fun initNeitherResetsOnboardingNorErasesWhenTheWalletReadFails() =
+        runTest {
+            val failingWalletProvider =
+                mockk<PersistableWalletProvider> {
+                    every { persistableWallet } returns MutableSharedFlow()
+                }
+            coEvery { failingWalletProvider.getPersistableWallet() } throws
+                IllegalStateException("encrypted preferences unreadable")
+
+            val (repository, harness) =
+                newRepository(
+                    onboardingState = OnboardingState.READY,
+                    initialWallet = null,
+                    persistableWalletProviderOverride = failingWalletProvider,
+                )
+            repository.useTestScope(testScheduler)
+
+            repository.init()
+            advanceUntilIdle()
+
+            assertEquals(emptyList<String>(), harness.events)
+            assertEquals("3", harness.fakePrefs.getString(StandardPreferenceKeys.ONBOARDING_STATE.key))
+            coVerify(exactly = 0) { Synchronizer.erase(any(), any(), any()) }
+        }
+
+    /**
+     * "The erase failed and we carried on anyway" is the half-reset state MOB-1836 was reported
+     * for, so it has to reach crash reporting rather than only a log line on the user's device.
+     */
+    @Test
+    fun initReportsAFailedEraseToCrashReporting() =
+        runTest {
+            mockkObject(GlobalCrashReporter)
+            every { GlobalCrashReporter.reportCaughtException(any()) } returns Unit
+
+            val (repository, harness) = newRepository(onboardingState = OnboardingState.READY, initialWallet = null)
+            val eraseFailure = RuntimeException("erasing the SDK databases failed")
+            coEvery { Synchronizer.erase(any(), any(), any()) } throws eraseFailure
+            repository.useTestScope(testScheduler)
+
+            repository.init()
+            advanceUntilIdle()
+
+            assertEquals(listOf("onboarding=0", "sdkRepair"), harness.events)
+            verify(exactly = 1) { GlobalCrashReporter.reportCaughtException(eraseFailure) }
         }
 
     /**

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/WalletRepositoryImplTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/WalletRepositoryImplTest.kt
@@ -28,6 +28,7 @@ import io.mockk.mockkObject
 import io.mockk.unmockkAll
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -35,6 +36,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
@@ -50,6 +52,8 @@ import kotlin.test.assertEquals
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class WalletRepositoryImplTest {
+    private val scopes = mutableListOf<CoroutineScope>()
+
     @BeforeTest
     fun setUp() {
         mockkObject(PersistableWallet.Companion)
@@ -60,6 +64,8 @@ class WalletRepositoryImplTest {
 
     @AfterTest
     fun tearDown() {
+        scopes.forEach { it.cancel() }
+        scopes.clear()
         unmockkAll()
     }
 
@@ -69,6 +75,7 @@ class WalletRepositoryImplTest {
         assertEquals(SecretState.NONE, resolveSecretState(true, OnboardingState.READY, false))
         assertEquals(SecretState.NONE, resolveSecretState(true, OnboardingState.NONE, false))
         assertEquals(SecretState.NONE, resolveSecretState(true, OnboardingState.NONE, true))
+        assertEquals(SecretState.NONE, resolveSecretState(true, OnboardingState.NEEDS_WARN, true))
         assertEquals(SecretState.NONE, resolveSecretState(true, OnboardingState.NEEDS_BACKUP, true))
         assertEquals(SecretState.LOADING, resolveSecretState(false, OnboardingState.READY, true))
     }
@@ -112,7 +119,7 @@ class WalletRepositoryImplTest {
     fun createNewWalletStoresWalletBeforeMarkingOnboardingReady() =
         runTest {
             val (repository, harness) = newRepository(onboardingState = OnboardingState.NONE, initialWallet = null)
-            repository.scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+            repository.useTestScope(testScheduler)
 
             repository.createNewWallet()
             advanceUntilIdle()
@@ -124,7 +131,7 @@ class WalletRepositoryImplTest {
     fun initResetsOnboardingAndErasesSdkDataWhenWalletIsMissing() =
         runTest {
             val (repository, harness) = newRepository(onboardingState = OnboardingState.READY, initialWallet = null)
-            repository.scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+            repository.useTestScope(testScheduler)
 
             repository.init()
             advanceUntilIdle()
@@ -137,7 +144,7 @@ class WalletRepositoryImplTest {
         runTest {
             val (repository, harness) =
                 newRepository(onboardingState = OnboardingState.READY, initialWallet = mockk(relaxed = true))
-            repository.scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+            repository.useTestScope(testScheduler)
 
             repository.init()
             advanceUntilIdle()
@@ -150,7 +157,7 @@ class WalletRepositoryImplTest {
     fun initSkipsRepairAndEraseWhenFlagIsNotReady() =
         runTest {
             val (repository, harness) = newRepository(onboardingState = OnboardingState.NONE, initialWallet = null)
-            repository.scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+            repository.useTestScope(testScheduler)
 
             repository.init()
             advanceUntilIdle()
@@ -158,6 +165,33 @@ class WalletRepositoryImplTest {
             assertEquals(emptyList<String>(), harness.events)
             coVerify(exactly = 0) { Synchronizer.erase(any(), any(), any()) }
         }
+
+    @Test
+    fun initSkipsEraseWhenAWalletIsStoredWhileSelfHealing() =
+        runTest {
+            val (repository, harness) =
+                newRepository(
+                    onboardingState = OnboardingState.READY,
+                    initialWallet = null,
+                    persistableWalletProviderOverride =
+                        WalletStoredAfterFirstReadProvider(mockk(relaxed = true)),
+                )
+            repository.useTestScope(testScheduler)
+
+            repository.init()
+            advanceUntilIdle()
+
+            assertEquals(listOf("onboarding=0", "sdkRepair"), harness.events)
+            coVerify(exactly = 0) { Synchronizer.erase(any(), any(), any()) }
+        }
+
+    /**
+     * Replaces the repository's production scope with one driven by the test's scheduler, and
+     * registers both for cancellation in [tearDown] so no test leaves a live scope behind.
+     */
+    private fun WalletRepositoryImpl.useTestScope(scheduler: TestCoroutineScheduler) {
+        scope = CoroutineScope(StandardTestDispatcher(scheduler)).also { scopes += it }
+    }
 
     private suspend fun newRepository(
         onboardingState: OnboardingState,
@@ -228,6 +262,8 @@ class WalletRepositoryImplTest {
 
         fakePrefs.seed(StandardPreferenceKeys.ONBOARDING_STATE.key, onboardingState.toNumber().toString())
 
+        scopes += repository.scope
+
         return repository to TestHarness(events, fakePrefs)
     }
 
@@ -269,6 +305,28 @@ private class FakePersistableWalletProvider(
     }
 
     override suspend fun getPersistableWallet(): PersistableWallet? = walletFlow.value
+
+    override suspend fun requirePersistableWallet(): PersistableWallet = checkNotNull(walletFlow.value)
+}
+
+/**
+ * Reports no wallet on the first read and a stored wallet on every read after it, which is the
+ * shape of the self-heal race: [WalletRepositoryImpl.init] sees an empty encrypted store, and by
+ * the time the erase would run a wallet has been stored under it. The erase must not happen.
+ */
+private class WalletStoredAfterFirstReadProvider(
+    private val storedLater: PersistableWallet
+) : PersistableWalletProvider {
+    private val walletFlow = MutableStateFlow<PersistableWallet?>(null)
+
+    override val persistableWallet: Flow<PersistableWallet?> = walletFlow
+
+    override suspend fun store(persistableWallet: PersistableWallet) {
+        walletFlow.value = persistableWallet
+    }
+
+    override suspend fun getPersistableWallet(): PersistableWallet? =
+        walletFlow.value.also { walletFlow.value = storedLater }
 
     override suspend fun requirePersistableWallet(): PersistableWallet = checkNotNull(walletFlow.value)
 }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/WalletRepositoryImplTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/WalletRepositoryImplTest.kt
@@ -263,6 +263,7 @@ class WalletRepositoryImplTest {
         fakePrefs.seed(StandardPreferenceKeys.ONBOARDING_STATE.key, onboardingState.toNumber().toString())
 
         scopes += repository.scope
+        scopes += repository.sharingScope
 
         return repository to TestHarness(events, fakePrefs)
     }

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/WalletRepositoryImplTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/WalletRepositoryImplTest.kt
@@ -1,0 +1,290 @@
+package co.electriccoin.zcash.ui.common.repository
+
+import android.app.Application
+import cash.z.ecc.android.sdk.Synchronizer
+import cash.z.ecc.android.sdk.model.PersistableWallet
+import co.electriccoin.lightwallet.client.model.LightWalletEndpoint
+import co.electriccoin.zcash.configuration.model.map.Configuration
+import co.electriccoin.zcash.preference.StandardPreferenceProvider
+import co.electriccoin.zcash.preference.api.PreferenceProvider
+import co.electriccoin.zcash.preference.model.entry.PreferenceKey
+import co.electriccoin.zcash.ui.common.datasource.RestoreTimestampDataSource
+import co.electriccoin.zcash.ui.common.model.OnboardingState
+import co.electriccoin.zcash.ui.common.model.WalletRestoringState
+import co.electriccoin.zcash.ui.common.provider.IsIronwoodAnnouncementShownStorageProvider
+import co.electriccoin.zcash.ui.common.provider.LightWalletEndpointProvider
+import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
+import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
+import co.electriccoin.zcash.ui.common.provider.WalletBackupFlagStorageProvider
+import co.electriccoin.zcash.ui.common.provider.WalletRestoringStateProvider
+import co.electriccoin.zcash.ui.common.viewmodel.SecretState
+import co.electriccoin.zcash.ui.preference.StandardPreferenceKeys
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression coverage for MOB-1836: the onboarding flag ([OnboardingState]) and the stored wallet
+ * live in separate preference files and can diverge when the encrypted store is recreated after
+ * provable corruption. [resolveSecretState] and [WalletRepositoryImpl.init]'s self-heal must keep
+ * a wallet-less app from ever presenting [SecretState.READY].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class WalletRepositoryImplTest {
+    @BeforeTest
+    fun setUp() {
+        mockkObject(PersistableWallet.Companion)
+        coEvery { PersistableWallet.new(any(), any(), any(), any()) } returns mockk(relaxed = true)
+
+        mockkObject(Synchronizer.Companion)
+        coEvery { Synchronizer.erase(any(), any(), any()) } returns true
+    }
+
+    @AfterTest
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `resolveSecretState combines the onboarding flag and wallet presence`() {
+        assertEquals(SecretState.READY, resolveSecretState(true, OnboardingState.READY, true))
+        assertEquals(SecretState.NONE, resolveSecretState(true, OnboardingState.READY, false))
+        assertEquals(SecretState.NONE, resolveSecretState(true, OnboardingState.NONE, false))
+        assertEquals(SecretState.NONE, resolveSecretState(true, OnboardingState.NONE, true))
+        assertEquals(SecretState.NONE, resolveSecretState(true, OnboardingState.NEEDS_BACKUP, true))
+        assertEquals(SecretState.LOADING, resolveSecretState(false, OnboardingState.READY, true))
+    }
+
+    @Test
+    fun secretStateFlowResolvesNoneWhenWalletIsMissing() =
+        runTest {
+            val (repository, _) = newRepository(onboardingState = OnboardingState.READY, initialWallet = null)
+
+            assertEquals(SecretState.NONE, repository.secretState.first { it != SecretState.LOADING })
+        }
+
+    @Test
+    fun secretStateFlowResolvesReadyWhenWalletIsPresent() =
+        runTest {
+            val (repository, _) =
+                newRepository(onboardingState = OnboardingState.READY, initialWallet = mockk(relaxed = true))
+
+            assertEquals(SecretState.READY, repository.secretState.first { it != SecretState.LOADING })
+        }
+
+    @Test
+    fun createNewWalletStoresWalletBeforeMarkingOnboardingReady() =
+        runTest {
+            val (repository, harness) = newRepository(onboardingState = OnboardingState.NONE, initialWallet = null)
+            repository.scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+
+            repository.createNewWallet()
+            advanceUntilIdle()
+
+            assertEquals(listOf("wallet", "restoring=INITIATING", "onboarding=3"), harness.events)
+        }
+
+    @Test
+    fun initResetsOnboardingAndErasesSdkDataWhenWalletIsMissing() =
+        runTest {
+            val (repository, harness) = newRepository(onboardingState = OnboardingState.READY, initialWallet = null)
+            repository.scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+
+            repository.init()
+            advanceUntilIdle()
+
+            assertEquals("0", harness.fakePrefs.getString(StandardPreferenceKeys.ONBOARDING_STATE.key))
+            coVerify(exactly = 1) { Synchronizer.erase(any(), any(), any()) }
+        }
+
+    @Test
+    fun initKeepsOnboardingWhenWalletIsPresent() =
+        runTest {
+            val (repository, harness) =
+                newRepository(onboardingState = OnboardingState.READY, initialWallet = mockk(relaxed = true))
+            repository.scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+
+            repository.init()
+            advanceUntilIdle()
+
+            assertEquals("3", harness.fakePrefs.getString(StandardPreferenceKeys.ONBOARDING_STATE.key))
+            coVerify(exactly = 0) { Synchronizer.erase(any(), any(), any()) }
+        }
+
+    private suspend fun newRepository(
+        onboardingState: OnboardingState,
+        initialWallet: PersistableWallet?,
+    ): Pair<WalletRepositoryImpl, TestHarness> {
+        val events = mutableListOf<String>()
+
+        val configurationRepository =
+            mockk<ConfigurationRepository> {
+                every { configurationFlow } returns MutableStateFlow<Configuration?>(mockk())
+            }
+
+        val application = mockk<Application>(relaxed = true)
+
+        val lightWalletEndpointProvider =
+            mockk<LightWalletEndpointProvider> {
+                every { getDefaultEndpoint() } returns LightWalletEndpoint("zec.rocks", 443, true)
+                every { getDecommissionedHosts() } returns emptySet()
+            }
+
+        val persistableWalletProvider = FakePersistableWalletProvider(initialWallet, events)
+
+        val synchronizerProvider =
+            mockk<SynchronizerProvider>(relaxed = true) {
+                every { synchronizer } returns MutableStateFlow<Synchronizer?>(null)
+            }
+
+        val fakePrefs = RecordingPreferenceProvider(events)
+        val standardPreferenceProvider = mockk<StandardPreferenceProvider>()
+        coEvery { standardPreferenceProvider() } returns fakePrefs
+
+        val restoreTimestampDataSource = mockk<RestoreTimestampDataSource>(relaxed = true)
+        val walletBackupFlagStorageProvider = mockk<WalletBackupFlagStorageProvider>(relaxed = true)
+
+        val walletRestoringStateProvider = mockk<WalletRestoringStateProvider>(relaxed = true)
+        coEvery { walletRestoringStateProvider.store(any()) } coAnswers {
+            events += "restoring=${firstArg<WalletRestoringState>()}"
+        }
+
+        val isIronwoodAnnouncementShownStorageProvider =
+            mockk<IsIronwoodAnnouncementShownStorageProvider> {
+                every { observe() } returns flowOf(null)
+            }
+
+        val repository =
+            WalletRepositoryImpl(
+                configurationRepository = configurationRepository,
+                application = application,
+                lightWalletEndpointProvider = lightWalletEndpointProvider,
+                persistableWalletProvider = persistableWalletProvider,
+                synchronizerProvider = synchronizerProvider,
+                standardPreferenceProvider = standardPreferenceProvider,
+                restoreTimestampDataSource = restoreTimestampDataSource,
+                walletRestoringStateProvider = walletRestoringStateProvider,
+                walletBackupFlagStorageProvider = walletBackupFlagStorageProvider,
+                isIronwoodAnnouncementShownStorageProvider = isIronwoodAnnouncementShownStorageProvider,
+            )
+
+        fakePrefs.seed(StandardPreferenceKeys.ONBOARDING_STATE.key, onboardingState.toNumber().toString())
+
+        return repository to TestHarness(events, fakePrefs)
+    }
+
+    private data class TestHarness(
+        val events: List<String>,
+        val fakePrefs: RecordingPreferenceProvider,
+    )
+}
+
+/**
+ * A hand-written [PersistableWalletProvider] stand-in: MockK cannot mock a suspend member whose
+ * parameter is the [PersistableWallet] value class in this codebase's setup, so [store] is
+ * implemented directly, backed by a [MutableStateFlow] the way the real
+ * `PersistableWalletProviderImpl` observes its storage provider.
+ */
+private class FakePersistableWalletProvider(
+    initial: PersistableWallet?,
+    private val events: MutableList<String>
+) : PersistableWalletProvider {
+    private val walletFlow = MutableStateFlow(initial)
+
+    override val persistableWallet: Flow<PersistableWallet?> = walletFlow
+
+    override suspend fun store(persistableWallet: PersistableWallet) {
+        walletFlow.value = persistableWallet
+        events += "wallet"
+    }
+
+    override suspend fun getPersistableWallet(): PersistableWallet? = walletFlow.value
+
+    override suspend fun requirePersistableWallet(): PersistableWallet = checkNotNull(walletFlow.value)
+}
+
+/**
+ * A hand-written [PreferenceProvider] stand-in, not a MockK proxy: [PreferenceProvider]'s methods
+ * take the [PreferenceKey] value class, and MockK's reflection-based call recorder throws on that
+ * combination for suspend members. [observe] re-emits after every [putString] the way the real
+ * `AndroidPreferenceProvider` re-emits on every preference change, so
+ * `StandardPreferenceKeys.ONBOARDING_STATE.observe(...)` reacts to writes made through this fake.
+ */
+internal class RecordingPreferenceProvider(
+    private val events: MutableList<String>
+) : PreferenceProvider {
+    private val values = mutableMapOf<String, String?>()
+    private val changes =
+        MutableSharedFlow<Unit>(replay = 1).apply {
+            tryEmit(Unit)
+        }
+
+    /**
+     * Sets [key]'s stored value directly, without recording it as an event or notifying
+     * [observe] collectors — test setup, not an action under test.
+     */
+    fun seed(
+        key: PreferenceKey,
+        value: String?
+    ) {
+        values[key.key] = value
+    }
+
+    override suspend fun hasKey(key: PreferenceKey) = values.containsKey(key.key)
+
+    override suspend fun putString(
+        key: PreferenceKey,
+        value: String?
+    ) {
+        values[key.key] = value
+        if (key == StandardPreferenceKeys.ONBOARDING_STATE.key) {
+            events += "onboarding=$value"
+        }
+        changes.emit(Unit)
+    }
+
+    override suspend fun putStringSet(
+        key: PreferenceKey,
+        value: Set<String>?
+    ) = Unit
+
+    override suspend fun putLong(
+        key: PreferenceKey,
+        value: Long?
+    ) = Unit
+
+    override suspend fun getLong(key: PreferenceKey): Long? = null
+
+    override suspend fun getString(key: PreferenceKey): String? = values[key.key]
+
+    override suspend fun getStringSet(key: PreferenceKey): Set<String>? = null
+
+    override fun observe(key: PreferenceKey): Flow<String?> = changes.map { getString(key) }
+
+    override suspend fun remove(key: PreferenceKey) {
+        values.remove(key.key)
+    }
+
+    override suspend fun clearPreferences(): Boolean {
+        values.clear()
+        return true
+    }
+}

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/WalletRepositoryImplTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/WalletRepositoryImplTest.kt
@@ -339,7 +339,7 @@ private class WalletStoredAfterFirstReadProvider(
  * `AndroidPreferenceProvider` re-emits on every preference change, so
  * `StandardPreferenceKeys.ONBOARDING_STATE.observe(...)` reacts to writes made through this fake.
  */
-internal class RecordingPreferenceProvider(
+private class RecordingPreferenceProvider(
     private val events: MutableList<String>
 ) : PreferenceProvider {
     private val values = mutableMapOf<String, String?>()

--- a/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/WalletRepositoryImplTest.kt
+++ b/ui-lib/src/test/java/co/electriccoin/zcash/ui/common/repository/WalletRepositoryImplTest.kt
@@ -14,6 +14,7 @@ import co.electriccoin.zcash.ui.common.model.WalletRestoringState
 import co.electriccoin.zcash.ui.common.provider.IsIronwoodAnnouncementShownStorageProvider
 import co.electriccoin.zcash.ui.common.provider.LightWalletEndpointProvider
 import co.electriccoin.zcash.ui.common.provider.PersistableWalletProvider
+import co.electriccoin.zcash.ui.common.provider.SdkEncryptedPreferenceRecoveryProvider
 import co.electriccoin.zcash.ui.common.provider.SynchronizerProvider
 import co.electriccoin.zcash.ui.common.provider.WalletBackupFlagStorageProvider
 import co.electriccoin.zcash.ui.common.provider.WalletRestoringStateProvider
@@ -55,7 +56,6 @@ class WalletRepositoryImplTest {
         coEvery { PersistableWallet.new(any(), any(), any(), any()) } returns mockk(relaxed = true)
 
         mockkObject(Synchronizer.Companion)
-        coEvery { Synchronizer.erase(any(), any(), any()) } returns true
     }
 
     @AfterTest
@@ -91,6 +91,24 @@ class WalletRepositoryImplTest {
         }
 
     @Test
+    fun secretStateDoesNotWaitOnTheWalletStoreWhenFlagIsNotReady() =
+        runTest {
+            val neverEmittingWalletProvider =
+                mockk<PersistableWalletProvider> {
+                    every { persistableWallet } returns MutableSharedFlow()
+                }
+
+            val (repository, _) =
+                newRepository(
+                    onboardingState = OnboardingState.NONE,
+                    initialWallet = null,
+                    persistableWalletProviderOverride = neverEmittingWalletProvider,
+                )
+
+            assertEquals(SecretState.NONE, repository.secretState.first { it != SecretState.LOADING })
+        }
+
+    @Test
     fun createNewWalletStoresWalletBeforeMarkingOnboardingReady() =
         runTest {
             val (repository, harness) = newRepository(onboardingState = OnboardingState.NONE, initialWallet = null)
@@ -111,8 +129,7 @@ class WalletRepositoryImplTest {
             repository.init()
             advanceUntilIdle()
 
-            assertEquals("0", harness.fakePrefs.getString(StandardPreferenceKeys.ONBOARDING_STATE.key))
-            coVerify(exactly = 1) { Synchronizer.erase(any(), any(), any()) }
+            assertEquals(listOf("onboarding=0", "sdkRepair", "erase"), harness.events)
         }
 
     @Test
@@ -129,11 +146,30 @@ class WalletRepositoryImplTest {
             coVerify(exactly = 0) { Synchronizer.erase(any(), any(), any()) }
         }
 
+    @Test
+    fun initSkipsRepairAndEraseWhenFlagIsNotReady() =
+        runTest {
+            val (repository, harness) = newRepository(onboardingState = OnboardingState.NONE, initialWallet = null)
+            repository.scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+
+            repository.init()
+            advanceUntilIdle()
+
+            assertEquals(emptyList<String>(), harness.events)
+            coVerify(exactly = 0) { Synchronizer.erase(any(), any(), any()) }
+        }
+
     private suspend fun newRepository(
         onboardingState: OnboardingState,
         initialWallet: PersistableWallet?,
+        persistableWalletProviderOverride: PersistableWalletProvider? = null,
     ): Pair<WalletRepositoryImpl, TestHarness> {
         val events = mutableListOf<String>()
+
+        coEvery { Synchronizer.erase(any(), any(), any()) } coAnswers {
+            events += "erase"
+            true
+        }
 
         val configurationRepository =
             mockk<ConfigurationRepository> {
@@ -148,7 +184,8 @@ class WalletRepositoryImplTest {
                 every { getDecommissionedHosts() } returns emptySet()
             }
 
-        val persistableWalletProvider = FakePersistableWalletProvider(initialWallet, events)
+        val persistableWalletProvider =
+            persistableWalletProviderOverride ?: FakePersistableWalletProvider(initialWallet, events)
 
         val synchronizerProvider =
             mockk<SynchronizerProvider>(relaxed = true) {
@@ -172,6 +209,8 @@ class WalletRepositoryImplTest {
                 every { observe() } returns flowOf(null)
             }
 
+        val sdkEncryptedPreferenceRecoveryProvider = FakeSdkEncryptedPreferenceRecoveryProvider(events)
+
         val repository =
             WalletRepositoryImpl(
                 configurationRepository = configurationRepository,
@@ -184,6 +223,7 @@ class WalletRepositoryImplTest {
                 walletRestoringStateProvider = walletRestoringStateProvider,
                 walletBackupFlagStorageProvider = walletBackupFlagStorageProvider,
                 isIronwoodAnnouncementShownStorageProvider = isIronwoodAnnouncementShownStorageProvider,
+                sdkEncryptedPreferenceRecoveryProvider = sdkEncryptedPreferenceRecoveryProvider,
             )
 
         fakePrefs.seed(StandardPreferenceKeys.ONBOARDING_STATE.key, onboardingState.toNumber().toString())
@@ -195,6 +235,18 @@ class WalletRepositoryImplTest {
         val events: List<String>,
         val fakePrefs: RecordingPreferenceProvider,
     )
+}
+
+/**
+ * Records `"sdkRepair"` into the shared events list, so tests can assert where the SDK secret
+ * store repair lands relative to the onboarding-flag write and the SDK data erase.
+ */
+private class FakeSdkEncryptedPreferenceRecoveryProvider(
+    private val events: MutableList<String>
+) : SdkEncryptedPreferenceRecoveryProvider {
+    override suspend fun ensureReadable() {
+        events += "sdkRepair"
+    }
 }
 
 /**


### PR DESCRIPTION
Fixes [MOB-1836 — Exception on Android after updating from an old release](https://linear.app/zodl/issue/MOB-1836/exception-on-android-after-updating-from-an-old-release) and [MOB-1565 — Seed destroyed on any transient Keystore/encrypted-prefs exception](https://linear.app/zodl/issue/MOB-1565/security-seed-destroyed-on-any-transient-keystoreencrypted-prefs).

## Problem

The wallet seed lives in the encrypted preferences store; the onboarding flag lives in the plain store. When the encrypted store is provably unreadable (for example after a device-to-device transfer, or the `AEADBadTagException` from MOB-1452), `newEncrypted` deletes and recreates it (MOB-1452 in 3.7.1, narrowed by MOB-1691 in 3.10.1) but nothing resets the onboarding flag. `secretState` derived READY from the flag alone, so the app opened Home with no wallet behind it and the balance and transaction list spun forever. That is the state the MOB-1836 user is in on 3.10.2: the reported exception predates their update, and 3.10.2 wiped the store silently.

MOB-1565 additionally asked for a bounded retry before the store is condemned, and for the corrupted file to be set aside rather than deleted.

## Fix

**MOB-1836 (ui-lib)**
- `SecretState.READY` now requires both the onboarding flag and a stored wallet (`resolveSecretState`); READY with no wallet resolves to NONE, and `RootNavGraph` already routes NONE to onboarding. The flow deliberately never maps a store failure to null.
- Startup self-heal in `WalletRepositoryImpl.init()`: when the flag says READY but no wallet is stored, erase the stale SDK databases and persist the flag back to NONE. This is what recovers users who were already wiped by 3.10.1/3.10.2.
- `createNewWallet()` persists the wallet before marking onboarding READY, so a crash between the two writes can never leave "flag without wallet".
- "Reset Zodl" also purges the quarantine directory.
- A failed `Synchronizer.erase` on the self-heal path is reported through `GlobalCrashReporter` as well as logged: "the erase failed and we carried on anyway" is the half-reset state this ticket was reported for, and a `Twig.error` never leaves the device.

**MOB-1565 (preference-impl-android-lib)**
- Opening the encrypted store is retried three times with a short backoff before any failure is classified (the MOB-1452 trace showed `AEADBadTagException` caused by a Keystore operation error).
- Provable corruption now quarantines `shared_prefs/<file>.xml` and its `.bak` sibling under `no_backup/encrypted_prefs_quarantine/` instead of deleting them. Retention keeps the oldest copy of a filename unconditionally plus the two newest: only the first quarantine can set aside a store that ever held a wallet, because the recovery that follows recreates it empty. A quarantine that fails mid-move is rethrown with the original files left in place — there is no delete fallback. The Keystore master-key alias is deleted only for key-level failures, so a quarantined file stays decryptable by this device for data-level ones.
- A cause chain carrying AOSP's transient marker (`android.security.KeyStoreException`) is never classified as corruption *or* as a master-key failure — one shared veto used by both classifiers — so a wedged Keystore daemon rethrows and leaves the store where it is.
- The persisted recreated-marker, written only after a quarantine actually succeeded, bounds the immediate retry within a run: it is cleared as soon as a store opens successfully, so it does **not** bound repeat quarantines across launches. Surviving repeat quarantines is what the retention policy above is for.

Deliberately left for follow-up tickets: the `:crash` process running the full app init, a `SecretState.ERROR` for a persistently unreadable store (which is also where the erase-after-a-failed-`ensureReadable` question belongs), finer API 33+ `KeyStoreException` classification, and the pre-existing `Twig.error(e)` on a `PersistableWallet` parse failure, which can log decrypted wallet JSON through `JSONTokener.syntaxError`.

## Test plan

- `:preference-impl-android-lib:testDebugUnitTest` — 35/35 (retry ladder, classification incl. the transient-marker veto for both classifiers, quarantine/prune retention, quarantine-failure rethrow).
- `:ui-lib:testZcashmainnetStoreDebugUnitTest` — full suite 469/469, incl. new `WalletRepositoryImplTest` (resolver, real combine, create-wallet ordering, init self-heal).
- `:ui-lib:testZcashmainnetInternalDebugUnitTest --tests '*WalletRepository*'` — 11/11 after the review fixes, incl. the fail-safe hinge (a wallet read that throws writes no onboarding state and erases nothing) and the failed-erase crash report.
- `:preference-impl-android-lib:connectedDebugAndroidTest` on Pixel 9 Pro XL (API 35) — 12/12; the two recovery tests now assert the quarantine file, no leftover `.bak`, and alias retention.
- ktlint + detektAll clean.
- Manual, debug build against the pinned SDK on the emulator:
  - corrupted Tink keyset → three failed attempts logged → quarantine → onboarding, flag reset, SDK DB erased; creating a new wallet from there reaches Home;
  - encrypted store deleted with the flag still READY (the reported user's state) → self-heal → onboarding.

# Author

- [ ] **Self-review** your own code in GitHub's web interface
- [x] Add **automated tests** as appropriate
- [ ] Update the [**manual tests**](../blob/main/docs/testing/manual_testing) as appropriate
- [ ] Check the **code coverage** report for the automated tests
- [x] Update **documentation** as appropriate (CHANGELOG.md)
- [x] **Run the app** and try the changes
- [ ] Pull in the latest changes from the **main** branch and **squash** your commits before assigning a reviewer

# Reviewer

- [ ] Check the code with the [Code Review Guidelines](../blob/main/docs/CODE_REVIEW_GUIDELINES.md) **checklist**
- [ ] Perform an **ad hoc review**
- [ ] Review the **automated tests**
- [ ] Review the **manual tests**
- [ ] Review the **documentation**
- [ ] **Run the app** and try the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rqq1yYyS5XofPcqE7bZ4r

