### PR TITLE
Consume the Zodl SDK snapshot from Maven instead of an SDK source pin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -114,6 +114,8 @@ SDK_INCLUDED_BUILD_PATH=
 # published Maven artifact — for co-developing an app change against unreleased SDK work,
 # without waiting on an SDK release. Locally this has no effect: set
 # ORG_GRADLE_PROJECT_SDK_INCLUDED_BUILD_PATH yourself, pointing at your own local SDK checkout.
+# When blank — the normal case — the build resolves the fork's own published artifacts under
+# the com.zodl.android Maven group at ZCASH_SDK_VERSION, so no Rust/NDK toolchain is needed.
 #
 # main, maint/* branches, and branches targeting either. Must be blank on release/candidate
 # branches — CI hard-fails if it finds this non-blank there (both in PR checks and,
@@ -124,7 +126,7 @@ SDK_INCLUDED_BUILD_PATH=
 # from something more durable than the SDK's own PR branch (which stops being fetchable once
 # that branch is deleted): repoint to the merged sha on origin/main (or the relevant
 # origin/maint/vX.Y.x line) once the companion SDK PR lands.
-SDK_COMMIT_PIN=66701636e2ab9b28dd95807365135f7eb097e75f
+SDK_COMMIT_PIN=
 # When blank, it pulls the BIP-39 library from Maven.
 # When set, it uses the path for a Gradle included build.  Path can either be absolute or relative to the root of this app's Gradle project.
 BIP_39_INCLUDED_BUILD_PATH=

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -116,6 +116,7 @@ dependencyResolutionManagement {
             if (isRepoRestrictionEnabled) {
                 content {
                     includeGroup("cash.z.ecc.android")
+                    includeGroup("com.zodl.android")
                 }
             }
         }
@@ -126,6 +127,7 @@ dependencyResolutionManagement {
             if (isRepoRestrictionEnabled) {
                 content {
                     includeGroup("cash.z.ecc.android")
+                    includeGroup("com.zodl.android")
                 }
             }
         }
