### PR TITLE
Add Tor state to the support email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this application adheres to [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added:
+
+- The support email now includes whether Tor is enabled.
+
 ## [3.11.0 (2653)] - 2026-09-08
 
 ### Added:

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/support/model/SupportFinancialInfoStateTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/support/model/SupportFinancialInfoStateTest.kt
@@ -1,10 +1,7 @@
 package co.electriccoin.zcash.ui.screen.support.model
 
 import co.electriccoin.zcash.configuration.AndroidConfigurationFactory
-import co.electriccoin.zcash.ui.common.provider.IsTorEnabledStorageProvider
 import co.electriccoin.zcash.ui.test.getAppContext
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import kotlin.test.assertFalse
@@ -152,17 +149,5 @@ private suspend fun newSupportInfo(isTorEnabled: Boolean? = true) =
     SupportInfo.new(
         getAppContext(),
         AndroidConfigurationFactory.new(),
-        FakeIsTorEnabledStorageProvider(isTorEnabled)
+        isTorEnabled
     )
-
-private class FakeIsTorEnabledStorageProvider(
-    private val value: Boolean?
-) : IsTorEnabledStorageProvider {
-    override suspend fun get(): Boolean? = value
-
-    override suspend fun store(amount: Boolean) = Unit
-
-    override fun observe(): Flow<Boolean?> = flowOf(value)
-
-    override suspend fun clear() = Unit
-}

--- a/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/support/model/SupportFinancialInfoStateTest.kt
+++ b/ui-lib/src/androidTest/java/co/electriccoin/zcash/ui/screen/support/model/SupportFinancialInfoStateTest.kt
@@ -1,7 +1,10 @@
 package co.electriccoin.zcash.ui.screen.support.model
 
 import co.electriccoin.zcash.configuration.AndroidConfigurationFactory
+import co.electriccoin.zcash.ui.common.provider.IsTorEnabledStorageProvider
 import co.electriccoin.zcash.ui.test.getAppContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import kotlin.test.assertFalse
@@ -11,7 +14,7 @@ class SupportFinancialInfoStateTest {
     @Test
     fun filter_time() =
         runTest {
-            val supportInfo = SupportInfo.new(getAppContext(), AndroidConfigurationFactory.new())
+            val supportInfo = newSupportInfo()
 
             val individualExpected = supportInfo.timeInfo.toSupportString()
 
@@ -25,7 +28,7 @@ class SupportFinancialInfoStateTest {
     @Test
     fun filter_app() =
         runTest {
-            val supportInfo = SupportInfo.new(getAppContext(), AndroidConfigurationFactory.new())
+            val supportInfo = newSupportInfo()
 
             val individualExpected = supportInfo.appInfo.toSupportString()
 
@@ -39,7 +42,7 @@ class SupportFinancialInfoStateTest {
     @Test
     fun filter_os() =
         runTest {
-            val supportInfo = SupportInfo.new(getAppContext(), AndroidConfigurationFactory.new())
+            val supportInfo = newSupportInfo()
 
             val individualExpected = supportInfo.operatingSystemInfo.toSupportString()
 
@@ -53,7 +56,7 @@ class SupportFinancialInfoStateTest {
     @Test
     fun filter_device() =
         runTest {
-            val supportInfo = SupportInfo.new(getAppContext(), AndroidConfigurationFactory.new())
+            val supportInfo = newSupportInfo()
 
             val individualExpected = supportInfo.deviceInfo.toSupportString()
 
@@ -67,7 +70,7 @@ class SupportFinancialInfoStateTest {
     @Test
     fun filter_crash() =
         runTest {
-            val supportInfo = SupportInfo.new(getAppContext(), AndroidConfigurationFactory.new())
+            val supportInfo = newSupportInfo()
 
             val individualExpected = supportInfo.crashInfo.toCrashSupportString()
 
@@ -78,7 +81,7 @@ class SupportFinancialInfoStateTest {
     @Test
     fun filter_environment() =
         runTest {
-            val supportInfo = SupportInfo.new(getAppContext(), AndroidConfigurationFactory.new())
+            val supportInfo = newSupportInfo()
 
             val individualExpected = supportInfo.environmentInfo.toSupportString()
 
@@ -90,9 +93,50 @@ class SupportFinancialInfoStateTest {
         }
 
     @Test
+    fun filter_tor() =
+        runTest {
+            val supportInfo = newSupportInfo()
+
+            val individualExpected = supportInfo.torInfo.toSupportString()
+
+            val actualIncluded = supportInfo.toSupportString(setOf(SupportInfoType.Tor))
+            assertTrue(actualIncluded.contains(individualExpected))
+
+            val actualExcluded = supportInfo.toSupportString(emptySet())
+            assertFalse(actualExcluded.contains(individualExpected))
+        }
+
+    @Test
+    fun tor_enabled() =
+        runTest {
+            val supportInfo = newSupportInfo(isTorEnabled = true)
+
+            val actual = supportInfo.toSupportString(setOf(SupportInfoType.Tor))
+            assertTrue(actual.contains("Tor enabled: Yes"))
+        }
+
+    @Test
+    fun tor_disabled() =
+        runTest {
+            val supportInfo = newSupportInfo(isTorEnabled = false)
+
+            val actual = supportInfo.toSupportString(setOf(SupportInfoType.Tor))
+            assertTrue(actual.contains("Tor enabled: No"))
+        }
+
+    @Test
+    fun tor_not_set() =
+        runTest {
+            val supportInfo = newSupportInfo(isTorEnabled = null)
+
+            val actual = supportInfo.toSupportString(setOf(SupportInfoType.Tor))
+            assertTrue(actual.contains("Tor enabled: Not set"))
+        }
+
+    @Test
     fun filter_permission() =
         runTest {
-            val supportInfo = SupportInfo.new(getAppContext(), AndroidConfigurationFactory.new())
+            val supportInfo = newSupportInfo()
 
             val individualExpected = supportInfo.permissionInfo.toPermissionSupportString()
 
@@ -102,4 +146,23 @@ class SupportFinancialInfoStateTest {
             val actualExcluded = supportInfo.toSupportString(emptySet())
             assertFalse(actualExcluded.contains(individualExpected))
         }
+}
+
+private suspend fun newSupportInfo(isTorEnabled: Boolean? = true) =
+    SupportInfo.new(
+        getAppContext(),
+        AndroidConfigurationFactory.new(),
+        FakeIsTorEnabledStorageProvider(isTorEnabled)
+    )
+
+private class FakeIsTorEnabledStorageProvider(
+    private val value: Boolean?
+) : IsTorEnabledStorageProvider {
+    override suspend fun get(): Boolean? = value
+
+    override suspend fun store(amount: Boolean) = Unit
+
+    override fun observe(): Flow<Boolean?> = flowOf(value)
+
+    override suspend fun clear() = Unit
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetSupportUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetSupportUseCase.kt
@@ -2,11 +2,14 @@ package co.electriccoin.zcash.ui.common.usecase
 
 import android.content.Context
 import co.electriccoin.zcash.configuration.api.ConfigurationProvider
+import co.electriccoin.zcash.ui.common.provider.IsTorEnabledStorageProvider
 import co.electriccoin.zcash.ui.screen.support.model.SupportInfo
 
 class GetSupportUseCase(
     private val context: Context,
-    private val androidConfigurationProvider: ConfigurationProvider
+    private val androidConfigurationProvider: ConfigurationProvider,
+    private val isTorEnabledStorageProvider: IsTorEnabledStorageProvider
 ) {
-    suspend operator fun invoke() = SupportInfo.new(context, androidConfigurationProvider)
+    suspend operator fun invoke() =
+        SupportInfo.new(context, androidConfigurationProvider, isTorEnabledStorageProvider)
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetSupportUseCase.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/common/usecase/GetSupportUseCase.kt
@@ -11,5 +11,5 @@ class GetSupportUseCase(
     private val isTorEnabledStorageProvider: IsTorEnabledStorageProvider
 ) {
     suspend operator fun invoke() =
-        SupportInfo.new(context, androidConfigurationProvider, isTorEnabledStorageProvider)
+        SupportInfo.new(context, androidConfigurationProvider, isTorEnabledStorageProvider.get())
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/support/model/SupportInfo.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/support/model/SupportInfo.kt
@@ -3,6 +3,7 @@ package co.electriccoin.zcash.ui.screen.support.model
 import android.content.Context
 import co.electriccoin.zcash.configuration.api.ConfigurationProvider
 import co.electriccoin.zcash.spackle.getPackageInfoCompatSuspend
+import co.electriccoin.zcash.ui.common.provider.IsTorEnabledStorageProvider
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 
@@ -12,6 +13,7 @@ enum class SupportInfoType {
     Os,
     Device,
     Environment,
+    Tor,
     Permission,
     Crash
 }
@@ -23,6 +25,7 @@ data class SupportInfo(
     val operatingSystemInfo: OperatingSystemInfo,
     val deviceInfo: DeviceInfo,
     val environmentInfo: EnvironmentInfo,
+    val torInfo: TorInfo,
     val permissionInfo: PersistentList<PermissionInfo>,
     val crashInfo: PersistentList<CrashInfo>
 ) {
@@ -51,6 +54,10 @@ data class SupportInfo(
                 append(environmentInfo.toSupportString())
             }
 
+            if (set.contains(SupportInfoType.Tor)) {
+                append(torInfo.toSupportString())
+            }
+
             if (set.contains(SupportInfoType.Permission)) {
                 append(permissionInfo.toPermissionSupportString())
             }
@@ -65,7 +72,8 @@ data class SupportInfo(
         // in the future.
         suspend fun new(
             context: Context,
-            androidConfigurationProvider: ConfigurationProvider
+            androidConfigurationProvider: ConfigurationProvider,
+            isTorEnabledStorageProvider: IsTorEnabledStorageProvider
         ): SupportInfo {
             val applicationContext = context.applicationContext
             val packageInfo = applicationContext.packageManager.getPackageInfoCompatSuspend(context.packageName, 0L)
@@ -77,6 +85,7 @@ data class SupportInfo(
                 OperatingSystemInfo.new(),
                 DeviceInfo.new(),
                 EnvironmentInfo.new(applicationContext),
+                TorInfo.new(isTorEnabledStorageProvider),
                 PermissionInfo.all(applicationContext).toPersistentList(),
                 CrashInfo.all(context).toPersistentList()
             )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/support/model/SupportInfo.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/support/model/SupportInfo.kt
@@ -3,7 +3,6 @@ package co.electriccoin.zcash.ui.screen.support.model
 import android.content.Context
 import co.electriccoin.zcash.configuration.api.ConfigurationProvider
 import co.electriccoin.zcash.spackle.getPackageInfoCompatSuspend
-import co.electriccoin.zcash.ui.common.provider.IsTorEnabledStorageProvider
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 
@@ -73,7 +72,7 @@ data class SupportInfo(
         suspend fun new(
             context: Context,
             androidConfigurationProvider: ConfigurationProvider,
-            isTorEnabledStorageProvider: IsTorEnabledStorageProvider
+            isTorEnabled: Boolean?
         ): SupportInfo {
             val applicationContext = context.applicationContext
             val packageInfo = applicationContext.packageManager.getPackageInfoCompatSuspend(context.packageName, 0L)
@@ -85,7 +84,7 @@ data class SupportInfo(
                 OperatingSystemInfo.new(),
                 DeviceInfo.new(),
                 EnvironmentInfo.new(applicationContext),
-                TorInfo.new(isTorEnabledStorageProvider),
+                TorInfo(isTorEnabled),
                 PermissionInfo.all(applicationContext).toPersistentList(),
                 CrashInfo.all(context).toPersistentList()
             )

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/support/model/TorInfo.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/support/model/TorInfo.kt
@@ -1,7 +1,5 @@
 package co.electriccoin.zcash.ui.screen.support.model
 
-import co.electriccoin.zcash.ui.common.provider.IsTorEnabledStorageProvider
-
 data class TorInfo(
     val isTorEnabled: Boolean?
 ) {
@@ -9,11 +7,6 @@ data class TorInfo(
         buildString {
             appendLine("Tor enabled: ${isTorEnabled.toSupportValue()}")
         }
-
-    companion object {
-        suspend fun new(isTorEnabledStorageProvider: IsTorEnabledStorageProvider) =
-            TorInfo(isTorEnabledStorageProvider.get())
-    }
 }
 
 private fun Boolean?.toSupportValue() =

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/support/model/TorInfo.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/support/model/TorInfo.kt
@@ -1,0 +1,24 @@
+package co.electriccoin.zcash.ui.screen.support.model
+
+import co.electriccoin.zcash.ui.common.provider.IsTorEnabledStorageProvider
+
+data class TorInfo(
+    val isTorEnabled: Boolean?
+) {
+    fun toSupportString() =
+        buildString {
+            appendLine("Tor enabled: ${isTorEnabled.toSupportValue()}")
+        }
+
+    companion object {
+        suspend fun new(isTorEnabledStorageProvider: IsTorEnabledStorageProvider) =
+            TorInfo(isTorEnabledStorageProvider.get())
+    }
+}
+
+private fun Boolean?.toSupportValue() =
+    when (this) {
+        true -> "Yes"
+        false -> "No"
+        null -> "Not set"
+    }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/support/viewmodel/SupportViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/support/viewmodel/SupportViewModel.kt
@@ -24,6 +24,7 @@ class SupportViewModel(
     // care about is capturing a snapshot of the app, OS, and device state.
     val supportInfo: StateFlow<SupportInfo?> =
         flow<SupportInfo?> {
-            emit(SupportInfo.new(application, androidConfigurationProvider, isTorEnabledStorageProvider))
+            val isTorEnabled = isTorEnabledStorageProvider.get()
+            emit(SupportInfo.new(application, androidConfigurationProvider, isTorEnabled))
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT, Duration.ZERO), null)
 }

--- a/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/support/viewmodel/SupportViewModel.kt
+++ b/ui-lib/src/main/java/co/electriccoin/zcash/ui/screen/support/viewmodel/SupportViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import cash.z.ecc.sdk.ANDROID_STATE_FLOW_TIMEOUT
 import co.electriccoin.zcash.configuration.api.ConfigurationProvider
+import co.electriccoin.zcash.ui.common.provider.IsTorEnabledStorageProvider
 import co.electriccoin.zcash.ui.screen.support.model.SupportInfo
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -15,13 +16,14 @@ import kotlin.time.Duration
 
 class SupportViewModel(
     application: Application,
-    androidConfigurationProvider: ConfigurationProvider
+    androidConfigurationProvider: ConfigurationProvider,
+    isTorEnabledStorageProvider: IsTorEnabledStorageProvider
 ) : AndroidViewModel(application) {
     // Technically, some of the support info could be invalidated after a configuration change,
     // such as the user's current locale. However it really doesn't matter here since all we
     // care about is capturing a snapshot of the app, OS, and device state.
     val supportInfo: StateFlow<SupportInfo?> =
         flow<SupportInfo?> {
-            emit(SupportInfo.new(application, androidConfigurationProvider))
+            emit(SupportInfo.new(application, androidConfigurationProvider, isTorEnabledStorageProvider))
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(ANDROID_STATE_FLOW_TIMEOUT, Duration.ZERO), null)
 }


### PR DESCRIPTION
Closes [MOB-1323](https://linear.app/zodl/issue/MOB-1323/add-tor-state-into-debug-email).

## Summary

- The support/feedback email now includes a `Tor enabled: Yes` / `No` / `Not set` line, read from `IsTorEnabledStorageProvider`, placed after the environment block and before permissions — the same position as the iOS `SupportDataGenerator` `TorItem`.
- New `TorInfo` support model; `SupportInfo` gained a `Tor` type and field; `GetSupportUseCase` and `SupportViewModel` take the provider via constructor (resolved by the existing `factoryOf` / `viewModelOf` registrations, no DI module changes).
- `Not set` is reported when the user has never made the Tor choice (iOS collapses that case to `No`); the app treats it as Tor off.
- CHANGELOG entry under Unreleased.

## Test plan

- `./gradlew :zashi-android:app:compileZcashmainnetStoreDebugKotlin :zashi-android:ktlint :zashi-android:detektAll` from the task workspace root — BUILD SUCCESSFUL.
- `SupportFinancialInfoStateTest` (instrumented) updated with a fake Tor provider and four new tests: the include/exclude filter for the new type plus one per rendered value. Not run on a device; note the ui-lib androidTest source set currently fails to compile on `maint/v3.11.x` in unrelated fixtures (`MockSynchronizer`, `ChooseServerSelectionTest`) that lag the SDK interfaces — that predates this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLpPj2TxQ8FnaLFRQ2kXxf