@@ -246,9 +248,9 @@ dependencyResolutionManagement {
             library("markdown", "org.jetbrains:markdown:$markdownVersion")
             library("mlkit-scanning", "com.google.mlkit:barcode-scanning:$mlkitScanningVersion")
             library("tink", "com.google.crypto.tink:tink-android:$tinkVersion")
-            library("zcash-sdk", "cash.z.ecc.android:zcash-android-sdk:$zcashSdkVersion")
-            library("zcash-sdk-backend", "cash.z.ecc.android:zcash-android-backend:$zcashSdkVersion")
-            library("zcash-sdk-incubator", "cash.z.ecc.android:zcash-android-sdk-incubator:$zcashSdkVersion")
+            library("zcash-sdk", "com.zodl.android:zcash-android-sdk:$zcashSdkVersion")
+            library("zcash-sdk-backend", "com.zodl.android:zcash-android-backend:$zcashSdkVersion")
+            library("zcash-sdk-incubator", "com.zodl.android:zcash-android-sdk-incubator:$zcashSdkVersion")
             library("zcash-bip39", "cash.z.ecc.android:kotlin-bip39:$zcashBip39Version")
             library("zip321", "org.zecdev:zip321:$zip321Version")
             library("zxing", "com.google.zxing:core:$zxingVersion")
@@ -373,9 +375,9 @@ if (zcashSdkIncludedBuildPath.isNotEmpty()) {
     logger.lifecycle("The SDK will be used from $zcashSdkIncludedBuildPath instead of Maven Central.")
     includeBuild(zcashSdkIncludedBuildPath) {
         dependencySubstitution {
-            substitute(module("cash.z.ecc.android:zcash-android-sdk")).using(project(":sdk-lib"))
-            substitute(module("cash.z.ecc.android:zcash-android-backend")).using(project(":backend-lib"))
-            substitute(module("cash.z.ecc.android:zcash-android-sdk-incubator")).using(project(":sdk-incubator-lib"))
+            substitute(module("com.zodl.android:zcash-android-sdk")).using(project(":sdk-lib"))
+            substitute(module("com.zodl.android:zcash-android-backend")).using(project(":backend-lib"))
+            substitute(module("com.zodl.android:zcash-android-sdk-incubator")).using(project(":sdk-incubator-lib"))
         }
     }
 }


### PR DESCRIPTION
## What

Point the app's SDK dependencies at the Zodl fork's own Maven group and drop the SDK source pin.

- `settings.gradle.kts`
  - `zcash-sdk`, `zcash-sdk-backend`, `zcash-sdk-incubator` version-catalog aliases: `cash.z.ecc.android:*` → `com.zodl.android:*` (version still `$zcashSdkVersion`).
  - The three `substitute(module(...))` targets for the `SDK_INCLUDED_BUILD_PATH` composite build: same group switch, so the included-build path keeps substituting.
  - Both snapshot repositories (`oss.sonatype.org/content/repositories/snapshots`, `central.sonatype.com/repository/maven-snapshots`) gain `includeGroup("com.zodl.android")` alongside the existing `cash.z.ecc.android`.
- `gradle.properties`
  - `SDK_COMMIT_PIN=66701636e2ab9b28dd95807365135f7eb097e75f` → `SDK_COMMIT_PIN=` (blank).
  - Comment block above the pin gains a line saying what "blank" now resolves to.

No lockfile changes — see below. No CHANGELOG entry: nothing user-facing, and the file only carries user-facing prose.

## Why

The fork `zodl-inc/zodl-android-wallet-sdk` publishes under the Maven group `com.zodl.android` (hardcoded in its `zcash-sdk.publishing-conventions.gradle.kts`), not upstream's `cash.z.ecc.android`. The app still declared the upstream coordinates, so the upstream `3.1.1-SNAPSHOT` it resolved was stale and the only way to build against current SDK work was `SDK_COMMIT_PIN` — CI checking out the SDK at a commit and compiling it from source, Rust/NDK toolchain and all, on every job.

A snapshot `3.1.1-20260908.055811-1` of all five fork artifacts (`zcash-android-sdk`, `zcash-android-backend`, `zcash-android-sdk-incubator`, `lightwallet-client`, `zcash-android-sdk-slipstream`) was published today from `maint/v3.1.x` @ `66701636e2ab9b28dd95807365135f7eb097e75f` — the exact commit the pin named. The published snapshot therefore carries what the source build carried, and the pin has nothing left to add.

## Deliberately left on `cash.z.ecc.android`

- `library("zcash-bip39", "cash.z.ecc.android:kotlin-bip39:$zcashBip39Version")` and its `substitute(module(...))` in the BIP-39 included build — separate upstream library, unaffected. It still resolves as `cash.z.ecc.android:kotlin-bip39:1.0.9` (see proof below).
- `includeGroup("cash.z.ecc.android")` kept on both snapshot repos, so upstream snapshots (BIP-39) stay resolvable.
- Kotlin `import cash.z.ecc.android.sdk.*` across `feature-migration`, `app`, `compose_stability_config.conf` — those are Java package names, not Maven coordinates; the fork did not rename packages.
- `docs/Setup.md`, `docs/Architecture.md`, `README.md` references to the upstream `zcash-android-wallet-sdk` repo — pre-existing, generic, and out of scope for a coordinate change.

The release repository (`mavenCentral()`) carries no group allowlist — only Google-group exclusions — so a future non-snapshot `com.zodl.android:*:3.1.1` resolves with no further change.

## Dependency locking

Regenerated the documented way with locking enabled and no included build:

- `./gradlew dependencies --write-locks -PZCASH_IS_DEPENDENCY_LOCKING_ENABLED=true`
- `./gradlew resolveAll --write-locks -PZCASH_IS_DEPENDENCY_LOCKING_ENABLED=true`

**Zero lockfile diff.** Locking here covers the Gradle buildscript classpath and the KMP/tooling modules (`spackle-lib`, `crash-lib`, `preference-api-lib`, `configuration-api-lib`, `build-info-lib`, `build-conventions-secant`, `buildSrc`); none of them depend on the Zcash SDK, so no coordinate in any `gradle.lockfile` moved. No unrelated version moved either.

## Verification

All of the below ran with `ORG_GRADLE_PROJECT_SDK_INCLUDED_BUILD_PATH` explicitly unset — i.e. against the published Maven snapshot, no composite build.

**Resolved dependencies** (`./gradlew --refresh-dependencies :app:dependencies --configuration zcashmainnetStoreDebugRuntimeClasspath`):

```
com.zodl.android:zcash-android-sdk:3.1.1-SNAPSHOT
com.zodl.android:zcash-android-backend:3.1.1-SNAPSHOT
com.zodl.android:zcash-android-sdk-incubator:3.1.1-SNAPSHOT
com.zodl.android:lightwallet-client:3.1.1-SNAPSHOT
com.zodl.android:zcash-android-sdk-slipstream:3.1.1-SNAPSHOT
cash.z.ecc.android:kotlin-bip39:1.0.9
cash.z.ecc.android:kotlin-bip39-jvm:1.0.9
```

All five SDK artifacts on the new group; the only `cash.z.ecc.android` left is BIP-39, as intended.

**Gates** — all green:

| Command | Result |
| --- | --- |
| `./gradlew ktlintFormat detektAll` | BUILD SUCCESSFUL, no files reformatted |
| `./gradlew :ui-lib:compileZcashmainnetInternalDebugKotlin :app:compileZcashmainnetStoreDebugKotlin` | BUILD SUCCESSFUL |
| `./gradlew :ui-lib:testZcashmainnetInternalDebugUnitTest` | BUILD SUCCESSFUL |
| `./gradlew :app:assembleZcashmainnetStoreDebug` | BUILD SUCCESSFUL |

**Native libraries** — the backend AAR from Maven carries them. `lib/arm64-v8a/libzcashwalletsdk.so` is present in the assembled APK (48,992,512 bytes), as are `armeabi-v7a`, `x86` and `x86_64`. `llvm-readelf --dyn-syms` on the arm64 one shows every JNI export family in the single merged library:

```
Java_cash_z_ecc_android_sdk_internal_jni_RustBackend
Java_cash_z_ecc_android_sdk_internal_jni_MigrationRustBackend
Java_cash_z_ecc_android_sdk_internal_jni_VotingRustBackend
Java_cash_z_ecc_android_sdk_internal_jni_RustDerivationTool
Java_cash_z_ecc_android_sdk_internal_jni_RustPaymentUriTool
Java_com_zodl_slipstream_SlipstreamNative
```

**No Rust in the build** — `grep -ci cargo` over the full Gradle output of both the compile and the assemble runs returns `0`. The source companion build is genuinely off.

**Included-build path not regressed** — with `ORG_GRADLE_PROJECT_SDK_INCLUDED_BUILD_PATH` pointed at a local SDK checkout, the substitutions still fire:

```
com.zodl.android:zcash-android-sdk:3.1.1-SNAPSHOT -> project :zcash-android-wallet-sdk:sdk-lib
com.zodl.android:zcash-android-backend:3.1.1-SNAPSHOT -> project :zcash-android-wallet-sdk:backend-lib
com.zodl.android:zcash-android-sdk-incubator:3.1.1-SNAPSHOT -> project :zcash-android-wallet-sdk:sdk-incubator-lib
```

This is now also consistent with the fork's own project group, where before the explicit rule was the only thing bridging the mismatch.

## Release policy unchanged

This does not make the branch releasable, and it is not meant to. `ZCASH_SDK_VERSION` stays `3.1.1-SNAPSHOT`; a release still needs a real SDK release plus a non-snapshot version here. The CI gates that refuse a non-blank `SDK_COMMIT_PIN` on release/candidate branches (`.github/actions/setup-sdk-companion`, `deploy.yml`, `release.yaml`, `create-release.yml`) are untouched — they simply have nothing to catch now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXV241FzSZi6wy2PXPNz3S
